### PR TITLE
Gives-check Late Move Reduction Adjustement

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -875,11 +875,19 @@ impl Worker {
         ply: usize,
         root_idx: Option<usize>,
         is_pv_move: bool,
-        reduction: i32,
+        mut reduction: i32,
     ) -> Result<(), SearchAborted> {
         let saved_acc = self.accumulator;
         let undo = self.pos.make_move(mv, &mut self.accumulator);
         searcher.tt.prefetch(self.pos.hash);
+
+        // ── Gives-Check LMR Adjustment ──
+        // A move that delivers check is forcing — the opponent has no choice
+        // but to respond. Don't reduce it as aggressively; give it a bit more
+        // depth so the resulting tactics are properly resolved.
+        if self.pos.checkers().is_not_empty() {
+            reduction = (reduction - 1).max(0);
+        }
 
         res.move_count += 1;
         searcher.history.push(self.pos.hash);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -881,7 +881,7 @@ impl Worker {
         let undo = self.pos.make_move(mv, &mut self.accumulator);
         searcher.tt.prefetch(self.pos.hash);
 
-        // ── Gives-Check LMR Adjustment ──
+        // ── Gives-Check LMR Adjustment (~4 Elo) ──
         // A move that delivers check is forcing — the opponent has no choice
         // but to respond. Don't reduce it as aggressively; give it a bit more
         // depth so the resulting tactics are properly resolved.


### PR DESCRIPTION
```
Elo   | 3.04 +- 2.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 40318 W: 14507 L: 14154 D: 11657
Penta | [2036, 4160, 7646, 4049, 2268]
```
<https://pyronomy.pythonanywhere.com/test/3803/>

```
Elo   | 3.94 +- 3.66 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 18762 W: 6189 L: 5976 D: 6597
Penta | [725, 2030, 3698, 2163, 765]
```
https://pyronomy.pythonanywhere.com/test/3804/

Bench: 13615290