### PR TITLE
Best-Move Stability TM

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -279,7 +279,7 @@ impl<'cfg> Searcher<'cfg> {
             let sp = &self.cfg.search_params;
             let new_score = self.root_moves[0].score;
 
-            // ── Best-Move Stability TM ──
+            // ── Best-Move Stability TM (~20 Elo) ──
             // Scale the soft budget by the best move's share
             // of total search effort. A large share means the search keeps
             // confirming one move — shrink the budget. A small share means

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -276,13 +276,35 @@ impl<'cfg> Searcher<'cfg> {
                 break;
             }
 
+            let sp = &self.cfg.search_params;
+            let new_score = self.root_moves[0].score;
+
+            // ── Best-Move Stability TM ──
+            // Scale the soft budget by the best move's share
+            // of total search effort. A large share means the search keeps
+            // confirming one move — shrink the budget. A small share means
+            // effort is scattered across candidates — stretch it.
+            //
+            //   percent = clamp(floor, base − scale · best_nodes / total_nodes)
+            //
+            // Gated below `bm_stab_depth` — early iterations haven't
+            // accumulated enough node signal for the ratio to be meaningful.
+            if depth >= sp.bm_stab_depth {
+                let best_nodes = self.root_moves[0].nodes;
+                let total_nodes = self.nodes.max(1);
+                let effort_discount = sp.bm_stab_scale as u64 * best_nodes / total_nodes;
+                let percent = (sp.bm_stab_base as u64)
+                    .saturating_sub(effort_discount)
+                    .max(sp.bm_stab_floor as u64);
+                self.tm.apply_stability_factor(percent as u32);
+            }
+
             // ── Score Drop Extension (~27 Elo) ──
             // A sharp drop from the previous iteration signals instability:
             // a refutation just surfaced, or the best move changed.
             // Stretch the soft budget so this iteration (and possibly one more)
-            // can resolve the swing before we commit. Hard cap still bounds us.
-            let sp = &self.cfg.search_params;
-            let new_score = self.root_moves[0].score;
+            // can resolve the swing before we commit. Applied on top of the
+            // stability factor; hard cap still bounds the result.
             if depth >= sp.score_drop_depth && new_score < self.prev_score - sp.score_drop_cp {
                 self.tm.extend_soft_limit(sp.score_drop_factor as u32);
             }
@@ -775,6 +797,10 @@ impl Worker {
                     0
                 };
 
+                // Per-root-move node accounting for best-move stability TM.
+                // Aspiration re-searches accumulate into the same slot,
+                // all that work belongs to this move.
+                let nodes_before = searcher.nodes;
                 self.search_move::<N>(
                     searcher,
                     mv,
@@ -786,6 +812,7 @@ impl Worker {
                     Some(mv) == pv_move,
                     reduction,
                 )?;
+                searcher.root_moves[i].nodes += searcher.nodes - nodes_before;
                 if likely(res.alpha >= beta) {
                     break;
                 }
@@ -1671,6 +1698,9 @@ pub struct RootMove {
     pub mv:    Move,
     pub score: i32,
     pub pv:    Box<Line>,
+    /// Cumulative subtree nodes across all ID iterations.The best move's
+    /// share of total nodes feeds the stability factor in time management.
+    pub nodes: u64,
 }
 
 impl RootMove {
@@ -1680,6 +1710,7 @@ impl RootMove {
             mv,
             score: -INF,
             pv: Box::new(Line::new()),
+            nodes: 0,
         }
     }
 }

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -526,6 +526,43 @@ search_params! {
             step:      5,
         },
 
+        /// Best-move stability minimum depth (plies).
+        /// Below this, per-move node accounting hasn't accumulated enough
+        /// signal for the ratio to be meaningful — leave the soft budget alone.
+        pub bm_stab_depth: i32 {
+            default:   5,
+            min:       3,
+            max:      10,
+            step:      1,
+        },
+        /// Best-move stability factor base term (×100 fixed-point).
+        /// Intercept of `factor = base − scale · best_nodes/total_nodes`.
+        /// Higher = more generous baseline when effort is scattered.
+        pub bm_stab_base: i32 {
+            default: 270,
+            min:     150,
+            max:     400,
+            step:      5,
+        },
+        /// Best-move stability factor slope (×100 fixed-point).
+        /// Coefficient on best/total ratio.
+        /// Higher = faster shrink as search consolidates on one move.
+        pub bm_stab_scale: i32 {
+            default: 220,
+            min:     100,
+            max:     350,
+            step:      5,
+        },
+        /// Best-move stability factor floor (×100 fixed-point).
+        /// Lower bound so an overwhelmingly confirmed best move can't shrink
+        /// the budget to near-zero and cut off mid-move.
+        pub bm_stab_floor: i32 {
+            default:  56,
+            min:      30,
+            max:      96,
+            step:      2,
+        },
+
         /// Non-pawn correction history weight (fixed-point, /256 scaling).
         /// Controls how strongly each non-pawn material configuration
         /// correction contributes to the static eval adjustment.

--- a/src/engine/tm.rs
+++ b/src/engine/tm.rs
@@ -63,7 +63,12 @@ impl TimeManager {
         params: &SearchParams,
     ) -> Self {
         let (soft, hard) = compute_budget(limits, stm, overhead, phase, params);
-        Self { start, soft, hard, base_soft: soft }
+        Self {
+            start,
+            soft,
+            hard,
+            base_soft: soft,
+        }
     }
 
     #[inline]
@@ -105,7 +110,8 @@ impl TimeManager {
 
     /// Rescale the soft budget relative to the original baseline.
     ///
-    /// `soft = min(base_soft · percent / 100, hard)`.
+    ///   `soft = min(base_soft · percent / 100, hard)`
+    ///
     /// Called once per ID iteration with a factor derived from per-root-move node effort:
     /// concentrated effort shrinks the budget, scattered effort stretches it.
     /// Anchoring on `base_soft` (not current `soft`) keeps the factor

--- a/src/engine/tm.rs
+++ b/src/engine/tm.rs
@@ -37,9 +37,14 @@ pub const TIME_HARD_CAP: f64 = 0.5;
 /// to decide when to stop iterating (`soft`) and when to bail mid-search
 /// regardless of progress (`hard`).
 pub struct TimeManager {
-    start: Instant,
-    hard:  Duration,
-    soft:  Duration,
+    start:     Instant,
+    hard:      Duration,
+    soft:      Duration,
+    /// Immutable baseline from the initial budget computation.
+    /// Dynamic scalers are always applied relative to this,
+    /// never to an already-scaled `soft` — so factors don't compound
+    /// across iterations.
+    base_soft: Duration,
 }
 
 impl TimeManager {
@@ -58,7 +63,7 @@ impl TimeManager {
         params: &SearchParams,
     ) -> Self {
         let (soft, hard) = compute_budget(limits, stm, overhead, phase, params);
-        Self { start, soft, hard }
+        Self { start, soft, hard, base_soft: soft }
     }
 
     #[inline]
@@ -86,17 +91,30 @@ impl TimeManager {
         self.start.elapsed()
     }
 
-    /// Stretch the soft budget by `factor_num / 100`, never past the hard cap.
+    /// Stretch the current soft budget by `percent / 100`, clamped to hard.
     ///
-    /// Used when iterative deepening detects instability that warrants more
-    /// time on this move (e.g. the root score just dropped sharply). The hard
-    /// clamp is the invariant: soft may grow, but we still refuse to exceed
-    /// what the clock allows.
+    /// Called when iterative deepening detects instability that warrants more
+    /// time on this move — e.g. the root score just dropped sharply. The hard
+    /// clamp is the invariant: soft may grow, but never past the clock cap.
     #[inline]
-    pub fn extend_soft_limit(&mut self, factor_num: u32) {
-        let ms = self.soft.as_millis() as u64;
-        let extended = Duration::from_millis(ms.saturating_mul(factor_num as u64) / 100);
+    pub fn extend_soft_limit(&mut self, percent: u32) {
+        let current_ms = self.soft.as_millis() as u64;
+        let extended = Duration::from_millis(current_ms.saturating_mul(percent as u64) / 100);
         self.soft = extended.min(self.hard);
+    }
+
+    /// Rescale the soft budget relative to the original baseline.
+    ///
+    /// `soft = min(base_soft · percent / 100, hard)`.
+    /// Called once per ID iteration with a factor derived from per-root-move node effort:
+    /// concentrated effort shrinks the budget, scattered effort stretches it.
+    /// Anchoring on `base_soft` (not current `soft`) keeps the factor
+    /// from compounding across iterations.
+    #[inline]
+    pub fn apply_stability_factor(&mut self, percent: u32) {
+        let base_ms = self.base_soft.as_millis() as u64;
+        let scaled = Duration::from_millis(base_ms.saturating_mul(percent as u64) / 100);
+        self.soft = scaled.min(self.hard);
     }
 }
 


### PR DESCRIPTION
```
Elo   | 13.61 +- 7.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.47, 2.91) [0.00, 5.00]
Games | N: 4162 W: 1263 L: 1100 D: 1799
Penta | [104, 459, 829, 548, 141]
```
https://pyronomy.pythonanywhere.com/test/4138/

```
Elo   | 19.94 +- 8.63 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.47, 2.91) [0.00, 5.00]
Games | N: 2372 W: 666 L: 530 D: 1176
Penta | [23, 262, 512, 334, 55]
```
https://pyronomy.pythonanywhere.com/test/4139/

Bench: 4903263