### PR TITLE
Introducing Razoring

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -605,7 +605,7 @@ impl Worker {
             return Ok(static_eval);
         }
 
-        // ── Razoring ──
+        // ── Razoring (~17 Elo) ──
         // Position is so far below alpha that a full-depth search is unlikely
         // to recover. Drop straight into qsearch to confirm.
         if !in_check

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -583,7 +583,7 @@ impl Worker {
         let checkers = self.pos.checkers();
         let in_check = checkers.is_not_empty();
 
-        // ── Check extension ──
+        // ── Check extension (~11 Elo) ──
         // Being in check is forcing — don't let the horizon cut us off
         // mid-tactic. Extend by one ply so the reply is always searched.
         let depth = if in_check { depth + 1 } else { depth };
@@ -596,13 +596,27 @@ impl Worker {
         };
         self.stack[ply].static_eval = static_eval;
 
-        // ── Reverse Futility Pruning ──
+        // ── Reverse Futility Pruning (~67 Elo) ──
         if !in_check
             && !N::PV
             && depth <= searcher.cfg.search_params.rfp_depth
             && static_eval - searcher.cfg.search_params.rfp_margin * depth >= beta
         {
             return Ok(static_eval);
+        }
+
+        // ── Razoring ──
+        // Position is so far below alpha that a full-depth search is unlikely
+        // to recover. Drop straight into qsearch to confirm.
+        if !in_check
+            && !N::PV
+            && depth <= searcher.cfg.search_params.razoring_depth
+            && static_eval + searcher.cfg.search_params.razoring_margin * depth < alpha
+        {
+            let score = self.qsearch::<N>(searcher, alpha, beta, ply)?;
+            if score <= alpha {
+                return Ok(score);
+            }
         }
 
         // ── Null Move Pruning (~85 Elo) ──

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -279,6 +279,21 @@ search_params! {
             step:      1,
         },
 
+        /// Razoring per-depth margin (cp/ply).
+        pub razoring_margin: i32 {
+            default: 300,
+            min:     100,
+            max:     600,
+            step:     10,
+        },
+        /// Razoring maximum depth (plies).
+        pub razoring_depth: i32 {
+            default:   3,
+            min:       1,
+            max:       5,
+            step:      1,
+        },
+
         /// Delta pruning margin for qsearch (cp).
         /// If stand_pat + best_capturable + margin < alpha, prune.
         pub delta_margin: i32 {


### PR DESCRIPTION
```
Elo   | 24.89 +- 9.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.55 (-2.20, 2.20) [0.00, 5.00]
Games | N: 3034 W: 1235 L: 1018 D: 781
Penta | [142, 244, 598, 321, 212]
https://pyronomy.pythonanywhere.com/test/3697/
```

```
Elo   | 17.34 +- 10.17 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.25 (-2.20, 2.20) [0.00, 5.00]
Games | N: 2808 W: 1054 L: 914 D: 840
Penta | [138, 239, 527, 345, 155]
https://pyronomy.pythonanywhere.com/test/3698/
```

Bench: 35083173