### PR TITLE
Lower capture history divisor default to 32

### DIFF
--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -458,9 +458,9 @@ search_params! {
         /// the contribution to a range comparable to MVV-LVA. Higher values
         /// give MVV-LVA more weight; lower values give history more influence.
         pub capt_hist_divisor: i32 {
-            default: 256,
-            min:      64,
-            max:    1024,
+            default:  32,
+            min:       8,
+            max:     256,
             step:      8,
         },
     }


### PR DESCRIPTION
```
Elo   | -0.35 +- 3.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.23 (-2.20, 2.20) [0.00, 5.00]
Games | N: 18094 W: 5540 L: 5558 D: 6996
Penta | [628, 2137, 3568, 2053, 661]
```
https://pyronomy.pythonanywhere.com/test/4042/

```
Elo   | 9.50 +- 6.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 4388 W: 1284 L: 1164 D: 1940
Penta | [87, 489, 954, 545, 119]
```
https://pyronomy.pythonanywhere.com/test/4043/

Bench: 5992434