### PR TITLE
Fix TT hash collision crashes and stalled connections

### DIFF
--- a/src/engine/movegen.rs
+++ b/src/engine/movegen.rs
@@ -70,6 +70,14 @@ pub fn is_legal(
     let from = mv.from();
     let to = mv.to();
 
+    // ── Ownership guard (TT collision defence) ──
+    // The hash move may come from a TT collision and reference an
+    // opponent's piece or an empty square. Reject it before any
+    // pin/check logic, which assumes a friendly piece on `from`.
+    if !board.side_bb[board.stm].check_bit(from) {
+        return false;
+    }
+
     // ── King moves ──
     if from == ksq {
         if mv.is_castling() {

--- a/src/engine/movegen.rs
+++ b/src/engine/movegen.rs
@@ -8,7 +8,7 @@ use crate::core::{
         B_OO_EMPTY, B_OOO_EMPTY, BLACK_OO, BLACK_OOO, CASTLE_B_KS, CASTLE_B_KS_CHECK, CASTLE_B_QS,
         CASTLE_B_QS_CHECK, CASTLE_W_KS, CASTLE_W_KS_CHECK, CASTLE_W_QS, CASTLE_W_QS_CHECK, Position,
         W_OO_EMPTY, W_OOO_EMPTY, WHITE_OO, WHITE_OOO,
-        bitboard::{atk_bishop, atk_king, atk_knight, atk_rook, between_bb, line_bb},
+        bitboard::{atk_bishop, atk_king, atk_knight, atk_pawn, atk_rook, between_bb, line_bb},
     },
     defs::{Bitboard, Color, Direction, FILE_A, FILE_H, PieceType, RANK_1, RANK_3, RANK_6, RANK_8, Square},
     moves::{Move, MoveList},
@@ -48,6 +48,84 @@ pub fn gen_legal_moves(board: &Position) -> MoveList {
     }
 
     legal
+}
+
+/// Validates that a TT move is pseudo-legal for the current position.
+///
+/// TT hash collisions can produce moves from completely unrelated positions.
+/// This checks: friendly piece on `from`, correct attack pattern for that
+/// piece, and flag consistency (captures, promotions, castling, EP, double push).
+/// Does NOT check legality (pins, checks) — that's `is_legal`'s job.
+#[inline]
+pub fn is_pseudo_legal(board: &Position, mv: Move) -> bool {
+
+    let from = mv.from();
+    let to = mv.to();
+    let stm = board.stm;
+    let us = board.side_bb[stm];
+    let them = board.side_bb[stm.opposite()];
+    let occ = board.occ;
+
+    // Must have a friendly piece on the origin square.
+    if !us.check_bit(from) {
+        return false;
+    }
+
+    let piece = board.piece_at(from);
+
+    // Castling — trust the flag; full validation happens in gen_castling / is_legal.
+    if mv.is_castling() {
+        return piece == PieceType::King;
+    }
+
+    // Destination must not hold a friendly piece.
+    if us.check_bit(to) {
+        return false;
+    }
+
+    // Capture flag consistency.
+    let enemy_on_to = them.check_bit(to);
+    if mv.is_capture() && !mv.is_en_passant() && !enemy_on_to {
+        return false;
+    }
+    if !mv.is_capture() && enemy_on_to {
+        return false;
+    }
+
+    // Promotions must come from a pawn.
+    if mv.is_promotion() && piece != PieceType::Pawn {
+        return false;
+    }
+
+    match piece {
+        PieceType::Pawn => {
+            let fwd = stm.forward_dir().delta();
+
+            if mv.is_en_passant() {
+                return board.en_passant == Some(to) && atk_pawn(from, stm).check_bit(to);
+            }
+
+            if mv.is_double_push() {
+                let mid = Square((from.0 as i8 + fwd) as u8);
+                return to.0 as i8 == from.0 as i8 + fwd * 2
+                    && !occ.check_bit(mid)
+                    && !occ.check_bit(to);
+            }
+
+            if mv.is_capture() {
+                return atk_pawn(from, stm).check_bit(to);
+            }
+
+            // Single push.
+            to.0 as i8 == from.0 as i8 + fwd && !occ.check_bit(to)
+        },
+        PieceType::Knight => atk_knight(from).check_bit(to),
+        PieceType::Bishop => atk_bishop(from, occ).check_bit(to),
+        PieceType::Rook => atk_rook(from, occ).check_bit(to),
+        PieceType::Queen => (atk_bishop(from, occ) | atk_rook(from, occ)).check_bit(to),
+        PieceType::King => atk_king(from).check_bit(to),
+        _ => false,
+    }
 }
 
 /// Legality — does this move leave our king safe?

--- a/src/engine/movegen.rs
+++ b/src/engine/movegen.rs
@@ -58,7 +58,6 @@ pub fn gen_legal_moves(board: &Position) -> MoveList {
 /// Does NOT check legality (pins, checks) — that's `is_legal`'s job.
 #[inline]
 pub fn is_pseudo_legal(board: &Position, mv: Move) -> bool {
-
     let from = mv.from();
     let to = mv.to();
     let stm = board.stm;
@@ -107,9 +106,7 @@ pub fn is_pseudo_legal(board: &Position, mv: Move) -> bool {
 
             if mv.is_double_push() {
                 let mid = Square((from.0 as i8 + fwd) as u8);
-                return to.0 as i8 == from.0 as i8 + fwd * 2
-                    && !occ.check_bit(mid)
-                    && !occ.check_bit(to);
+                return to.0 as i8 == from.0 as i8 + fwd * 2 && !occ.check_bit(mid) && !occ.check_bit(to);
             }
 
             if mv.is_capture() {

--- a/src/engine/movegen.rs
+++ b/src/engine/movegen.rs
@@ -72,9 +72,15 @@ pub fn is_pseudo_legal(board: &Position, mv: Move) -> bool {
 
     let piece = board.piece_at(from);
 
-    // Castling — trust the flag; full validation happens in gen_castling / is_legal.
+    // Castling: the 'to' square encodes the rook's home square.
+    // A TT collision with the CASTLE flag but a garbage 'to' would make
+    // apply_castling lift a non-rook piece and place a phantom rook,
+    // permanently corrupting the board after unmake.
     if mv.is_castling() {
-        return piece == PieceType::King;
+        return piece == PieceType::King
+            && board.piece_at(to) == PieceType::Rook
+            && us.check_bit(to)
+            && board.castling_rooks.contains(&to);
     }
 
     // Destination must not hold a friendly piece.

--- a/src/engine/movegen.rs
+++ b/src/engine/movegen.rs
@@ -70,14 +70,6 @@ pub fn is_legal(
     let from = mv.from();
     let to = mv.to();
 
-    // ── Ownership guard (TT collision defence) ──
-    // The hash move may come from a TT collision and reference an
-    // opponent's piece or an empty square. Reject it before any
-    // pin/check logic, which assumes a friendly piece on `from`.
-    if !board.side_bb[board.stm].check_bit(from) {
-        return false;
-    }
-
     // ── King moves ──
     if from == ksq {
         if mv.is_castling() {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -290,7 +290,14 @@ impl<'cfg> Searcher<'cfg> {
         }
 
         if !self.cfg.limits.silent {
-            let best = self.prev_pv.get(0).unwrap_or(self.root_moves[0].mv);
+            let mut best = self.prev_pv.get(0).unwrap_or(self.root_moves[0].mv);
+
+            // Guard: if the PV move is somehow not legal for the root position
+            // fall back to root_moves[0] which was generated legally.
+            if !is_pseudo_legal(&self.root_pos, best) {
+                best = self.root_moves[0].mv;
+            }
+
             match self.cfg.limits.protocol {
                 Protocol::Uci => println!("bestmove {}", best.to_uci(self.root_pos.is_frc)),
                 Protocol::XBoard => println!("move {}", best.to_uci(self.root_pos.is_frc)),

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -547,10 +547,14 @@ impl Worker {
 
         // ── TT probe (~128 Elo) ──
         let tt_move = if let Some((mv, score, depth_stored, bound)) = searcher.tt.probe(self.pos.hash, ply) {
-            if !N::PV && depth_stored >= depth && tt::can_cutoff(bound, score, alpha, beta) {
+            // Validate the TT move belongs to the side to move.
+            // Hash collisions can store moves from unrelated positions.
+            let valid = mv.is_null() || self.pos.side_bb[self.pos.stm].check_bit(mv.from());
+
+            if valid && !N::PV && depth_stored >= depth && tt::can_cutoff(bound, score, alpha, beta) {
                 return Ok(score);
             }
-            if mv.is_null() { None } else { Some(mv) }
+            if valid && !mv.is_null() { Some(mv) } else { None }
         } else {
             None
         };

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -29,7 +29,10 @@ use crate::{
         moves::Move,
     },
     engine::{
-        eval::evaluate, history, movegen::gen_legal_moves, movepicker::MovePicker,
+        eval::evaluate,
+        history,
+        movegen::{gen_legal_moves, is_legal, is_pseudo_legal},
+        movepicker::MovePicker,
         search_params::SearchParams, tm::TimeManager, tt,
     },
     tools::tui,
@@ -547,9 +550,10 @@ impl Worker {
 
         // ── TT probe (~128 Elo) ──
         let tt_move = if let Some((mv, score, depth_stored, bound)) = searcher.tt.probe(self.pos.hash, ply) {
-            // Validate the TT move belongs to the side to move.
-            // Hash collisions can store moves from unrelated positions.
-            let valid = mv.is_null() || self.pos.side_bb[self.pos.stm].check_bit(mv.from());
+            // Hash collisions can inject moves from unrelated positions.
+            // Full pseudo-legality check rejects garbage before it reaches
+            // the move picker or triggers a cutoff with a bogus score.
+            let valid = mv.is_null() || is_pseudo_legal(&self.pos, mv);
 
             if valid && !N::PV && depth_stored >= depth && tt::can_cutoff(bound, score, alpha, beta) {
                 return Ok(score);
@@ -654,7 +658,7 @@ impl Worker {
             // Interior: staged move generation via MovePicker.
             let mut picker = MovePicker::new(hash_move, searcher.cfg);
             while let Some(mv) = picker.next(&self.pos, &self.history) {
-                if !crate::engine::movegen::is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
+                if !is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
                     continue;
                 }
 
@@ -963,7 +967,7 @@ impl Worker {
         let mut picker = MovePicker::new_qsearch(None, searcher.cfg, in_check);
 
         while let Some(mv) = picker.next(&self.pos, &self.history) {
-            if !crate::engine::movegen::is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
+            if !is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
                 continue;
             }
 

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -33,7 +33,9 @@ use crate::{
         history,
         movegen::{gen_legal_moves, is_legal, is_pseudo_legal},
         movepicker::MovePicker,
-        search_params::SearchParams, tm::TimeManager, tt,
+        search_params::SearchParams,
+        tm::TimeManager,
+        tt,
     },
     tools::tui,
     weave::Vu64x4,
@@ -558,12 +560,17 @@ impl Worker {
             if valid && !N::PV && depth_stored >= depth && tt::can_cutoff(bound, score, alpha, beta) {
                 return Ok(score);
             }
-            if valid && !mv.is_null() { Some(mv) } else { None }
+            if valid && !mv.is_null() {
+                Some(mv)
+            } else {
+                None
+            }
         } else {
             None
         };
 
         // ── TT move ordering (~56 Elo) ──
+        let pv_move = pv_move.filter(|&mv| is_pseudo_legal(&self.pos, mv));
         let hash_move = tt_move.or(pv_move);
 
         let checkers = self.pos.checkers();

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -5,6 +5,7 @@
 
 use std::{
     io::{self, Write},
+    panic,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -149,11 +150,31 @@ impl UciState {
             while let Ok(cmd) = rx.recv() {
                 match cmd {
                     SearchCommand::Go(cfg, board, history, history_table, tt, result_tx) => {
-                        let mut ctx =
-                            crate::engine::search::Searcher::new(&cfg, &board, &history, history_table, tt);
-                        let final_history = ctx.iterative_deepening();
-                        is_searching_worker.store(false, Ordering::Release);
-                        let _ = result_tx.send(final_history);
+                        let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                            let mut ctx =
+                                crate::engine::search::Searcher::new(&cfg, &board, &history, history_table, tt);
+                            ctx.iterative_deepening()
+                        }));
+
+                        match result {
+                            Ok(final_history) => {
+                                is_searching_worker.store(false, Ordering::Release);
+                                let _ = result_tx.send(final_history);
+                            },
+                            Err(payload) => {
+                                let msg = if let Some(s) = payload.downcast_ref::<&str>() {
+                                    s.to_string()
+                                } else if let Some(s) = payload.downcast_ref::<String>() {
+                                    s.clone()
+                                } else {
+                                    "unknown panic".to_string()
+                                };
+                                eprintln!("info string search panic: {msg}");
+                                println!("bestmove 0000");
+                                let _ = io::stdout().flush();
+                                is_searching_worker.store(false, Ordering::Release);
+                            },
+                        }
                     },
                     SearchCommand::Quit => break,
                 }

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -5,7 +5,6 @@
 
 use std::{
     io::{self, Write},
-    panic,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -150,31 +149,11 @@ impl UciState {
             while let Ok(cmd) = rx.recv() {
                 match cmd {
                     SearchCommand::Go(cfg, board, history, history_table, tt, result_tx) => {
-                        let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                            let mut ctx =
-                                crate::engine::search::Searcher::new(&cfg, &board, &history, history_table, tt);
-                            ctx.iterative_deepening()
-                        }));
-
-                        match result {
-                            Ok(final_history) => {
-                                is_searching_worker.store(false, Ordering::Release);
-                                let _ = result_tx.send(final_history);
-                            },
-                            Err(payload) => {
-                                let msg = if let Some(s) = payload.downcast_ref::<&str>() {
-                                    s.to_string()
-                                } else if let Some(s) = payload.downcast_ref::<String>() {
-                                    s.clone()
-                                } else {
-                                    "unknown panic".to_string()
-                                };
-                                eprintln!("info string search panic: {msg}");
-                                println!("bestmove 0000");
-                                let _ = io::stdout().flush();
-                                is_searching_worker.store(false, Ordering::Release);
-                            },
-                        }
+                        let mut ctx =
+                            crate::engine::search::Searcher::new(&cfg, &board, &history, history_table, tt);
+                        let final_history = ctx.iterative_deepening();
+                        is_searching_worker.store(false, Ordering::Release);
+                        let _ = result_tx.send(final_history);
                     },
                     SearchCommand::Quit => break,
                 }

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -239,9 +239,12 @@ fn spawn_stdin_listener(
                     }
                 },
                 _ => {
-                    // Only forward commands when not searching.
-                    // UCI spec says to silently ignore unexpected commands during search.
-                    if !is_searching.load(Ordering::Acquire) && tx.send(line).is_err() {
+                    // Always forward to the main thread's command channel.
+                    // Commands queue up and are processed in order after any
+                    // pending stop_search() completes. Dropping commands here
+                    // causes a race: cutechess-cli gets readyok before the
+                    // search thread stops, sends position/go, and we lose them.
+                    if tx.send(line).is_err() {
                         break; // Main thread died
                     }
                 },


### PR DESCRIPTION
This PR addresses several critical stability issues related to search and UCI protocol compliance. The most significant changes involve hardening move validation against Transposition Table's hash collisions and fixing a race condition in the UCI command listener.

- Added full `is_pseudo_legal` validation for TT moves.
  Previously, `is_legal` assumed its input was pseudo-legal (true for generator output, but not for TT probes). TT hash collisions could inject moves from unrelated positions, leading to permanent board state corruption via `make`/`unmake`. All moves retrieved from the TT are now validated for pseudo-legality.
- Hardened castling validation against TT garbage.
  A TT collision with the `CASTLE` flag but a garbage `to` square could previously bypass checks, causing `apply_castling` to place phantom rooks and corrupt bitboards. Validation now strictly requires a friendly registered castling rook on the destination square.
- PV Move Ordering Sanitization.
  PV moves from previous iterations are now filtered through `is_pseudo_legal` before use as hash moves. This prevents stale or corrupted PV lines from poisoning move ordering in subsequent iterations.

- Guarded bestmove emission.
  The final `bestmove` is now validated against the root position before output. In rare cases where the PV move fails pseudo-legality, the engine now safely falls back to the first generated legal move (`root_moves[0]`).
- Fixed UCI command race condition.
  The stdin listener was silently dropping commands received during search. This caused a race with `cutechess-cli` where `position`/`go` commands were lost if they arrived immediately after a search stopped but before the main thread was ready.

```
Elo   | 0.72 +- 3.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.41 (-2.89, 2.25) [-5.00, 0.50]
Games | N: 16326 W: 6273 L: 6239 D: 3814
Penta | [759, 1313, 3997, 1323, 771]
```
https://pyronomy.pythonanywhere.com/test/3682/