### PR TITLE
Quiescence TT move ordering

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1017,11 +1017,17 @@ impl Worker {
         // Read TT entries stored by negamax or prior qsearch visits.
         // Cutoffs gated on non-PV nodes — PV nodes need the full capture
         // sequence for accurate PV reporting.
+        //
+        // Quiescence TT Move (~9 Elo)
         let qs_tt_move = if let Some((mv, score, _depth, bound)) = searcher.tt.probe(self.pos.hash, ply) {
             if !N::PV && tt::can_cutoff(bound, score, alpha, beta) {
                 return Ok(score);
             }
-            if !mv.is_null() && is_pseudo_legal(&self.pos, mv) { Some(mv) } else { None }
+            if !mv.is_null() && is_pseudo_legal(&self.pos, mv) {
+                Some(mv)
+            } else {
+                None
+            }
         } else {
             None
         };

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1017,12 +1017,14 @@ impl Worker {
         // Read TT entries stored by negamax or prior qsearch visits.
         // Cutoffs gated on non-PV nodes — PV nodes need the full capture
         // sequence for accurate PV reporting.
-        if let Some((_mv, score, _depth, bound)) = searcher.tt.probe(self.pos.hash, ply)
-            && !N::PV
-            && tt::can_cutoff(bound, score, alpha, beta)
-        {
-            return Ok(score);
-        }
+        let qs_tt_move = if let Some((mv, score, _depth, bound)) = searcher.tt.probe(self.pos.hash, ply) {
+            if !N::PV && tt::can_cutoff(bound, score, alpha, beta) {
+                return Ok(score);
+            }
+            if !mv.is_null() && is_pseudo_legal(&self.pos, mv) { Some(mv) } else { None }
+        } else {
+            None
+        };
 
         let checkers = self.pos.checkers();
         let in_check = checkers.is_not_empty();
@@ -1071,7 +1073,7 @@ impl Worker {
         let ksq = self.pos.pieces(PieceType::King, stm).lsb();
         let pinned = self.pos.king_blockers();
 
-        let mut picker = MovePicker::new_qsearch(None, searcher.cfg, in_check);
+        let mut picker = MovePicker::new_qsearch(qs_tt_move, searcher.cfg, in_check);
 
         while let Some(mv) = picker.next(&self.pos, &self.history) {
             if !is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {


### PR DESCRIPTION
```
Elo   | 9.68 +- 7.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 5.00]
Games | N: 5420 W: 1996 L: 1845 D: 1579
Penta | [254, 532, 1034, 589, 301]
```
https://pyronomy.pythonanywhere.com/test/3750/

```
Elo   | 8.77 +- 6.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 5664 W: 1959 L: 1816 D: 1889
Penta | [202, 611, 1119, 642, 258]
```
https://pyronomy.pythonanywhere.com/test/3751/

Bench: 12563678