### PR TITLE
Recapture-only Deep QS

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -550,7 +550,7 @@ impl Worker {
         }
 
         if depth <= 0 {
-            return self.qsearch::<N>(searcher, alpha, beta, ply);
+            return self.qsearch::<N>(searcher, alpha, beta, ply, None, 0);
         }
         if ply >= MAX_PLY {
             return Ok(evaluate(&self.pos, &self.accumulator));
@@ -680,7 +680,7 @@ impl Worker {
             && depth <= searcher.cfg.search_params.razoring_depth
             && static_eval + searcher.cfg.search_params.razoring_margin * depth < alpha
         {
-            let score = self.qsearch::<N>(searcher, alpha, beta, ply)?;
+            let score = self.qsearch::<N>(searcher, alpha, beta, ply, None, 0)?;
             if score <= alpha {
                 return Ok(score);
             }
@@ -1260,6 +1260,8 @@ impl Worker {
         mut alpha: i32,
         beta: i32,
         ply: usize,
+        prev_to: Option<Square>,
+        qs_ply: i32,
     ) -> Result<i32, SearchAborted> {
         self.stack[ply].pv.len = 0;
 
@@ -1360,8 +1362,23 @@ impl Worker {
 
         let mut picker = MovePicker::new_qsearch(qs_tt_move, searcher.cfg, in_check);
 
+        let recapture_only = !in_check && qs_ply >= searcher.cfg.search_params.qs_recapture_ply;
+
         while let Some(mv) = picker.next(&self.pos, &self.history) {
             if !is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
+                continue;
+            }
+
+            // ── Recapture-only Deep QS ──
+            // Past `qs_recapture_ply`, captures only matter if they continue
+            // the forcing exchange on the square the opponent just moved to.
+            // Speculative off-square captures are what explodes in mutual-
+            // attack soup (e.g. 30-bishop pathologicals). Tactics are
+            // preserved because real combinations are recapture chains.
+            if recapture_only
+                && let Some(prev) = prev_to
+                && mv.to() != prev
+            {
                 continue;
             }
 
@@ -1379,7 +1396,7 @@ impl Worker {
             moves_made += 1;
             searcher.zobrist_trail.push(self.pos.hash);
 
-            let score = match self.qsearch::<N>(searcher, -beta, -alpha, ply + 1) {
+            let score = match self.qsearch::<N>(searcher, -beta, -alpha, ply + 1, Some(mv.to()), qs_ply + 1) {
                 Ok(v) => -v,
                 Err(e) => {
                     searcher.zobrist_trail.pop();

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1369,7 +1369,7 @@ impl Worker {
                 continue;
             }
 
-            // ── Recapture-only Deep QS ──
+            // ── Recapture-only Deep QS (~1 Elo) ──
             // Past `qs_recapture_ply`, captures only matter if they continue
             // the forcing exchange on the square the opponent just moved to.
             // Speculative off-square captures are what explodes in mutual-

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -356,6 +356,18 @@ search_params! {
             step:     10,
         },
 
+        /// QSearch recapture-only threshold (plies since QS entry).
+        /// Past this ply, non-evasion nodes restrict captures to the square
+        /// the opponent's last move landed on. Keeps forcing recapture
+        /// chains intact; prunes off-square captures that cause branching
+        /// to blow up in mutual-attack positions.
+        pub qs_recapture_ply: i32 {
+            default:   4,
+            min:       2,
+            max:      10,
+            step:      1,
+        },
+
         /// SEE pruning capture margin (cp/ply) — linear depth scaling.
         /// Prune noisy moves with `see < -margin · depth`. Captures have
         /// rigid material bounds, so the tolerance grows linearly with


### PR DESCRIPTION
```
Elo   | 1.01 +- 3.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.35 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 16506 W: 4877 L: 4829 D: 6800
Penta | [524, 1938, 3288, 1972, 531]
```
https://pyronomy.pythonanywhere.com/test/4135/

For example fixes explosions in this FEN: `1b2kBbK/2BbB1B1/2B2bb1/B2b4/bbb1b3/BBb2BBB/BB3b2/BB1bb2b w - - 0 1`

Bench: 4903263