### PR TITLE
History-guided LMR / LMR History Adjustment

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -769,7 +769,9 @@ impl Worker {
                 // Search them at reduced depth; re-search fully on surprise.
                 let reduction = if depth >= 2 && res.move_count >= 1 && mv.is_quiet() && !in_check {
                     let r = searcher.cfg.lmr_table[depth as usize][res.move_count + 1] as i32;
-                    r.clamp(0, depth - 1)
+                    let pt = self.pos.expect_piece_at(mv.from());
+                    let hist = self.history.score_quiet(self.pos.stm, pt, mv.to());
+                    (r - hist / 8192).clamp(0, depth - 1)
                 } else {
                     0
                 };

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -770,7 +770,7 @@ impl Worker {
                 let reduction = if depth >= 2 && res.move_count >= 1 && mv.is_quiet() && !in_check {
                     let r = searcher.cfg.lmr_table[depth as usize][res.move_count + 1] as i32;
                     let pt = self.pos.expect_piece_at(mv.from());
-                    let hist = self.history.score_quiet(self.pos.stm, pt, mv.to());
+                    let hist = self.history.score_quiet(self.pos.stm, pt, mv.to()); // ~13 Elo
                     (r - hist / 8192).clamp(0, depth - 1)
                 } else {
                     0


### PR DESCRIPTION
```
Elo   | 4.64 +- 4.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.23 (-2.20, 2.20) [0.00, 5.00]
Games | N: 15864 W: 5819 L: 5607 D: 4438
Penta | [793, 1569, 3083, 1607, 880]
```
https://pyronomy.pythonanywhere.com/test/3787/

```
Elo   | 13.84 +- 8.70 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.26 (-2.20, 2.20) [0.00, 5.00]
Games | N: 3390 W: 1197 L: 1062 D: 1131
Penta | [128, 324, 690, 391, 162]
```
https://pyronomy.pythonanywhere.com/test/3788/

Bench: 13453919