### PR TITLE
Mate Distance Pruning

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -556,6 +556,27 @@ impl Worker {
             return Ok(evaluate(&self.pos, &self.accumulator));
         }
 
+        // ── Mate Distance Pruning (? Elo) ──
+        // Scores are bounded; no line from here can find mate faster than
+        // MATE - ply plies, and we can't be mated before -MATE + ply.
+        // Tighten the search window to those limits. If the tightened
+        // window collapses (a >= b), every achievable score in this
+        // subtree already satisfies the bound — return a, the tightest
+        // value provable without searching a single move.
+        //
+        // Skipped at the root so iterative_deepening always has a scored
+        // move list to sort; the cutoff path bypasses root_moves updates.
+        let (alpha, beta) = if N::ROOT {
+            (alpha, beta)
+        } else {
+            let a = alpha.max(-MATE + ply as i32);
+            let b = beta.min(MATE - ply as i32 - 1);
+            if a >= b {
+                return Ok(a);
+            }
+            (a, b)
+        };
+
         let alpha_orig = alpha;
 
         // ── TT Probe (~128 Elo) ──

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -556,7 +556,7 @@ impl Worker {
             return Ok(evaluate(&self.pos, &self.accumulator));
         }
 
-        // ── Mate Distance Pruning (? Elo) ──
+        // ── Mate Distance Pruning ──
         // Scores are bounded; no line from here can find mate faster than
         // MATE - ply plies, and we can't be mated before -MATE + ply.
         // Tighten the search window to those limits. If the tightened


### PR DESCRIPTION
```
Elo   | -3.01 +- 4.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.48 (-2.47, 2.91) [0.00, 5.00]
Games | N: 8316 W: 2431 L: 2503 D: 3382
Penta | [216, 902, 1962, 894, 184]
```
https://pyronomy.pythonanywhere.com/test/4129/

```
Elo   | -1.61 +- 3.44 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -2.52 (-2.47, 2.91) [0.00, 5.00]
Games | N: 11002 W: 2925 L: 2976 D: 5101
Penta | [137, 1035, 3196, 1008, 125]
```
https://pyronomy.pythonanywhere.com/test/4130/

Why gainer bounds and not non regression bounds?
well, very simple, tired aeth thought → enmpty instance, gainer bounds = more games<i>!</i>

Bench: 5141681