### PR TITLE
Non-Pawn STM Correction History

### DIFF
--- a/src/core/board/mod.rs
+++ b/src/core/board/mod.rs
@@ -548,6 +548,18 @@ impl Position {
         }
         key
     }
+
+    /// Compute a Zobrist hash of non-pawn, non-king pieces for a given color.
+    /// Used by non-pawn correction history to index by material configuration.
+    pub fn calc_non_pawn_hash(&self, color: Color) -> u64 {
+        let mut key = 0u64;
+        let pieces = self.side_bb[color as usize]
+            & !(self.role_bb[PieceType::Pawn as usize] | self.role_bb[PieceType::King as usize]);
+        for sq in pieces {
+            key ^= zobrist::key_piece(self.piece_at(sq), color, sq);
+        }
+        key
+    }
 }
 
 impl Default for Position {

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -312,39 +312,19 @@ impl History {
         *entry = (e + bonus - e * bonus.abs() / 16384).clamp(-16384, 16384) as i16;
     }
 
-    /// Blended correction: pawn structure + white non-pawn config + black non-pawn config.
+    /// Blended correction: pawn structure + side-to-move's non-pawn configuration.
     ///
-    /// Pawn correction is at full weight; NP corrections are scaled by `np_weight / 256`
-    /// so the tuner can dial their contribution independently.
+    /// Pawn correction is at full weight; NP correction is scaled by `np_weight / 256`
+    /// so the tuner can dial its contribution independently.
     #[inline(always)]
-    pub fn correction(
-        &self,
-        stm: Color,
-        pawn_hash: u64,
-        w_np_hash: u64,
-        b_np_hash: u64,
-        np_weight: i32,
-    ) -> i32 {
-        self.correction.get(stm, pawn_hash)
-            + self.np_correction.get(Color::White, w_np_hash) * np_weight / 256
-            + self.np_correction.get(Color::Black, b_np_hash) * np_weight / 256
+    pub fn correction(&self, stm: Color, pawn_hash: u64, stm_np_hash: u64, np_weight: i32) -> i32 {
+        self.correction.get(stm, pawn_hash) + self.np_correction.get(stm, stm_np_hash) * np_weight / 256
     }
 
     #[inline(always)]
-    pub fn update_correction(
-        &mut self,
-        stm: Color,
-        pawn_hash: u64,
-        w_np_hash: u64,
-        b_np_hash: u64,
-        diff: i32,
-        depth: i32,
-    ) {
+    pub fn update_correction(&mut self, stm: Color, pawn_hash: u64, stm_np_hash: u64, diff: i32, depth: i32) {
         self.correction.update(stm, pawn_hash, diff, depth);
-        self.np_correction
-            .update(Color::White, w_np_hash, diff, depth);
-        self.np_correction
-            .update(Color::Black, b_np_hash, diff, depth);
+        self.np_correction.update(stm, stm_np_hash, diff, depth);
     }
 
     /// Retrieve the capture history score for a capture move.

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -207,7 +207,7 @@ pub struct History {
     /// `[side][pawn_hash & 0x3FFF]`
     correction:    CorrectionHistory, // ~53 Elo
     /// `[color][non_pawn_hash & 0x3FFF]` — Zobrist-indexed by material configuration
-    np_correction: CorrectionHistory,
+    np_correction: CorrectionHistory, // ~18 Elo
     /// `[side][attacker][to][victim]`
     capt:          CaptureHistory, // ~8 Elo
 }

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -6,10 +6,7 @@
 //! High-scoring moves are sorted to the front of the move list, maximizing
 //! the probability of early cutoffs in subsequent searches.
 
-use crate::core::{
-    board::Position,
-    defs::{Color, PieceType, Square},
-};
+use crate::core::defs::{Color, PieceType, Square};
 
 #[derive(Clone, Copy)]
 pub struct ContContext {
@@ -202,29 +199,29 @@ impl Default for CorrectionHistory {
 #[derive(Clone)]
 pub struct History {
     /// `[side][piece][to_square]` — bounds `[-16384, 16384]`
-    table:      [[[i16; 64]; 6]; 2],
+    table:         [[[i16; 64]; 6]; 2],
     /// `[side][from · 64 + to]` — bounds `[-16384, 16384]`
-    butterfly:  [[i16; 4096]; 2], // ~20 Elo
+    butterfly:     [[i16; 4096]; 2], // ~20 Elo
     /// `[ply_offset][side][prev_piece][prev_to][piece][to]`
-    cont:       [ContinuationHistory; 2], // n-1 (~13 Elo), n-2 (~3 Elo), n-3 (~3 Elo)
+    cont:          [ContinuationHistory; 2], // n-1 (~13 Elo), n-2 (~3 Elo), n-3 (~3 Elo)
     /// `[side][pawn_hash & 0x3FFF]`
-    correction: CorrectionHistory, // ~53 Elo
-    /// `[side][piece][square]`
-    np_corr:    [[[i16; 64]; 6]; 2],
+    correction:    CorrectionHistory, // ~53 Elo
+    /// `[color][non_pawn_hash & 0x3FFF]` — Zobrist-indexed by material configuration
+    np_correction: CorrectionHistory,
     /// `[side][attacker][to][victim]`
-    capt:       CaptureHistory, // ~8 Elo
+    capt:          CaptureHistory, // ~8 Elo
 }
 
 impl History {
     /// Create a zeroed history table.
     pub fn new() -> Self {
         Self {
-            table:      [[[0; 64]; 6]; 2],
-            butterfly:  [[0; 4096]; 2],
-            cont:       [ContinuationHistory::new(), ContinuationHistory::new()],
-            correction: CorrectionHistory::new(),
-            np_corr:    [[[0; 64]; 6]; 2],
-            capt:       CaptureHistory::new(),
+            table:         [[[0; 64]; 6]; 2],
+            butterfly:     [[0; 4096]; 2],
+            cont:          [ContinuationHistory::new(), ContinuationHistory::new()],
+            correction:    CorrectionHistory::new(),
+            np_correction: CorrectionHistory::new(),
+            capt:          CaptureHistory::new(),
         }
     }
 
@@ -235,7 +232,7 @@ impl History {
         self.cont[0].clear();
         self.cont[1].clear();
         self.correction.clear();
-        self.np_corr = [[[0; 64]; 6]; 2];
+        self.np_correction.clear();
         self.capt.clear();
     }
 
@@ -315,32 +312,39 @@ impl History {
         *entry = (e + bonus - e * bonus.abs() / 16384).clamp(-16384, 16384) as i16;
     }
 
+    /// Blended correction: pawn structure + white non-pawn config + black non-pawn config.
+    ///
+    /// Pawn correction is at full weight; NP corrections are scaled by `np_weight / 256`
+    /// so the tuner can dial their contribution independently.
     #[inline(always)]
-    pub fn correction(&self, stm: Color, pawn_hash: u64, pos: &Position) -> i32 {
-        let mut np_bias = 0;
-        let stm_non_pawns = pos.side_bb[stm as usize] & !pos.role_bb[PieceType::Pawn];
-        for sq in stm_non_pawns {
-            let pt = pos.piece_at(sq);
-            np_bias += i32::from(self.np_corr[stm as usize][pt as usize][sq.0 as usize]);
-        }
-        self.correction.get(stm, pawn_hash) + np_bias / stm_non_pawns.popcount().max(1) as i32
+    pub fn correction(
+        &self,
+        stm: Color,
+        pawn_hash: u64,
+        w_np_hash: u64,
+        b_np_hash: u64,
+        np_weight: i32,
+    ) -> i32 {
+        self.correction.get(stm, pawn_hash)
+            + self.np_correction.get(Color::White, w_np_hash) * np_weight / 256
+            + self.np_correction.get(Color::Black, b_np_hash) * np_weight / 256
     }
 
     #[inline(always)]
-    pub fn update_correction(&mut self, stm: Color, pawn_hash: u64, pos: &Position, diff: i32, depth: i32) {
+    pub fn update_correction(
+        &mut self,
+        stm: Color,
+        pawn_hash: u64,
+        w_np_hash: u64,
+        b_np_hash: u64,
+        diff: i32,
+        depth: i32,
+    ) {
         self.correction.update(stm, pawn_hash, diff, depth);
-
-        let stm_non_pawns = pos.side_bb[stm as usize] & !pos.role_bb[PieceType::Pawn];
-        let weight = (1 + depth).min(16);
-        let scaled = diff * CORRECTION_SCALE;
-
-        for sq in stm_non_pawns {
-            let pt = pos.piece_at(sq);
-            let entry = &mut self.np_corr[stm as usize][pt as usize][sq.0 as usize];
-            let e = i32::from(*entry);
-            *entry = ((e * (256 - weight) + scaled * weight) / 256).clamp(-CORRECTION_LIMIT, CORRECTION_LIMIT)
-                as i16;
-        }
+        self.np_correction
+            .update(Color::White, w_np_hash, diff, depth);
+        self.np_correction
+            .update(Color::Black, b_np_hash, diff, depth);
     }
 
     /// Retrieve the capture history score for a capture move.
@@ -373,14 +377,14 @@ impl Default for History {
     /// Only use as a placeholder for `std::mem::take` — never score moves against this.
     fn default() -> Self {
         Self {
-            table:      [[[0; 64]; 6]; 2],
-            butterfly:  [[0; 4096]; 2],
-            cont:       [ContinuationHistory { data: Box::new([]) }, ContinuationHistory {
+            table:         [[[0; 64]; 6]; 2],
+            butterfly:     [[0; 4096]; 2],
+            cont:          [ContinuationHistory { data: Box::new([]) }, ContinuationHistory {
                 data: Box::new([]),
             }],
-            correction: CorrectionHistory { data: Box::new([]) },
-            np_corr:    [[[0; 64]; 6]; 2],
-            capt:       CaptureHistory { data: Box::new([]) },
+            correction:    CorrectionHistory { data: Box::new([]) },
+            np_correction: CorrectionHistory { data: Box::new([]) },
+            capt:          CaptureHistory { data: Box::new([]) },
         }
     }
 }

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -6,7 +6,10 @@
 //! High-scoring moves are sorted to the front of the move list, maximizing
 //! the probability of early cutoffs in subsequent searches.
 
-use crate::core::defs::{Color, PieceType, Square};
+use crate::core::{
+    board::Position,
+    defs::{Color, PieceType, Square},
+};
 
 #[derive(Clone, Copy)]
 pub struct ContContext {
@@ -206,6 +209,8 @@ pub struct History {
     cont:       [ContinuationHistory; 2], // n-1 (~13 Elo), n-2 (~3 Elo), n-3 (~3 Elo)
     /// `[side][pawn_hash & 0x3FFF]`
     correction: CorrectionHistory, // ~53 Elo
+    /// `[side][piece][square]`
+    np_corr:    [[[i16; 64]; 6]; 2],
     /// `[side][attacker][to][victim]`
     capt:       CaptureHistory, // ~8 Elo
 }
@@ -218,6 +223,7 @@ impl History {
             butterfly:  [[0; 4096]; 2],
             cont:       [ContinuationHistory::new(), ContinuationHistory::new()],
             correction: CorrectionHistory::new(),
+            np_corr:    [[[0; 64]; 6]; 2],
             capt:       CaptureHistory::new(),
         }
     }
@@ -229,6 +235,7 @@ impl History {
         self.cont[0].clear();
         self.cont[1].clear();
         self.correction.clear();
+        self.np_corr = [[[0; 64]; 6]; 2];
         self.capt.clear();
     }
 
@@ -309,13 +316,31 @@ impl History {
     }
 
     #[inline(always)]
-    pub fn correction(&self, stm: Color, pawn_hash: u64) -> i32 {
-        self.correction.get(stm, pawn_hash)
+    pub fn correction(&self, stm: Color, pawn_hash: u64, pos: &Position) -> i32 {
+        let mut np_bias = 0;
+        let stm_non_pawns = pos.side_bb[stm as usize] & !pos.role_bb[PieceType::Pawn];
+        for sq in stm_non_pawns {
+            let pt = pos.piece_at(sq);
+            np_bias += i32::from(self.np_corr[stm as usize][pt as usize][sq.0 as usize]);
+        }
+        self.correction.get(stm, pawn_hash) + np_bias / stm_non_pawns.popcount().max(1) as i32
     }
 
     #[inline(always)]
-    pub fn update_correction(&mut self, stm: Color, pawn_hash: u64, diff: i32, depth: i32) {
+    pub fn update_correction(&mut self, stm: Color, pawn_hash: u64, pos: &Position, diff: i32, depth: i32) {
         self.correction.update(stm, pawn_hash, diff, depth);
+
+        let stm_non_pawns = pos.side_bb[stm as usize] & !pos.role_bb[PieceType::Pawn];
+        let weight = (1 + depth).min(16);
+        let scaled = diff * CORRECTION_SCALE;
+
+        for sq in stm_non_pawns {
+            let pt = pos.piece_at(sq);
+            let entry = &mut self.np_corr[stm as usize][pt as usize][sq.0 as usize];
+            let e = i32::from(*entry);
+            *entry = ((e * (256 - weight) + scaled * weight) / 256).clamp(-CORRECTION_LIMIT, CORRECTION_LIMIT)
+                as i16;
+        }
     }
 
     /// Retrieve the capture history score for a capture move.
@@ -354,6 +379,7 @@ impl Default for History {
                 data: Box::new([]),
             }],
             correction: CorrectionHistory { data: Box::new([]) },
+            np_corr:    [[[0; 64]; 6]; 2],
             capt:       CaptureHistory { data: Box::new([]) },
         }
     }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -25,7 +25,7 @@ pub use crate::core::defs::Protocol;
 use crate::{
     core::{
         board::Position,
-        defs::{Color, INF, MATE, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square},
+        defs::{INF, MATE, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square},
         moves::Move,
     },
     engine::{
@@ -617,15 +617,10 @@ impl Worker {
         } else {
             self.pos.calc_pawn_hash()
         };
-        let w_np_hash = if in_check {
+        let stm_np_hash = if in_check {
             0
         } else {
-            self.pos.calc_non_pawn_hash(Color::White)
-        };
-        let b_np_hash = if in_check {
-            0
-        } else {
-            self.pos.calc_non_pawn_hash(Color::Black)
+            self.pos.calc_non_pawn_hash(self.pos.stm)
         };
         let static_eval = if in_check {
             tt::SCORE_NONE
@@ -633,8 +628,7 @@ impl Worker {
             let correction = self.history.correction(
                 self.pos.stm,
                 pawn_hash,
-                w_np_hash,
-                b_np_hash,
+                stm_np_hash,
                 searcher.cfg.search_params.np_corr_weight,
             ) / history::CORRECTION_SCALE;
             (raw_static_eval + correction).clamp(-MATE_BOUND, MATE_BOUND)
@@ -1049,7 +1043,7 @@ impl Worker {
         {
             let diff = res.best_eval - raw_static_eval;
             self.history
-                .update_correction(self.pos.stm, pawn_hash, w_np_hash, b_np_hash, diff, depth);
+                .update_correction(self.pos.stm, pawn_hash, stm_np_hash, diff, depth);
         }
 
         Ok(res.best_eval)
@@ -1264,13 +1258,11 @@ impl Worker {
         } else {
             let raw_eval = evaluate(&self.pos, &self.accumulator);
             let pawn_hash = self.pos.calc_pawn_hash();
-            let w_np_hash = self.pos.calc_non_pawn_hash(Color::White);
-            let b_np_hash = self.pos.calc_non_pawn_hash(Color::Black);
+            let stm_np_hash = self.pos.calc_non_pawn_hash(self.pos.stm);
             let correction = self.history.correction(
                 self.pos.stm,
                 pawn_hash,
-                w_np_hash,
-                b_np_hash,
+                stm_np_hash,
                 searcher.cfg.search_params.np_corr_weight,
             ) / history::CORRECTION_SCALE;
             let eval = (raw_eval + correction).clamp(-MATE_BOUND, MATE_BOUND);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -25,7 +25,7 @@ pub use crate::core::defs::Protocol;
 use crate::{
     core::{
         board::Position,
-        defs::{INF, MATE, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square},
+        defs::{Color, INF, MATE, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square},
         moves::Move,
     },
     engine::{
@@ -617,11 +617,26 @@ impl Worker {
         } else {
             self.pos.calc_pawn_hash()
         };
+        let w_np_hash = if in_check {
+            0
+        } else {
+            self.pos.calc_non_pawn_hash(Color::White)
+        };
+        let b_np_hash = if in_check {
+            0
+        } else {
+            self.pos.calc_non_pawn_hash(Color::Black)
+        };
         let static_eval = if in_check {
             tt::SCORE_NONE
         } else {
-            let correction =
-                self.history.correction(self.pos.stm, pawn_hash, &self.pos) / history::CORRECTION_SCALE;
+            let correction = self.history.correction(
+                self.pos.stm,
+                pawn_hash,
+                w_np_hash,
+                b_np_hash,
+                searcher.cfg.search_params.np_corr_weight,
+            ) / history::CORRECTION_SCALE;
             (raw_static_eval + correction).clamp(-MATE_BOUND, MATE_BOUND)
         };
         self.stack[ply].static_eval = static_eval;
@@ -1034,7 +1049,7 @@ impl Worker {
         {
             let diff = res.best_eval - raw_static_eval;
             self.history
-                .update_correction(self.pos.stm, pawn_hash, &self.pos, diff, depth);
+                .update_correction(self.pos.stm, pawn_hash, w_np_hash, b_np_hash, diff, depth);
         }
 
         Ok(res.best_eval)
@@ -1248,10 +1263,16 @@ impl Worker {
             -INF
         } else {
             let raw_eval = evaluate(&self.pos, &self.accumulator);
-            let correction = self
-                .history
-                .correction(self.pos.stm, self.pos.calc_pawn_hash(), &self.pos)
-                / history::CORRECTION_SCALE;
+            let pawn_hash = self.pos.calc_pawn_hash();
+            let w_np_hash = self.pos.calc_non_pawn_hash(Color::White);
+            let b_np_hash = self.pos.calc_non_pawn_hash(Color::Black);
+            let correction = self.history.correction(
+                self.pos.stm,
+                pawn_hash,
+                w_np_hash,
+                b_np_hash,
+                searcher.cfg.search_params.np_corr_weight,
+            ) / history::CORRECTION_SCALE;
             let eval = (raw_eval + correction).clamp(-MATE_BOUND, MATE_BOUND);
             if eval >= beta {
                 return Ok(eval);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -620,7 +620,8 @@ impl Worker {
         let static_eval = if in_check {
             tt::SCORE_NONE
         } else {
-            let correction = self.history.correction(self.pos.stm, pawn_hash) / history::CORRECTION_SCALE;
+            let correction =
+                self.history.correction(self.pos.stm, pawn_hash, &self.pos) / history::CORRECTION_SCALE;
             (raw_static_eval + correction).clamp(-MATE_BOUND, MATE_BOUND)
         };
         self.stack[ply].static_eval = static_eval;
@@ -1033,7 +1034,7 @@ impl Worker {
         {
             let diff = res.best_eval - raw_static_eval;
             self.history
-                .update_correction(self.pos.stm, pawn_hash, diff, depth);
+                .update_correction(self.pos.stm, pawn_hash, &self.pos, diff, depth);
         }
 
         Ok(res.best_eval)
@@ -1249,7 +1250,7 @@ impl Worker {
             let raw_eval = evaluate(&self.pos, &self.accumulator);
             let correction = self
                 .history
-                .correction(self.pos.stm, self.pos.calc_pawn_hash())
+                .correction(self.pos.stm, self.pos.calc_pawn_hash(), &self.pos)
                 / history::CORRECTION_SCALE;
             let eval = (raw_eval + correction).clamp(-MATE_BOUND, MATE_BOUND);
             if eval >= beta {

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -463,5 +463,16 @@ search_params! {
             max:     256,
             step:      8,
         },
+
+        /// Non-pawn correction history weight (fixed-point, /256 scaling).
+        /// Controls how strongly each non-pawn material configuration
+        /// correction contributes to the static eval adjustment.
+        /// 256 = full weight (same as pawn correction), 128 = half.
+        pub np_corr_weight: i32 {
+            default: 128,
+            min:       0,
+            max:     512,
+            step:      8,
+        },
     }
 }


### PR DESCRIPTION
```
Elo   | 8.81 +- 6.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 5406 W: 1730 L: 1593 D: 2083
Penta | [177, 570, 1101, 649, 206]
```
https://pyronomy.pythonanywhere.com/test/4056/

```
Elo   | 18.77 +- 9.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 2020 W: 615 L: 506 D: 899
Penta | [41, 185, 460, 272, 52]
```
https://pyronomy.pythonanywhere.com/test/4057/

Bench: 5141681