### PR TITLE
Introduce Killers History

### DIFF
--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -71,6 +71,7 @@ pub struct MovePicker {
     mvvlva_v:   [i32; 8],
     mvvlva_a:   [i32; 8],
     mvvlva_ep:  i32,
+    killers:    [Move; 2],
     is_qsearch: bool,
     in_check:   bool,
 }
@@ -80,7 +81,7 @@ const _: () = assert!(std::mem::size_of::<Move>() == 2);
 
 impl MovePicker {
     #[inline]
-    pub fn new(hash_move: Option<Move>, cfg: &SearchConfig) -> Self {
+    pub fn new(hash_move: Option<Move>, cfg: &SearchConfig, killers: [Move; 2]) -> Self {
         Self {
             stage: Stage::Hash,
             hash_move,
@@ -89,6 +90,7 @@ impl MovePicker {
             mvvlva_v: cfg.mvvlva_v,
             mvvlva_a: cfg.mvvlva_a,
             mvvlva_ep: cfg.search_params.mvvlva_ep,
+            killers,
             is_qsearch: false,
             in_check: false,
         }
@@ -104,6 +106,7 @@ impl MovePicker {
             mvvlva_v: cfg.mvvlva_v,
             mvvlva_a: cfg.mvvlva_a,
             mvvlva_ep: cfg.search_params.mvvlva_ep,
+            killers: [Move::null(); 2],
             is_qsearch: true,
             in_check,
         }
@@ -417,14 +420,10 @@ impl MovePicker {
 
         // ──────── Move Ordering Heuristics ────────
 
-        // History values are mathematically bounded to [-16384, 16384] by the
-        // update gravity. If this ever breaches 32767, the bitpacked sort
-        // key will overflow and destroy move ordering.
-        debug_assert!(score.abs() <= 16384, "History score overflow: {score}");
-
+        // History values are mathematically bounded to `[-32768, 32768]` combined.
         // Added 32768 guarantees a positive value without overflow.
-        // History ranges from [-16384, 16384], so logic natively boundaries at [16384, 49152].
-        let mut sort_score = (score + 32768).clamp(0, 65535) as u32;
+        // We safely clamp at 63000 to keep the highest `[64000, 65535]` band exclusive for killers and promotions.
+        let mut sort_score = (score + 32768).clamp(0, 63000) as u32;
 
         // Quiet promotions outrank all other quiet moves.
         // Queen first (almost always best), then knight (fork potential),
@@ -436,6 +435,10 @@ impl MovePicker {
                 Some(PieceType::Rook) => 65533,
                 _ => 65532,
             };
+        } else if mv == self.killers[0] {
+            sort_score = 65000;
+        } else if mv == self.killers[1] {
+            sort_score = 64000;
         }
 
         let packed = (sort_score << 16) | (mv.inner() as u32);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -824,7 +824,7 @@ impl Worker {
                         let pt = self.pos.expect_piece_at(mv.from());
                         self.history.update(stm, pt, mv.from(), mv.to(), bonus);
 
-                        // ── Killer Moves (???) ──
+                        // ── Killer Moves (~35 Elo) ──
                         // Maintain a 2-slot pseudo-Least-Recently-Used cache for tracking quiet cutoffs.
                         // If the move isn't already the primary killer, shift the old primary to slot 1
                         // and promote the new move to slot 0. If it was slot 1, this natively swaps them.

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -736,7 +736,7 @@ impl Worker {
             self.stack[ply].quiet_count = 0;
 
             // Interior: staged move generation via MovePicker.
-            let mut picker = MovePicker::new(hash_move, searcher.cfg);
+            let mut picker = MovePicker::new(hash_move, searcher.cfg, self.stack[ply].killers);
             while let Some(mv) = picker.next(&self.pos, &self.history) {
                 if !is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
                     continue;
@@ -779,12 +779,17 @@ impl Worker {
                 // Moves late in the list are unlikely to beat alpha.
                 // Search them at reduced depth; re-search fully on surprise.
                 let reduction = if depth >= 2 && res.move_count >= 1 && mv.is_quiet() && !in_check {
-                    let r = searcher.cfg.lmr_table[depth as usize][res.move_count + 1] as i32;
+                    let mut r = searcher.cfg.lmr_table[depth as usize][res.move_count + 1] as i32;
                     let pt = self.pos.expect_piece_at(mv.from());
                     // ~13 Elo
                     let hist = self
                         .history
                         .score_quiet(self.pos.stm, pt, mv.from(), mv.to());
+
+                    if mv == self.stack[ply].killers[0] || mv == self.stack[ply].killers[1] {
+                        r -= 1;
+                    }
+
                     (r - hist / 8192).clamp(0, depth - 1)
                 } else {
                     0
@@ -818,6 +823,15 @@ impl Worker {
                     if mv.is_history_quiet() {
                         let pt = self.pos.expect_piece_at(mv.from());
                         self.history.update(stm, pt, mv.from(), mv.to(), bonus);
+
+                        // ── Killer Moves (???) ──
+                        // Maintain a 2-slot pseudo-Least-Recently-Used cache for tracking quiet cutoffs.
+                        // If the move isn't already the primary killer, shift the old primary to slot 1
+                        // and promote the new move to slot 0. If it was slot 1, this natively swaps them.
+                        if mv != self.stack[ply].killers[0] {
+                            self.stack[ply].killers[1] = self.stack[ply].killers[0];
+                            self.stack[ply].killers[0] = mv;
+                        }
                     }
 
                     // ── Asymmetric Penalty (~25 Elo) ──
@@ -1459,6 +1473,7 @@ pub struct Stack {
     pub pv:          Line,
     pub quiet_moves: [Move; MAX_TRACKED_QUIETS],
     pub quiet_count: usize,
+    pub killers:     [Move; 2],
     pub static_eval: i32,
     pub is_null:     bool,
 }
@@ -1469,6 +1484,7 @@ impl Default for Stack {
             pv:          Line::new(),
             quiet_moves: [Move::null(); MAX_TRACKED_QUIETS],
             quiet_count: 0,
+            killers:     [Move::null(); 2],
             static_eval: tt::SCORE_NONE,
             is_null:     false,
         }


### PR DESCRIPTION
```
Elo   | 37.35 +- 15.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.30 (-2.20, 2.20) [0.00, 5.00]
Games | N: 1242 W: 472 L: 339 D: 431
Penta | [46, 100, 223, 179, 73]
```
https://pyronomy.pythonanywhere.com/test/3845/

```
Elo   | 34.01 +- 13.90 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 5.00]
Games | N: 1158 W: 387 L: 274 D: 497
Penta | [22, 111, 226, 172, 48]
```
https://pyronomy.pythonanywhere.com/test/3846/

Bench: 9490132