### PR TITLE
Introducing Late Move Pruning

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -716,9 +716,22 @@ impl Worker {
                 // that a quiet move is unlikely to raise it, skip the move.
                 if !in_check
                     && mv.is_quiet()
+                    && !N::PV
                     && res.move_count >= 1
                     && depth <= searcher.cfg.search_params.fp_depth
                     && static_eval + searcher.cfg.search_params.fp_margin * depth <= res.alpha
+                {
+                    continue;
+                }
+
+                // ── Late Move Pruning ──
+                // At shallow depth, quiet moves beyond a fixed count threshold
+                // are unlikely to be the best move — skip them entirely.
+                if !in_check
+                    && mv.is_quiet()
+                    && !N::PV
+                    && depth <= searcher.cfg.search_params.lmp_depth
+                    && res.move_count as i32 >= searcher.cfg.search_params.lmp_base + depth * depth
                 {
                     continue;
                 }

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -279,6 +279,21 @@ search_params! {
             step:      1,
         },
 
+        /// LMP base move count before pruning kicks in.
+        pub lmp_base: i32 {
+            default:   2,
+            min:       1,
+            max:       6,
+            step:      1,
+        },
+        /// LMP maximum depth (plies).
+        pub lmp_depth: i32 {
+            default:   5,
+            min:       2,
+            max:       8,
+            step:      1,
+        },
+
         /// Futility pruning per-depth margin (cp/ply).
         pub fp_margin: i32 {
             default: 100,


### PR DESCRIPTION
```
Elo   | 4.99 +- 4.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.36 (-2.20, 2.20) [0.00, 5.00]
Games | N: 16630 W: 6552 L: 6313 D: 3765
Penta | [1086, 1371, 3232, 1470, 1156]
```
https://pyronomy.pythonanywhere.com/test/3735/

```
Elo   | 14.23 +- 8.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.30 (-2.20, 2.20) [0.00, 5.00]
Games | N: 3542 W: 1317 L: 1172 D: 1053
Penta | [165, 324, 673, 419, 190]
https://pyronomy.pythonanywhere.com/test/3736/
```

Bench: 23260194