### PR TITLE
Fix missing unmake on search abort and stop race

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -614,14 +614,22 @@ impl Worker {
             self.stack[ply + 1].is_null = true;
             let undo = self.pos.make_null_move();
             searcher.history.push(self.pos.hash);
-            let score = -self.negamax::<NonPvNode>(
+            let score = match self.negamax::<NonPvNode>(
                 searcher,
                 (depth - r - 1).max(0),
                 -beta,
                 -beta + 1,
                 ply + 1,
                 None,
-            )?;
+            ) {
+                Ok(v) => -v,
+                Err(e) => {
+                    searcher.history.pop();
+                    self.pos.unmake_null_move(&undo);
+                    self.stack[ply + 1].is_null = false;
+                    return Err(e);
+                },
+            };
             searcher.history.pop();
             self.pos.unmake_null_move(&undo);
             self.stack[ply + 1].is_null = false;
@@ -991,7 +999,15 @@ impl Worker {
             moves_made += 1;
             searcher.history.push(self.pos.hash);
 
-            let score = -self.qsearch::<N>(searcher, -beta, -alpha, ply + 1)?;
+            let score = match self.qsearch::<N>(searcher, -beta, -alpha, ply + 1) {
+                Ok(v) => -v,
+                Err(e) => {
+                    searcher.history.pop();
+                    self.pos.unmake_move(mv, &undo);
+                    self.accumulator = saved_acc;
+                    return Err(e);
+                },
+            };
 
             searcher.history.pop();
             self.pos.unmake_move(mv, &undo);

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -28,7 +28,7 @@ use crate::{
 pub fn main_loop(initial_command: Option<String>) {
     let mut state = UciState::new();
 
-    let rx = spawn_stdin_listener(state.stop.clone(), state.is_searching.clone());
+    let rx = spawn_stdin_listener(state.stop.clone());
 
     if let Some(cmd) = initial_command {
         process_command(&mut state, cmd.trim());
@@ -200,10 +200,7 @@ impl UciState {
 ///
 /// This is required by UCI spec:
 /// "the engine must always be able to process input from stdin, even while thinking."
-fn spawn_stdin_listener(
-    stop: Arc<AtomicBool>,
-    is_searching: Arc<AtomicBool>,
-) -> std::sync::mpsc::Receiver<String> {
+fn spawn_stdin_listener(stop: Arc<AtomicBool>) -> std::sync::mpsc::Receiver<String> {
     let (tx, rx) = std::sync::mpsc::channel();
 
     thread::spawn(move || {
@@ -234,9 +231,7 @@ fn spawn_stdin_listener(
 
                 "stop" => {
                     stop.store(true, Ordering::Release);
-                    if is_searching.load(Ordering::Acquire) {
-                        let _ = tx.send(line);
-                    }
+                    let _ = tx.send(line);
                 },
                 _ => {
                     // Always forward to the main thread's command channel.


### PR DESCRIPTION
Qsearch and null move pruning used bare `?` after `make_move`/`make_null_move`. When the search aborted mid-tree, every frame from the abort point up skipped its `unmake`, corrupting the position for the caller's own `unmake`. This triggered assertion failures (`occ.check_bit`) on the next search.

The stop command in the stdin listener was gated on `is_searching`, so a `stop` arriving before the main thread processed `go` was silently lost. as in `stop_search()` in `cmd_go` cleared the flag before the search started.

Big thanks to @analog-hors and @MinusKelvin for helping find this vulnerability<i>!</i>

Bench: 36911111