### PR TITLE
Draw Score Jitter Adjustment

### DIFF
--- a/src/core/defs.rs
+++ b/src/core/defs.rs
@@ -30,6 +30,20 @@ pub const MATE: i32 = 30_000;
 /// Any |score| above this threshold is a forced mate, not merely a large eval.
 pub const MATE_BOUND: i32 = MATE - 100;
 
+/// Deterministic ±8 cp jitter for draw scores, keyed by the node counter.
+///
+/// Returning exactly 0 for every draw makes the search indifferent between
+/// drawing lines — it picks whichever comes first in move order and sticks.
+/// In positions with multiple drawish paths, that can mean repeating the
+/// same sequence when a slightly-less-drawn alternative exists. A small
+/// node-keyed jitter breaks the tie without perturbing non-draw scores,
+/// so the search naturally explores alternate draw routes where the
+/// opponent has a chance to stray.
+#[inline]
+pub fn draw_score(nodes: u64) -> i32 {
+    (nodes & 0xF) as i32 - 8
+}
+
 // ──────── Adjudication thresholds ────────
 
 /// |score| < this for N plies → Draw

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -25,7 +25,7 @@ pub use crate::core::defs::Protocol;
 use crate::{
     core::{
         board::Position,
-        defs::{INF, MATE, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square},
+        defs::{INF, MATE, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square, draw_score},
         moves::Move,
     },
     engine::{
@@ -580,7 +580,7 @@ impl Worker {
         searcher.nodes += 1;
 
         if self.is_draw(ply, &searcher.zobrist_trail) {
-            return Ok(0);
+            return Ok(draw_score(searcher.nodes));
         }
 
         if ply as i32 > searcher.sel_depth {
@@ -1336,7 +1336,7 @@ impl Worker {
         searcher.nodes += 1;
 
         if self.is_draw(ply, &searcher.zobrist_trail) {
-            return Ok(0);
+            return Ok(draw_score(searcher.nodes));
         }
 
         if ply as i32 > searcher.sel_depth {


### PR DESCRIPTION
```
Elo   | 1.37 +- 3.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.75 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 22532 W: 6462 L: 6373 D: 9697
Penta | [595, 2724, 4607, 2677, 663]
```
https://pyronomy.pythonanywhere.com/test/4143/

Bench: 5022196