### PR TITLE
Internal Iterative Reduction

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -675,7 +675,7 @@ impl Worker {
             }
         }
 
-        // ── Internal Iterative Reduction ──
+        // ── Internal Iterative Reduction (~14 Elo) ──
         // No TT move means we're searching blind — our first guesses are just
         // that, guesses. Reduce by one ply to acknowledge the uncertainty
         // and avoid investing full depth into an unguided search.

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -675,6 +675,17 @@ impl Worker {
             }
         }
 
+        // ── Internal Iterative Reduction ──
+        // No TT move means we're searching blind — our first guesses are just
+        // that, guesses. Reduce by one ply to acknowledge the uncertainty
+        // and avoid investing full depth into an unguided search.
+        // The next iteration will have a TT move and do it properly.
+        let depth = if depth >= 4 && N::PV && tt_move.is_none() {
+            depth - 1
+        } else {
+            depth
+        };
+
         // ──────── Move loop ────────
 
         let mut res = MoveResult {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -680,7 +680,7 @@ impl Worker {
         // that, guesses. Reduce by one ply to acknowledge the uncertainty
         // and avoid investing full depth into an unguided search.
         // The next iteration will have a TT move and do it properly.
-        let depth = if depth >= 4 && N::PV && tt_move.is_none() {
+        let depth = if depth >= 4 && tt_move.is_none() {
             depth - 1
         } else {
             depth


### PR DESCRIPTION
```
Elo   | 5.87 +- 5.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.30 (-2.20, 2.20) [0.00, 5.00]
Games | N: 11480 W: 4197 L: 4003 D: 3280
Penta | [584, 1148, 2182, 1142, 684]
```
https://pyronomy.pythonanywhere.com/test/3784/

```
Elo   | 14.41 +- 9.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.23 (-2.20, 2.20) [0.00, 5.00]
Games | N: 3280 W: 1194 L: 1058 D: 1028
Penta | [137, 298, 673, 356, 176]
```
https://pyronomy.pythonanywhere.com/test/3785/

Bench: 13453997