### PR TITLE
Root LMR

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -699,6 +699,17 @@ impl Worker {
             // Iterate the pre-sorted root move list.
             for i in 0..searcher.root_moves.len() {
                 let mv = searcher.root_moves[i].mv;
+
+                // ── Root LMR ──
+                // Root moves are pre-sorted by the previous iteration's scores,
+                // so late moves in the list are already the engine's worst guesses.
+                // Scout them at reduced depth; a fail-high triggers a full re-search.
+                let reduction = if depth >= 2 && i >= 1 && mv.is_quiet() && !in_check {
+                    searcher.cfg.lmr_table[depth as usize][i + 1] as i32
+                } else {
+                    0
+                };
+
                 self.search_move::<N>(
                     searcher,
                     mv,
@@ -708,7 +719,7 @@ impl Worker {
                     ply,
                     Some(i),
                     Some(mv) == pv_move,
-                    0,
+                    reduction,
                 )?;
                 if likely(res.alpha >= beta) {
                     break;

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -700,7 +700,7 @@ impl Worker {
             for i in 0..searcher.root_moves.len() {
                 let mv = searcher.root_moves[i].mv;
 
-                // ── Root LMR ──
+                // ── Root LMR (~21 Elo) ──
                 // Root moves are pre-sorted by the previous iteration's scores,
                 // so late moves in the list are already the engine's worst guesses.
                 // Scout them at reduced depth; a fail-high triggers a full re-search.


### PR DESCRIPTION
```
Elo   | 19.35 +- 10.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.55 (-2.20, 2.20) [0.00, 5.00]
Games | N: 2678 W: 955 L: 806 D: 917
Penta | [89, 284, 505, 311, 150]
```
https://pyronomy.pythonanywhere.com/test/3808/

```
Elo   | 21.47 +- 10.73 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.28 (-2.20, 2.20) [0.00, 5.00]
Games | N: 1944 W: 656 L: 536 D: 752
Penta | [50, 185, 407, 255, 75]
```
https://pyronomy.pythonanywhere.com/test/3809/

Bench: 9850861