### PR TITLE
Null Move Pruning Verification Search

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -127,10 +127,14 @@ pub struct Searcher<'cfg> {
 
 #[repr(align(32))]
 pub struct Worker {
-    pub pos:         Position,
-    pub accumulator: crate::weave::Vi16x8,
-    pub stack:       Box<[Stack; MAX_PLY + 1]>,
-    pub history:     history::History,
+    pub pos:          Position,
+    pub accumulator:  crate::weave::Vi16x8,
+    pub stack:        Box<[Stack; MAX_PLY + 1]>,
+    pub history:      history::History,
+    /// Set while a null-move verification search is on the stack.
+    /// Suppresses nested NMP, which would otherwise recurse forever on
+    /// the same position at ever-shrinking depth.
+    pub is_nmp_verif: bool,
 }
 
 impl<'cfg> Searcher<'cfg> {
@@ -186,13 +190,14 @@ impl<'cfg> Searcher<'cfg> {
 
         // fresh worker initialized ONCE — prevents 123KB stack memset per iteration.
         let mut worker = Worker {
-            pos:         self.root_pos,
-            accumulator: self.root_pos.get_initial_accumulator(),
-            stack:       vec![Stack::default(); MAX_PLY + 1]
+            pos:          self.root_pos,
+            accumulator:  self.root_pos.get_initial_accumulator(),
+            stack:        vec![Stack::default(); MAX_PLY + 1]
                 .into_boxed_slice()
                 .try_into()
                 .unwrap_or_else(|_| unreachable!()),
-            history:     self.history_table.clone(),
+            history:      self.history_table.clone(),
+            is_nmp_verif: false,
         };
 
         let mut last_iter_elapsed = 0;
@@ -726,6 +731,7 @@ impl Worker {
         if !in_check
             && !N::PV
             && !self.stack[ply].is_null
+            && !self.is_nmp_verif
             && static_eval >= beta
             && self.pos.has_non_pawn_material(self.pos.stm)
         {
@@ -758,7 +764,27 @@ impl Worker {
             self.stack[ply + 1].is_null = false;
 
             if score >= beta {
-                return Ok(if score > MATE_BOUND { beta } else { score });
+                let null_score = if score > MATE_BOUND { beta } else { score };
+
+                // ── Verification Search ──
+                // Below the threshold, trust the cutoff outright — cheap and
+                // almost always correct. Above it, re-search the same position
+                // without null-move at reduced depth. If that also fails high,
+                // the cutoff is real; if it fails low, we were about to prune
+                // a zugzwang or a tactic the null search couldn't see — let
+                // the regular move loop handle it.
+                if depth <= sp.nmp_verif_min_depth {
+                    return Ok(null_score);
+                }
+
+                self.is_nmp_verif = true;
+                let verif =
+                    self.negamax::<NonPvNode>(searcher, (depth - r - 1).max(0), beta - 1, beta, ply, None);
+                self.is_nmp_verif = false;
+
+                if verif? >= beta {
+                    return Ok(null_score);
+                }
             }
         }
 

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -240,6 +240,17 @@ search_params! {
             max:       5,
             step:      1,
         },
+        /// NMP verification minimum depth (plies).
+        /// Below this, a null-move cutoff is trusted outright. At or above it,
+        /// re-search the same position (no null move) at reduced depth — if
+        /// that also fails high, the cutoff stands; otherwise fall through to
+        /// the regular move loop. Catches zugzwangs NMP would otherwise miss.
+        pub nmp_verif_min_depth: i32 {
+            default:  14,
+            min:       6,
+            max:      20,
+            step:      1,
+        },
 
         /// LMR base constant (scaled by 100).
         pub lmr_base: i32 {


### PR DESCRIPTION
```
Elo   | 0.67 +- 3.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.28 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 18096 W: 5090 L: 5055 D: 7951
Penta | [420, 2037, 4091, 2088, 412]
```
https://pyronomy.pythonanywhere.com/test/4141/

```
Elo   | 0.82 +- 3.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.28 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 16556 W: 4170 L: 4131 D: 8255
Penta | [313, 1937, 3718, 2018, 292]
```
https://pyronomy.pythonanywhere.com/test/4142/

Bench: 4903263