### PR TITLE
Introduce TT integration into the Quiescence Search

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1017,10 +1017,11 @@ impl Worker {
         // Read TT entries stored by negamax or prior qsearch visits.
         // Cutoffs gated on non-PV nodes — PV nodes need the full capture
         // sequence for accurate PV reporting.
-        if let Some((_mv, score, _depth, bound)) = searcher.tt.probe(self.pos.hash, ply) {
-            if !N::PV && tt::can_cutoff(bound, score, alpha, beta) {
-                return Ok(score);
-            }
+        if let Some((_mv, score, _depth, bound)) = searcher.tt.probe(self.pos.hash, ply)
+            && !N::PV
+            && tt::can_cutoff(bound, score, alpha, beta)
+        {
+            return Ok(score);
         }
 
         let checkers = self.pos.checkers();

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -994,6 +994,18 @@ impl Worker {
             return Ok(evaluate(&self.pos, &self.accumulator));
         }
 
+        let alpha_orig = alpha;
+
+        // ── QSearch TT Probe ──
+        // Read TT entries stored by negamax or prior qsearch visits.
+        // Cutoffs gated on non-PV nodes — PV nodes need the full capture
+        // sequence for accurate PV reporting.
+        if let Some((_mv, score, _depth, bound)) = searcher.tt.probe(self.pos.hash, ply) {
+            if !N::PV && tt::can_cutoff(bound, score, alpha, beta) {
+                return Ok(score);
+            }
+        }
+
         let checkers = self.pos.checkers();
         let in_check = checkers.is_not_empty();
         let stm = self.pos.stm;
@@ -1037,6 +1049,7 @@ impl Worker {
         };
 
         let mut moves_made = 0;
+        let mut best_move = Move::null();
         let ksq = self.pos.pieces(PieceType::King, stm).lsb();
         let pinned = self.pos.king_blockers();
 
@@ -1069,6 +1082,7 @@ impl Worker {
 
             if score > best_eval {
                 best_eval = score;
+                best_move = mv;
                 if score > alpha {
                     if score >= beta {
                         break;
@@ -1081,6 +1095,18 @@ impl Worker {
         if in_check && moves_made == 0 {
             return Ok(-MATE + ply as i32);
         }
+
+        // ── QSearch TT Store ──
+        let bound = if best_eval >= beta {
+            tt::BOUND_LOWER
+        } else if best_eval > alpha_orig {
+            tt::BOUND_EXACT
+        } else {
+            tt::BOUND_UPPER
+        };
+        searcher
+            .tt
+            .store_qs(self.pos.hash, ply, best_eval, best_move, bound);
 
         Ok(best_eval)
     }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -558,6 +558,10 @@ impl Worker {
         let alpha_orig = alpha;
 
         // ── TT Probe (~128 Elo) ──
+        // Have we seen this position before?
+        // If a previous search already explored it to sufficient depth,
+        // we can reuse its result and skip the entire subtree.
+        // This is what makes iterative deepening fast — earlier iterations populate the table for later ones.
         let tt_move = if let Some((mv, score, depth_stored, bound)) = searcher.tt.probe(self.pos.hash, ply) {
             // Hash collisions can inject moves from unrelated positions.
             // Full pseudo-legality check rejects garbage before it reaches
@@ -577,6 +581,9 @@ impl Worker {
         };
 
         // ── TT Move Ordering (~56 Elo) ──
+        // Even when the TT score didn't produce a cutoff, the move it stored
+        // is still our best guess at what's good here. Searching it first makes
+        // beta cutoffs happen earlier, which lets alpha-beta prune far more of the tree.
         let pv_move = pv_move.filter(|&mv| is_pseudo_legal(&self.pos, mv));
         let hash_move = tt_move.or(pv_move);
 
@@ -589,6 +596,10 @@ impl Worker {
         let depth = if in_check { depth + 1 } else { depth };
 
         // ── Static Eval ──
+        // Our best guess at how good this position is without searching deeper.
+        // Used as a baseline for pruning decisions — if the position looks
+        // overwhelmingly good or hopeless, we can take shortcuts.
+        // Meaningless when in check (we're forced to respond, not evaluate).
         let static_eval = if in_check {
             tt::SCORE_NONE
         } else {
@@ -597,6 +608,9 @@ impl Worker {
         self.stack[ply].static_eval = static_eval;
 
         // ── Reverse Futility Pruning (~52 Elo) ──
+        // Position is already so good that even after subtracting a generous
+        // margin, we're still above beta. The opponent wouldn't have let us
+        // get here — just return the eval and move on.
         if !in_check
             && !N::PV
             && depth <= searcher.cfg.search_params.rfp_depth
@@ -620,6 +634,9 @@ impl Worker {
         }
 
         // ── Null Move Pruning (~85 Elo) ──
+        // If our position is so good that we can pass the turn (do nothing)
+        // and still beat beta after a reduced search, the opponent would
+        // never allow this line. Skip it. The "null move" is the pass.
         if !in_check
             && !N::PV
             && !self.stack[ply].is_null
@@ -996,7 +1013,7 @@ impl Worker {
 
         let alpha_orig = alpha;
 
-        // ── QSearch TT Probe ──
+        // ── QSearch TT Probe (~22 elo) ──
         // Read TT entries stored by negamax or prior qsearch visits.
         // Cutoffs gated on non-PV nodes — PV nodes need the full capture
         // sequence for accurate PV reporting.

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -153,6 +153,31 @@ impl TranspositionTable {
         }
     }
 
+    /// Stores a qsearch result (depth = 0). Conservative replacement policy:
+    /// only overwrites empty slots or existing depth-0 entries so that deeper
+    /// negamax entries are never evicted by high-volume qsearch stores.
+    #[inline(always)]
+    pub fn store_qs(&self, hash: u64, ply: usize, score: i32, mv: Move, bound: u8) {
+        if self.entries.is_empty() {
+            return;
+        }
+
+        let idx = self.index(hash);
+        // SAFETY: Obtaining mutable reference to a slot via an immutable &self.
+        // Standard high-performance lockless TT approach.
+        let entry = unsafe { &mut *(self.entries.as_ptr().add(idx) as *mut TtEntry) };
+
+        // Only overwrite empty slots or existing depth-0 (qsearch) entries.
+        // Depth-preferred negamax entries must not be evicted.
+        if entry.bound == BOUND_NONE || entry.depth == 0 {
+            entry.key = hash;
+            entry.mv = mv.inner();
+            entry.score = Self::score_to_tt(score, ply) as i16;
+            entry.depth = 0;
+            entry.bound = bound;
+        }
+    }
+
     /// Maps 64-bit hash to [0, count).
     #[inline(always)]
     fn index(&self, hash: u64) -> usize {


### PR DESCRIPTION
```
Elo   | 40.06 +- 16.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 5.00]
Games | N: 1176 W: 507 L: 372 D: 297
Penta | [52, 83, 231, 122, 100]
```
https://pyronomy.pythonanywhere.com/test/3747/

```
Elo   | 22.31 +- 11.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 1934 W: 722 L: 598 D: 614
Penta | [65, 177, 395, 229, 101]
```
https://pyronomy.pythonanywhere.com/test/3748/

Bench: 13002625