### PR TITLE
Introducing Reverse Futility Pruning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ profile: ## Generate CPU performance profile
 
 openbench: ## OpenBench native build
 	@echo "Building for OpenBench..."
-	@RUSTFLAGS="$(LINKER_FLAGS) -C target-cpu=native" \
+	@CC=cc RUSTFLAGS="$(LINKER_FLAGS) -C target-cpu=native" \
 		cargo build --release --quiet
 	@cp target/release/$(EXE_NAME) $(EXE)
 	@echo "Done: ./$(EXE)"

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
         evaltune searchtune test seeformat format clippy profile \
         releases avx2 avx2-bmi2 avx512
 
-all: help
+all: openbench
 
 debug: ## Build for development
 	@echo "Building debug..."

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 EXE_NAME := soul
-DEPTH    ?= 16
+DEPTH    ?= 12
+
+# OpenBench passes CC=cargo (for C/C++ engines). Override it so cc-rs
+# (used by zstd-sys) finds a real C compiler instead of cargo.
+override CC := cc
 
 VERSION := $(shell awk -F'"' '/^version/ {print $$2; exit}' Cargo.toml)
 ifeq ($(VERSION),)

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -577,7 +577,7 @@ impl Worker {
         {
             return Ok(static_eval);
         }
-        
+
         // ── Null Move Pruning (~85 Elo) ──
         if !in_check
             && !N::PV

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -569,6 +569,15 @@ impl Worker {
         };
         self.stack[ply].static_eval = static_eval;
 
+        // ── Reverse Futility Pruning ──
+        if !in_check
+            && !N::PV
+            && depth <= searcher.cfg.search_params.rfp_depth
+            && static_eval - searcher.cfg.search_params.rfp_margin * depth >= beta
+        {
+            return Ok(static_eval);
+        }
+        
         // ── Null Move Pruning (~85 Elo) ──
         if !in_check
             && !N::PV
@@ -598,15 +607,6 @@ impl Worker {
             if score >= beta {
                 return Ok(if score > MATE_BOUND { beta } else { score });
             }
-        }
-
-        // ── Reverse Futility Pruning ──
-        if !in_check
-            && !N::PV
-            && depth <= searcher.cfg.search_params.rfp_depth
-            && static_eval - searcher.cfg.search_params.rfp_margin * depth >= beta
-        {
-            return Ok(static_eval);
         }
 
         // ──────── Move loop ────────

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -600,6 +600,15 @@ impl Worker {
             }
         }
 
+        // ── Reverse Futility Pruning ──
+        if !in_check
+            && !N::PV
+            && depth <= searcher.cfg.search_params.rfp_depth
+            && static_eval - searcher.cfg.search_params.rfp_margin * depth >= beta
+        {
+            return Ok(static_eval);
+        }
+
         // ──────── Move loop ────────
 
         let mut res = MoveResult {

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -264,6 +264,21 @@ search_params! {
             step:      1,
         },
 
+        /// RFP per-depth margin (cp/ply).
+        pub rfp_margin: i32 {
+            default:  45,
+            min:      30,
+            max:     150,
+            step:      5,
+        },
+        /// RFP maximum depth (plies).
+        pub rfp_depth: i32 {
+            default:   8,
+            min:       3,
+            max:      10,
+            step:      1,
+        },
+
         /// Delta pruning margin for qsearch (cp).
         /// If stand_pat + best_capturable + margin < alpha, prune.
         pub delta_margin: i32 {


### PR DESCRIPTION
```
Elo   | 67.32 +- 20.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.38 (-2.20, 2.20) [0.00, 5.00]
Games | N: 742 W: 357 L: 215 D: 170
Penta | [21, 49, 143, 83, 75]
https://pyronomy.pythonanywhere.com/test/3667/
```

```
Elo   | 52.64 +- 18.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.23 (-2.20, 2.20) [0.00, 5.00]
Games | N: 838 W: 363 L: 237 D: 238
Penta | [20, 71, 158, 103, 67]
https://pyronomy.pythonanywhere.com/test/3668/
```

Bench: 36911111