### PR TITLE
Score Drop Extension

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -276,6 +276,17 @@ impl<'cfg> Searcher<'cfg> {
                 break;
             }
 
+            // ── Score Drop Extension ──
+            // A sharp drop from the previous iteration signals instability:
+            // a refutation just surfaced, or the best move changed.
+            // Stretch the soft budget so this iteration (and possibly one more)
+            // can resolve the swing before we commit. Hard cap still bounds us.
+            let sp = &self.cfg.search_params;
+            let new_score = self.root_moves[0].score;
+            if depth >= sp.score_drop_depth && new_score < self.prev_score - sp.score_drop_cp {
+                self.tm.extend_soft_limit(sp.score_drop_factor as u32);
+            }
+
             self.prev_pv = *self.root_moves[0].pv;
             self.prev_score = self.root_moves[0].score;
             self.print_info(depth, self.prev_score, &self.prev_pv);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -276,7 +276,7 @@ impl<'cfg> Searcher<'cfg> {
                 break;
             }
 
-            // ── Score Drop Extension ──
+            // ── Score Drop Extension (~27 Elo) ──
             // A sharp drop from the previous iteration signals instability:
             // a refutation just surfaced, or the best move changed.
             // Stretch the soft budget so this iteration (and possibly one more)

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -499,6 +499,33 @@ search_params! {
             step:      8,
         },
 
+        /// Score-drop extension minimum depth (plies).
+        /// Below this, aspiration-window wobble dominates the signal, so a
+        /// drop is as likely to be noise as real instability.
+        pub score_drop_depth: i32 {
+            default:   5,
+            min:       3,
+            max:      10,
+            step:      1,
+        },
+        /// Score-drop extension trigger threshold (cp).
+        /// Extend the soft time limit when this iteration's root score falls
+        /// more than this many cp below the previous iteration's score.
+        pub score_drop_cp: i32 {
+            default:  30,
+            min:      10,
+            max:      80,
+            step:      2,
+        },
+        /// Score-drop extension factor (×100 fixed-point).
+        /// 135 = stretch the soft limit by 1.35×, clamped to the hard cap.
+        pub score_drop_factor: i32 {
+            default: 135,
+            min:     110,
+            max:     200,
+            step:      5,
+        },
+
         /// Non-pawn correction history weight (fixed-point, /256 scaling).
         /// Controls how strongly each non-pawn material configuration
         /// correction contributes to the static eval adjustment.

--- a/src/engine/tm.rs
+++ b/src/engine/tm.rs
@@ -85,6 +85,19 @@ impl TimeManager {
     pub fn elapsed(&self) -> Duration {
         self.start.elapsed()
     }
+
+    /// Stretch the soft budget by `factor_num / 100`, never past the hard cap.
+    ///
+    /// Used when iterative deepening detects instability that warrants more
+    /// time on this move (e.g. the root score just dropped sharply). The hard
+    /// clamp is the invariant: soft may grow, but we still refuse to exceed
+    /// what the clock allows.
+    #[inline]
+    pub fn extend_soft_limit(&mut self, factor_num: u32) {
+        let ms = self.soft.as_millis() as u64;
+        let extended = Duration::from_millis(ms.saturating_mul(factor_num as u64) / 100);
+        self.soft = extended.min(self.hard);
+    }
 }
 
 // ──────── Private ────────


### PR DESCRIPTION
```
Elo   | 24.51 +- 9.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.47, 2.91) [0.00, 5.00]
Games | N: 2158 W: 705 L: 553 D: 900
Penta | [41, 217, 454, 283, 84]
```
https://pyronomy.pythonanywhere.com/test/4136/

```
Elo   | 27.05 +- 10.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.47, 2.91) [0.00, 5.00]
Games | N: 1660 W: 495 L: 366 D: 799
Penta | [14, 149, 412, 204, 51]
```
https://pyronomy.pythonanywhere.com/test/4137/

Bench: 4903263