### PR TITLE
Eval refactor: Accumulators + Combiner + LinearTerm trait

### DIFF
--- a/src/engine/combiner.rs
+++ b/src/engine/combiner.rs
@@ -21,7 +21,13 @@
 //! Future combiners (sigmoid over king danger, winnable eg-scale) slot
 //! in by implementing [`Combiner`] without touching any term.
 
-use crate::{core::defs::TOTAL_PHASE, engine::autograd::EvalMath};
+use crate::{
+    core::defs::TOTAL_PHASE,
+    engine::{
+        autograd::EvalMath,
+        term::{BucketUpstreams, TaperPair},
+    },
+};
 
 /// Per-bucket evaluation scores, filled by the term layer prior to combination.
 /// Every field is a score contribution in the same units;
@@ -56,6 +62,12 @@ pub struct Accumulators<T: EvalMath> {
 /// king danger, quadratic pressure, eg scale factors) belong here.
 pub trait Combiner {
     fn forward<T: EvalMath<Scalar = T>>(buckets: &Accumulators<T>, phase: T) -> T;
+
+    /// Produce per-term upstream derivatives given the loss derivative
+    /// (STM sign folded in) and the game phase. Future non-linear combiners
+    /// also write gradients for their own tunable params into `grads`;
+    /// [`LinearCombiner`] has none, so `grads` is unused here.
+    fn backward(phase: f64, d_loss: f64, grads: &mut [f64]) -> BucketUpstreams;
 }
 
 /// Soul's current combiner — linear sum with a single multiplicative taper
@@ -78,5 +90,14 @@ impl Combiner for LinearCombiner {
         let safety_diff = buckets.safety_us - buckets.safety_them + buckets.xray;
         let safety_tapered = (safety_diff * phase / T::from_i32(TOTAL_PHASE)).trunc();
         buckets.mg_eg + buckets.mobility + safety_tapered
+    }
+
+    #[inline]
+    fn backward(phase: f64, d_loss: f64, _grads: &mut [f64]) -> BucketUpstreams {
+        let t_mg = phase / f64::from(TOTAL_PHASE);
+        let t_eg = 1.0 - t_mg;
+        let taper = TaperPair { d_mg: d_loss * t_mg, d_eg: d_loss * t_eg };
+        let safety_block = d_loss * t_mg;
+        BucketUpstreams { mg_eg: taper, mobility: taper, king_safety: safety_block, xray: safety_block }
     }
 }

--- a/src/engine/combiner.rs
+++ b/src/engine/combiner.rs
@@ -79,7 +79,7 @@ pub trait Combiner {
 /// Soul's current combiner — linear sum with a single multiplicative taper
 /// over the king-safety block.
 ///
-/// ```rust
+/// ```text
 /// final = mg_eg
 ///       + mobility
 ///       + trunc((safety_us − safety_them + xray) · phase / TOTAL_PHASE)

--- a/src/engine/combiner.rs
+++ b/src/engine/combiner.rs
@@ -31,20 +31,16 @@ pub struct Accumulators<T: EvalMath> {
     /// Tapered material + PSQT score, read straight from the SIMD accumulator.
     /// Pre-tapered because the accumulator owns the mg/eg blend via `EvalMath::tapered`.
     pub mg_eg: T,
-
     /// Tapered mobility differential.
     /// Pre-tapered because the openness interpolation and phase blend both happen inside
     /// `madd`-packed i16 SIMD lanes — extracting them into the combiner would lose the vectorization.
     pub mobility: T,
-
     /// Raw king-safety score from "us"'s perspective, untapered.
     /// Combiner applies `phase / TOTAL_PHASE` to the `us - them + xray`
     /// differential so the whole king-safety block shares one taper.
     pub safety_us: T,
-
     /// Raw king-safety score from "them"'s perspective, untapered.
     pub safety_them: T,
-
     /// X-ray king-ring differential, untapered.
     /// Sits in the same taper block as `safety_us`/`safety_them`.
     /// Separate bucket because its feature (orthogonal x-ray count)

--- a/src/engine/combiner.rs
+++ b/src/engine/combiner.rs
@@ -41,6 +41,12 @@ pub struct Accumulators<T: EvalMath> {
     /// Pre-tapered because the openness interpolation and phase blend both happen inside
     /// `madd`-packed i16 SIMD lanes — extracting them into the combiner would lose the vectorization.
     pub mobility: T,
+    /// Shared pre-tapered bucket for simple linear bonuses.
+    /// Each such term `+=` its own `mg · phase + eg · eg_phase` contribution;
+    /// scatter writes that term's own param slots.
+    /// Lets new tapered bonuses land as one-line `register_terms!`
+    /// additions rather than bucket expansions.
+    pub bonus: T,
     /// Raw king-safety score from "us"'s perspective, untapered.
     /// Combiner applies `phase / TOTAL_PHASE` to the `us - them + xray`
     /// differential so the whole king-safety block shares one taper.
@@ -89,7 +95,7 @@ impl Combiner for LinearCombiner {
     fn forward<T: EvalMath<Scalar = T>>(buckets: &Accumulators<T>, phase: T) -> T {
         let safety_diff = buckets.safety_us - buckets.safety_them + buckets.xray;
         let safety_tapered = (safety_diff * phase / T::from_i32(TOTAL_PHASE)).trunc();
-        buckets.mg_eg + buckets.mobility + safety_tapered
+        buckets.mg_eg + buckets.mobility + buckets.bonus + safety_tapered
     }
 
     #[inline]
@@ -98,6 +104,6 @@ impl Combiner for LinearCombiner {
         let t_eg = 1.0 - t_mg;
         let taper = TaperPair { d_mg: d_loss * t_mg, d_eg: d_loss * t_eg };
         let safety_block = d_loss * t_mg;
-        BucketUpstreams { mg_eg: taper, mobility: taper, king_safety: safety_block, xray: safety_block }
+        BucketUpstreams { mg_eg: taper, mobility: taper, bonus: taper, king_safety: safety_block, xray: safety_block }
     }
 }

--- a/src/engine/combiner.rs
+++ b/src/engine/combiner.rs
@@ -1,0 +1,86 @@
+//! Score combination layer.
+//!
+//! # Architecture
+//!
+//! Evaluation runs in two stages:
+//!
+//! 1. Terms produce per-bucket scores, written into [`Accumulators`].
+//!    Each term reads `SharedFeatures` and writes one or more bucket fields.
+//! 2. Combiner reads the filled accumulators and produces the final
+//!    single-scalar evaluation. All non-linearities beyond the per-term
+//!    internal shape (mobility's openness/phase blend, king safety's
+//!    attacker-pressure curve) live here.
+//!
+//! Splitting these stages is what lets the tuner propagate a single
+//! upstream derivative per bucket through each term's scatter, rather
+//! than baking the combiner shape into every term.
+//!
+//! Soul's current combiner ([`LinearCombiner`]) is linear in the tunable
+//! parameters; the only operation beyond summation is a multiplicative
+//! taper that folds the raw king-safety block into the phase blend.
+//! Future combiners (sigmoid over king danger, winnable eg-scale) slot
+//! in by implementing [`Combiner`] without touching any term.
+
+use crate::{core::defs::TOTAL_PHASE, engine::autograd::EvalMath};
+
+/// Per-bucket evaluation scores, filled by the term layer prior to combination.
+/// Every field is a score contribution in the same units;
+/// either pre-tapered (mg_eg, mobility)
+/// or raw awaiting combiner taper (safety_us, safety_them, xray).
+pub struct Accumulators<T: EvalMath> {
+    /// Tapered material + PSQT score, read straight from the SIMD accumulator.
+    /// Pre-tapered because the accumulator owns the mg/eg blend via `EvalMath::tapered`.
+    pub mg_eg: T,
+
+    /// Tapered mobility differential.
+    /// Pre-tapered because the openness interpolation and phase blend both happen inside
+    /// `madd`-packed i16 SIMD lanes — extracting them into the combiner would lose the vectorization.
+    pub mobility: T,
+
+    /// Raw king-safety score from "us"'s perspective, untapered.
+    /// Combiner applies `phase / TOTAL_PHASE` to the `us - them + xray`
+    /// differential so the whole king-safety block shares one taper.
+    pub safety_us: T,
+
+    /// Raw king-safety score from "them"'s perspective, untapered.
+    pub safety_them: T,
+
+    /// X-ray king-ring differential, untapered.
+    /// Sits in the same taper block as `safety_us`/`safety_them`.
+    /// Separate bucket because its feature (orthogonal x-ray count)
+    /// is unrelated to the safety metrics, so future terms can route
+    /// elsewhere without disturbing the safety path.
+    pub xray: T,
+}
+
+/// Strategy for collapsing [`Accumulators`] into a final evaluation scalar.
+///
+/// A combiner consumes only bucket values and combiner-owned params; it
+/// never reads raw features. Non-linearities over bucket values (sigmoid
+/// king danger, quadratic pressure, eg scale factors) belong here.
+pub trait Combiner {
+    fn forward<T: EvalMath<Scalar = T>>(buckets: &Accumulators<T>, phase: T) -> T;
+}
+
+/// Soul's current combiner — linear sum with a single multiplicative taper
+/// over the king-safety block.
+///
+/// ```rust
+/// final = mg_eg
+///       + mobility
+///       + trunc((safety_us − safety_them + xray) · phase / TOTAL_PHASE)
+/// ```
+///
+/// "Linear" refers to parameter dependence; phase is position-derived
+/// non-tunable data, so `safety_tapered` is a fixed fraction of a
+/// parameter-linear sum.
+pub struct LinearCombiner;
+
+impl Combiner for LinearCombiner {
+    #[inline(always)]
+    fn forward<T: EvalMath<Scalar = T>>(buckets: &Accumulators<T>, phase: T) -> T {
+        let safety_diff = buckets.safety_us - buckets.safety_them + buckets.xray;
+        let safety_tapered = (safety_diff * phase / T::from_i32(TOTAL_PHASE)).trunc();
+        buckets.mg_eg + buckets.mobility + safety_tapered
+    }
+}

--- a/src/engine/eval.rs
+++ b/src/engine/eval.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     engine::{
         autograd::EvalMath,
+        combiner::{Accumulators, Combiner, LinearCombiner},
         mobility::{Mobility, MobilityData},
         search_params::SearchParams,
     },
@@ -120,29 +121,15 @@ pub struct DetailedEval {
 pub fn detailed_eval(board: &Position, acc: &Vi16x8) -> DetailedEval {
     let phase = extract_phase(acc);
     let params = EvalParams::<i32>::from_const();
-
-    let psqt = i32::tapered(acc, phase);
-
     let features = SharedFeatures::compute(board);
 
-    let w_atk_us = params.atk_weights[features.data.safety_us.attackers.min(5)];
-    let w_atk_them = params.atk_weights[features.data.safety_them.attackers.min(5)];
+    let buckets = fill_accumulators::<i32>(acc, phase, &features, &params);
 
-    let s_us_score = features.data.safety_us.score(params.w_shield, params.w_ortho, params.w_diag, w_atk_us);
-    let s_them_score = features
-        .data
-        .safety_them
-        .score(params.w_shield, params.w_ortho, params.w_diag, w_atk_them);
+    let psqt = buckets.mg_eg;
+    let mobility = buckets.mobility;
+    let total = LinearCombiner::forward(&buckets, phase);
+    let safety = total - psqt - mobility;
 
-    let xray_diff = params.w_xray_ortho * features.xray_ortho;
-    let safety = (s_us_score - s_them_score + xray_diff) * phase / crate::core::defs::TOTAL_PHASE;
-
-    let mobility = Mobility::evaluate_score_diff::<i32>(
-        &features.data.metrics_us, &features.data.metrics_them, features.openness, phase, params.mg_mob_open, params.mg_mob_closed,
-        params.eg_mob_open, params.eg_mob_closed,
-    );
-
-    let total = psqt + safety + mobility;
     let (p, m, s, t) =
         if board.stm == Color::White { (psqt, mobility, safety, total) } else { (-psqt, -mobility, -safety, -total) };
 
@@ -204,31 +191,42 @@ pub fn scatter_xray_grad(xray_ortho: i32, d_safety: f64, grads: &mut [f64]) {
 /// The single source of truth for evaluation math.
 /// Generic over `EvalMath` to support both `i32` search and `DualNode` tuning.
 #[inline(always)]
-pub fn compute_macro_eval<T: EvalMath<Scalar = T>>(acc: &T::Vec8, phase: T, features: &SharedFeatures, params: &EvalParams<T>) -> T {
-    let mut score = T::tapered(acc, phase);
+pub fn compute_macro_eval<T: EvalMath<Scalar = T>>(
+    acc: &T::Vec8,
+    phase: T,
+    features: &SharedFeatures,
+    params: &EvalParams<T>,
+) -> T {
+    let buckets = fill_accumulators::<T>(acc, phase, features, params);
+    LinearCombiner::forward(&buckets, phase)
+}
 
+/// Run every term against the shared features, producing a filled
+/// [`Accumulators`]. Isolated so both `compute_macro_eval` and
+/// `detailed_eval` produce identical bucket values from one code path.
+#[inline]
+fn fill_accumulators<T: EvalMath<Scalar = T>>(
+    acc: &T::Vec8,
+    phase: T,
+    features: &SharedFeatures,
+    params: &EvalParams<T>,
+) -> Accumulators<T> {
     let w_atk_us = params.atk_weights[features.data.safety_us.attackers.min(5)];
     let w_atk_them = params.atk_weights[features.data.safety_them.attackers.min(5)];
 
-    let s_us_score = features.data.safety_us.score(params.w_shield, params.w_ortho, params.w_diag, w_atk_us);
-    let s_them_score = features
-        .data
-        .safety_them
-        .score(params.w_shield, params.w_ortho, params.w_diag, w_atk_them);
-
-    let xray_diff = params.w_xray_ortho * T::from_i32(features.xray_ortho);
-
-    // Tapered king safety: only applies heavily in the middlegame
-    // Combines direct king safety and x-ray attacks into the ring.
-    let safety_diff = s_us_score - s_them_score + xray_diff;
-    score += ((safety_diff * phase) / T::from_i32(crate::core::defs::TOTAL_PHASE)).trunc();
-
-    score += Mobility::evaluate_score_diff::<T>(
-        &features.data.metrics_us, &features.data.metrics_them, features.openness, phase, params.mg_mob_open, params.mg_mob_closed,
-        params.eg_mob_open, params.eg_mob_closed,
-    );
-
-    score
+    Accumulators::<T> {
+        mg_eg: T::tapered(acc, phase),
+        mobility: Mobility::evaluate_score_diff::<T>(
+            &features.data.metrics_us, &features.data.metrics_them, features.openness, phase, params.mg_mob_open,
+            params.mg_mob_closed, params.eg_mob_open, params.eg_mob_closed,
+        ),
+        safety_us: features.data.safety_us.score(params.w_shield, params.w_ortho, params.w_diag, w_atk_us),
+        safety_them: features
+            .data
+            .safety_them
+            .score(params.w_shield, params.w_ortho, params.w_diag, w_atk_them),
+        xray: params.w_xray_ortho * T::from_i32(features.xray_ortho),
+    }
 }
 
 // ──────── Parameters & Utilities ────────

--- a/src/engine/eval.rs
+++ b/src/engine/eval.rs
@@ -76,10 +76,15 @@ pub fn lazy_eval_margin(board: &Position, phase: i32, params: &SearchParams) -> 
 ///
 /// WARNING: Autograd Linearity Booby Trap
 /// If you introduce any non-linear math (e.g. `feature * feature * weight` or `max(feature, 0)`)
-/// to the evaluation parameters, `eval_linear_grad` in `tuner/src/evaltune/tape.rs` will silently compute
-/// mathematically invalid gradients because it assumes perfect parameter linearity (`y = w * x`).
-/// Any non-linear eval updates require a manual calculus derivation update in `tape.rs`.
-/// If you aren't sure, use `DualNode` oracle mode to verify structural gradients.
+/// to the evaluation parameters, the per-term `scatter_*_grad` functions
+/// (co-located with each term — `mobility::scatter_mobility_grad`,
+/// `mobility::scatter_king_safety_grad`, `scatter_xray_grad`) will silently
+/// compute mathematically invalid gradients because each assumes perfect
+/// parameter linearity (`y = w · x`). Any non-linear eval update requires
+/// a matching manual calculus derivation in the affected term's scatter.
+/// If you aren't sure, run the `test_linear_oracle_verification` test in
+/// `tuner/src/evaltune/tape.rs` — it compares against the dual-number forward
+/// pass and fails loudly on any drift.
 ///
 /// Non-PSQT weights come from `params` rather than const arrays,
 /// so the autograd tape can track them.
@@ -89,30 +94,13 @@ pub fn evaluate_generic<T: EvalMath<Scalar = T>>(
     acc: &T::Vec8,
     phase: T,
     params: &EvalParams<T>,
-    features: Option<&MacroFeatures>,
+    features: Option<&SharedFeatures>,
 ) -> T {
     let features_store;
     let features = if let Some(f) = features {
         f
     } else {
-        use crate::core::board::spatial::SpatialTensor;
-
-        let pinned_w = board.pinned_pieces(Color::White);
-        let pinned_b = board.pinned_pieces(Color::Black);
-        let tensor = SpatialTensor::compute(board, pinned_w.0, pinned_b.0);
-
-        let data = Mobility::compute_all(board, Color::White, &tensor, pinned_w, pinned_b);
-        let openness = Mobility::compute_openness(board);
-
-        let w_ksq = board.pieces(PieceType::King, Color::White).lsb();
-        let b_ksq = board.pieces(PieceType::King, Color::Black).lsb();
-        let w_king_ring = crate::core::board::bitboard::atk_king(w_ksq).0;
-        let b_king_ring = crate::core::board::bitboard::atk_king(b_ksq).0;
-
-        let xray_ortho =
-            (tensor.w_ortho_xray() & b_king_ring).count_ones() as i32 - (tensor.b_ortho_xray() & w_king_ring).count_ones() as i32;
-
-        features_store = MacroFeatures { openness, data, xray_ortho };
+        features_store = SharedFeatures::compute(board);
         &features_store
     };
 
@@ -130,29 +118,12 @@ pub struct DetailedEval {
 
 /// A version of evaluate that returns individual components for debugging and visualization.
 pub fn detailed_eval(board: &Position, acc: &Vi16x8) -> DetailedEval {
-    use crate::core::board::spatial::SpatialTensor;
-
     let phase = extract_phase(acc);
     let params = EvalParams::<i32>::from_const();
 
     let psqt = i32::tapered(acc, phase);
 
-    let pinned_w = board.pinned_pieces(Color::White);
-    let pinned_b = board.pinned_pieces(Color::Black);
-    let tensor = SpatialTensor::compute(board, pinned_w.0, pinned_b.0);
-
-    let data = Mobility::compute_all(board, Color::White, &tensor, pinned_w, pinned_b);
-    let openness = Mobility::compute_openness(board);
-
-    let w_ksq = board.pieces(PieceType::King, Color::White).lsb();
-    let b_ksq = board.pieces(PieceType::King, Color::Black).lsb();
-    let w_king_ring = crate::core::board::bitboard::atk_king(w_ksq).0;
-    let b_king_ring = crate::core::board::bitboard::atk_king(b_ksq).0;
-
-    let xray_ortho_raw =
-        (tensor.w_ortho_xray() & b_king_ring).count_ones() as i32 - (tensor.b_ortho_xray() & w_king_ring).count_ones() as i32;
-
-    let features = MacroFeatures { openness, data, xray_ortho: xray_ortho_raw };
+    let features = SharedFeatures::compute(board);
 
     let w_atk_us = params.atk_weights[features.data.safety_us.attackers.min(5)];
     let w_atk_them = params.atk_weights[features.data.safety_them.attackers.min(5)];
@@ -178,18 +149,62 @@ pub fn detailed_eval(board: &Position, acc: &Vi16x8) -> DetailedEval {
     DetailedEval { psqt: p, mobility: m, safety: s, total: t }
 }
 
-/// Macroscopic features extracted from the position.
-/// Used to bridge the engine's search eval and the tuner's gradient extraction.
-pub struct MacroFeatures {
+/// Macroscopic features extracted once per position.
+///
+/// Single feature-extraction boundary: computed once, consumed by both
+/// the engine's score pass (`compute_macro_eval`) and the tuner's gradient
+/// scatter functions (`mobility::scatter_*`, `scatter_xray_grad`). Adding
+/// a new eval term that depends on fresh board state should extend this
+/// struct, not duplicate extraction.
+pub struct SharedFeatures {
     pub openness: i32,
     pub data: MobilityData,
     pub xray_ortho: i32,
 }
 
+impl SharedFeatures {
+    /// Single-pass extraction: spatial tensor, mobility/safety metrics, openness,
+    /// king-ring x-ray differential. Mirrors what both the engine and the tuner
+    /// need, so neither side recomputes.
+    #[inline]
+    pub fn compute(board: &Position) -> Self {
+        use crate::core::board::spatial::SpatialTensor;
+
+        let pinned_w = board.pinned_pieces(Color::White);
+        let pinned_b = board.pinned_pieces(Color::Black);
+        let tensor = SpatialTensor::compute(board, pinned_w.0, pinned_b.0);
+
+        let data = Mobility::compute_all(board, Color::White, &tensor, pinned_w, pinned_b);
+        let openness = Mobility::compute_openness(board);
+
+        let w_ksq = board.pieces(PieceType::King, Color::White).lsb();
+        let b_ksq = board.pieces(PieceType::King, Color::Black).lsb();
+        let w_king_ring = crate::core::board::bitboard::atk_king(w_ksq).0;
+        let b_king_ring = crate::core::board::bitboard::atk_king(b_ksq).0;
+
+        let xray_ortho =
+            (tensor.w_ortho_xray() & b_king_ring).count_ones() as i32 - (tensor.b_ortho_xray() & w_king_ring).count_ones() as i32;
+
+        Self { openness, data, xray_ortho }
+    }
+}
+
+/// Scatter the x-ray linear-parameter gradient.
+///
+/// Contract: `d_safety = outer · t_mg` (x-ray is tapered MG-only, same
+/// cadence as king safety). `outer` already folds in STM sign + loss derivative.
+///
+/// Co-located with the x-ray scoring term so the score formula and its
+/// gradient live next to one another. Any future change to the x-ray
+/// contribution updates both here.
+pub fn scatter_xray_grad(xray_ortho: i32, d_safety: f64, grads: &mut [f64]) {
+    grads[crate::core::psqt::LAYOUT.xray_offset] += d_safety * xray_ortho as f64;
+}
+
 /// The single source of truth for evaluation math.
 /// Generic over `EvalMath` to support both `i32` search and `DualNode` tuning.
 #[inline(always)]
-pub fn compute_macro_eval<T: EvalMath<Scalar = T>>(acc: &T::Vec8, phase: T, features: &MacroFeatures, params: &EvalParams<T>) -> T {
+pub fn compute_macro_eval<T: EvalMath<Scalar = T>>(acc: &T::Vec8, phase: T, features: &SharedFeatures, params: &EvalParams<T>) -> T {
     let mut score = T::tapered(acc, phase);
 
     let w_atk_us = params.atk_weights[features.data.safety_us.attackers.min(5)];

--- a/src/engine/eval.rs
+++ b/src/engine/eval.rs
@@ -77,15 +77,15 @@ pub fn lazy_eval_margin(board: &Position, phase: i32, params: &SearchParams) -> 
 ///
 /// WARNING: Autograd Linearity Booby Trap
 /// If you introduce any non-linear math (e.g. `feature * feature * weight` or `max(feature, 0)`)
-/// to the evaluation parameters, the per-term `scatter_*_grad` functions
-/// (co-located with each term — `mobility::scatter_mobility_grad`,
-/// `mobility::scatter_king_safety_grad`, `scatter_xray_grad`) will silently
-/// compute mathematically invalid gradients because each assumes perfect
-/// parameter linearity (`y = w · x`). Any non-linear eval update requires
-/// a matching manual calculus derivation in the affected term's scatter.
-/// If you aren't sure, run the `test_linear_oracle_verification` test in
+/// to the evaluation parameters, the affected [`crate::engine::term::LinearTerm::scatter`]
+/// impl will silently compute mathematically invalid gradients because
+/// [`LinearTerm`] assumes perfect parameter linearity (`y = w · x`).
+/// Non-linear shapes belong in the [`crate::engine::combiner::Combiner`] layer
+/// or soon a future `NonlinearTerm`.
+///
+/// If you aren't sure, just run the `test_linear_oracle_verification` test in
 /// `tuner/src/evaltune/tape.rs` — it compares against the dual-number forward
-/// pass and fails loudly on any drift.
+/// pass and fails on any drift.
 ///
 /// Non-PSQT weights come from `params` rather than const arrays,
 /// so the autograd tape can track them.
@@ -139,10 +139,10 @@ pub fn detailed_eval(board: &Position, acc: &Vi16x8) -> DetailedEval {
 /// Macroscopic features extracted once per position.
 ///
 /// Single feature-extraction boundary: computed once, consumed by both
-/// the engine's score pass (`compute_macro_eval`) and the tuner's gradient
-/// scatter functions (`mobility::scatter_*`, `scatter_xray_grad`). Adding
-/// a new eval term that depends on fresh board state should extend this
-/// struct, not duplicate extraction.
+/// the engine's score pass (`compute_macro_eval`) and every registered
+/// [`crate::engine::term::LinearTerm::scatter`] in the tuner's backward
+/// pass. Adding a new eval term that depends on fresh board state should
+/// extend this struct, not duplicate extraction.
 pub struct SharedFeatures {
     pub openness: i32,
     pub data: MobilityData,
@@ -176,16 +176,30 @@ impl SharedFeatures {
     }
 }
 
-/// Scatter the x-ray linear-parameter gradient.
-///
-/// Contract: `d_safety = outer · t_mg` (x-ray is tapered MG-only, same
-/// cadence as king safety). `outer` already folds in STM sign + loss derivative.
-///
-/// Co-located with the x-ray scoring term so the score formula and its
-/// gradient live next to one another. Any future change to the x-ray
-/// contribution updates both here.
-pub fn scatter_xray_grad(xray_ortho: i32, d_safety: f64, grads: &mut [f64]) {
-    grads[crate::core::psqt::LAYOUT.xray_offset] += d_safety * xray_ortho as f64;
+/// X-ray king-ring differential: `w_xray_ortho · xray_ortho`. Writes
+/// `acc.xray`; shares the king-safety block's scalar upstream.
+pub struct XrayTerm;
+
+impl crate::engine::term::LinearTerm for XrayTerm {
+    /// Scalar upstream — x-ray is tapered MG-only inside the combiner's
+    /// king-safety block, same cadence as king safety.
+    type Upstream = f64;
+
+    #[inline(always)]
+    fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, _phase: T, acc: &mut Accumulators<T>) {
+        acc.xray = params.w_xray_ortho * T::from_i32(features.xray_ortho);
+    }
+
+    #[inline]
+    fn scatter(features: &SharedFeatures, upstream: f64, grads: &mut [f64]) {
+        grads[crate::core::psqt::LAYOUT.xray_offset] += upstream * features.xray_ortho as f64;
+    }
+}
+
+crate::register_terms! {
+    crate::engine::mobility::MobilityTerm => mobility,
+    crate::engine::mobility::KingSafetyTerm => king_safety,
+    XrayTerm => xray,
 }
 
 /// The single source of truth for evaluation math.
@@ -201,8 +215,10 @@ pub fn compute_macro_eval<T: EvalMath<Scalar = T>>(
     LinearCombiner::forward(&buckets, phase)
 }
 
-/// Run every term against the shared features, producing a filled
-/// [`Accumulators`]. Isolated so both `compute_macro_eval` and
+/// Build the per-bucket accumulator by initializing the PSQT-level
+/// `mg_eg` bucket from the SIMD accumulator, zeroing the rest, and letting
+/// every registered [`LinearTerm`] populate its owned bucket(s) via
+/// [`apply_all_terms`]. Isolated so both `compute_macro_eval` and
 /// `detailed_eval` produce identical bucket values from one code path.
 #[inline]
 fn fill_accumulators<T: EvalMath<Scalar = T>>(
@@ -211,22 +227,15 @@ fn fill_accumulators<T: EvalMath<Scalar = T>>(
     features: &SharedFeatures,
     params: &EvalParams<T>,
 ) -> Accumulators<T> {
-    let w_atk_us = params.atk_weights[features.data.safety_us.attackers.min(5)];
-    let w_atk_them = params.atk_weights[features.data.safety_them.attackers.min(5)];
-
-    Accumulators::<T> {
+    let mut buckets = Accumulators::<T> {
         mg_eg: T::tapered(acc, phase),
-        mobility: Mobility::evaluate_score_diff::<T>(
-            &features.data.metrics_us, &features.data.metrics_them, features.openness, phase, params.mg_mob_open,
-            params.mg_mob_closed, params.eg_mob_open, params.eg_mob_closed,
-        ),
-        safety_us: features.data.safety_us.score(params.w_shield, params.w_ortho, params.w_diag, w_atk_us),
-        safety_them: features
-            .data
-            .safety_them
-            .score(params.w_shield, params.w_ortho, params.w_diag, w_atk_them),
-        xray: params.w_xray_ortho * T::from_i32(features.xray_ortho),
-    }
+        mobility: T::zero(),
+        safety_us: T::zero(),
+        safety_them: T::zero(),
+        xray: T::zero(),
+    };
+    apply_all_terms::<T>(features, params, phase, &mut buckets);
+    buckets
 }
 
 // ──────── Parameters & Utilities ────────

--- a/src/engine/eval.rs
+++ b/src/engine/eval.rs
@@ -113,6 +113,7 @@ pub fn evaluate_generic<T: EvalMath<Scalar = T>>(
 pub struct DetailedEval {
     pub psqt: i32,
     pub mobility: i32,
+    pub bonus: i32,
     pub safety: i32,
     pub total: i32,
 }
@@ -127,13 +128,17 @@ pub fn detailed_eval(board: &Position, acc: &Vi16x8) -> DetailedEval {
 
     let psqt = buckets.mg_eg;
     let mobility = buckets.mobility;
+    let bonus = buckets.bonus;
     let total = LinearCombiner::forward(&buckets, phase);
-    let safety = total - psqt - mobility;
+    let safety = total - psqt - mobility - bonus;
 
-    let (p, m, s, t) =
-        if board.stm == Color::White { (psqt, mobility, safety, total) } else { (-psqt, -mobility, -safety, -total) };
+    let (p, m, b, s, t) = if board.stm == Color::White {
+        (psqt, mobility, bonus, safety, total)
+    } else {
+        (-psqt, -mobility, -bonus, -safety, -total)
+    };
 
-    DetailedEval { psqt: p, mobility: m, safety: s, total: t }
+    DetailedEval { psqt: p, mobility: m, bonus: b, safety: s, total: t }
 }
 
 /// Macroscopic features extracted once per position.
@@ -230,6 +235,7 @@ fn fill_accumulators<T: EvalMath<Scalar = T>>(
     let mut buckets = Accumulators::<T> {
         mg_eg: T::tapered(acc, phase),
         mobility: T::zero(),
+        bonus: T::zero(),
         safety_us: T::zero(),
         safety_them: T::zero(),
         xray: T::zero(),

--- a/src/engine/mobility.rs
+++ b/src/engine/mobility.rs
@@ -226,13 +226,7 @@ pub fn scatter_mobility_grad(
 /// (opposite sign for `idx_them`). When both sides share an attacker index,
 /// contributions sum.
 #[inline]
-pub fn scatter_king_safety_grad(
-    safety_us: &SafetyMetrics,
-    safety_them: &SafetyMetrics,
-    d: f64,
-    t_mg: f64,
-    grads: &mut [f64],
-) {
+pub fn scatter_king_safety_grad(safety_us: &SafetyMetrics, safety_them: &SafetyMetrics, d: f64, t_mg: f64, grads: &mut [f64]) {
     use crate::core::psqt::LAYOUT;
 
     let ks = LAYOUT.king_safety_offset;

--- a/src/engine/mobility.rs
+++ b/src/engine/mobility.rs
@@ -14,7 +14,13 @@ use crate::{
         },
         defs::{Bitboard, Color, PieceType, Square, TOTAL_PHASE},
     },
-    engine::eval_params::ATTACKER_WEIGHTS,
+    engine::{
+        autograd::EvalMath,
+        combiner::Accumulators,
+        eval::{EvalParams, SharedFeatures},
+        eval_params::ATTACKER_WEIGHTS,
+        term::{LinearTerm, TaperPair},
+    },
 };
 
 // ──────── Position Openness ────────
@@ -134,126 +140,148 @@ pub fn compute_openness_raw(us_pawns: u64, them_pawns: u64) -> i32 {
         .clamp(0, OPEN_UNITY)
 }
 
-// ──────── Tuner Gradient Scatter ────────
+// ──────── Eval Terms ────────
 //
-// Per-term, linear-parameter gradient scatter. Each function lives next to
-// its score counterpart so the formula and its derivative stay together —
-// edit one, edit the other, no cross-file hunting.
-//
-// Contract for every `scatter_*_grad`:
-// - `d`  = outer loss derivative folded with STM sign (`2·err·sig·(1−sig)·k · stm_sign`).
-// - `t_mg`, `t_eg` = tapered-phase fractions (`phase/24`, `(24−phase)/24`).
-// - The function writes `d · ∂score_white/∂param` into `grads` at each param's
-//   LAYOUT offset. PSQT/material stay out of band (handled in the tuner tape).
+// Each term owns its forward (`apply`) and backward (`scatter`) math;
+// co-located so the score formula and its derivative stay in lockstep.
+// Edit one, edit the other; no cross-file hunting.
 
-/// Scatter gradients for the four mobility weight vectors
-/// (MG/EG × open/closed, 4 lanes each = 16 params).
-///
-/// # Derivation
-///
-/// `evaluate_score_diff` interpolates open/closed weight vectors by `openness`,
-/// then tapers MG↔EG. For lane `j`:
-///
-///   `∂score/∂mg_mob_open[j]    = t_mg · diff[j] · (openness / 1024)`
-///   `∂score/∂mg_mob_closed[j]  = t_mg · diff[j] · (closedness / 1024)`
-///
-/// same pattern for EG weights with `t_eg`. Scatter multiplies by `d`.
-#[inline]
-pub fn scatter_mobility_grad(
-    metrics_us: &SideMetrics,
-    metrics_them: &SideMetrics,
-    openness: i32,
-    d: f64,
-    t_mg: f64,
-    t_eg: f64,
-    grads: &mut [f64],
-) {
-    use crate::{core::psqt::LAYOUT, weave::Vf64x4};
+/// Mobility differential: safe squares · open/closed · MG/EG · 4 lanes.
+/// Writes `acc.mobility`; `scatter` walks the mobility slots.
+pub struct MobilityTerm;
 
-    let lo = LAYOUT.mobility_open_offset;
-    let lc = LAYOUT.mobility_closed_offset;
+impl LinearTerm for MobilityTerm {
+    type Upstream = TaperPair;
 
-    let o_frac = openness as f64 / f64::from(OPEN_UNITY);
-    let c_frac = (OPEN_UNITY - openness) as f64 / f64::from(OPEN_UNITY);
+    #[inline(always)]
+    fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, phase: T, acc: &mut Accumulators<T>) {
+        acc.mobility = Mobility::evaluate_score_diff::<T>(
+            &features.data.metrics_us, &features.data.metrics_them, features.openness, phase, params.mg_mob_open,
+            params.mg_mob_closed, params.eg_mob_open, params.eg_mob_closed,
+        );
+    }
 
-    let diff = [
-        (metrics_us.mobility - metrics_them.mobility) as f64,
-        (metrics_us.shadow_mobility - metrics_them.shadow_mobility) as f64,
-        (metrics_us.threats - metrics_them.threats) as f64,
-        (metrics_us.shadow_threats - metrics_them.shadow_threats) as f64,
-    ];
+    /// # Derivation
+    ///
+    /// `evaluate_score_diff` interpolates open/closed weight vectors by
+    /// `openness`, then tapers MG↔EG. For lane `j`:
+    ///
+    ///   `∂score/∂mg_mob_open[j]    = d_mg · diff[j] · (openness / 1024)`
+    ///   `∂score/∂mg_mob_closed[j]  = d_mg · diff[j] · (closedness / 1024)`
+    ///
+    /// Same pattern for EG weights with `d_eg`. The combiner pre-multiplies
+    /// `d_mg = d · t_mg` and `d_eg = d · t_eg` so scatter skips the reshape.
+    #[inline]
+    fn scatter(features: &SharedFeatures, upstream: TaperPair, grads: &mut [f64]) {
+        use crate::{core::psqt::LAYOUT, weave::Vf64x4};
 
-    let v_diff = Vf64x4::from(diff);
-    let v_d_om = Vf64x4::splat(d * t_mg * o_frac);
-    let v_d_oe = Vf64x4::splat(d * t_eg * o_frac);
-    let v_d_cm = Vf64x4::splat(d * t_mg * c_frac);
-    let v_d_ce = Vf64x4::splat(d * t_eg * c_frac);
+        let lo = LAYOUT.mobility_open_offset;
+        let lc = LAYOUT.mobility_closed_offset;
 
-    // SAFETY: LAYOUT offsets place all four 4-wide mobility blocks (lo, lo+4,
-    // lc, lc+4) contiguously within the tunable region. Caller guarantees
-    // `grads.len() >= LAYOUT.xray_offset + 1` (asserted in the tape), which
-    // covers this range.
-    unsafe {
-        let p_lo_m = grads.as_mut_ptr().add(lo);
-        let p_lo_e = grads.as_mut_ptr().add(lo + 4);
-        let p_lc_m = grads.as_mut_ptr().add(lc);
-        let p_lc_e = grads.as_mut_ptr().add(lc + 4);
+        let o_frac = features.openness as f64 / f64::from(OPEN_UNITY);
+        let c_frac = (OPEN_UNITY - features.openness) as f64 / f64::from(OPEN_UNITY);
 
-        (Vf64x4::loadu(p_lo_m) + v_diff * v_d_om).storeu(p_lo_m);
-        (Vf64x4::loadu(p_lo_e) + v_diff * v_d_oe).storeu(p_lo_e);
-        (Vf64x4::loadu(p_lc_m) + v_diff * v_d_cm).storeu(p_lc_m);
-        (Vf64x4::loadu(p_lc_e) + v_diff * v_d_ce).storeu(p_lc_e);
+        let metrics_us = &features.data.metrics_us;
+        let metrics_them = &features.data.metrics_them;
+        let diff = [
+            (metrics_us.mobility - metrics_them.mobility) as f64,
+            (metrics_us.shadow_mobility - metrics_them.shadow_mobility) as f64,
+            (metrics_us.threats - metrics_them.threats) as f64,
+            (metrics_us.shadow_threats - metrics_them.shadow_threats) as f64,
+        ];
+
+        let v_diff = Vf64x4::from(diff);
+        let v_d_om = Vf64x4::splat(upstream.d_mg * o_frac);
+        let v_d_oe = Vf64x4::splat(upstream.d_eg * o_frac);
+        let v_d_cm = Vf64x4::splat(upstream.d_mg * c_frac);
+        let v_d_ce = Vf64x4::splat(upstream.d_eg * c_frac);
+
+        // SAFETY: LAYOUT offsets place all four 4-wide mobility blocks (lo, lo+4,
+        // lc, lc+4) contiguously within the tunable region. Caller guarantees
+        // `grads.len() >= LAYOUT.xray_offset + 1` (asserted in the tape), which
+        // covers this range.
+        unsafe {
+            let p_lo_m = grads.as_mut_ptr().add(lo);
+            let p_lo_e = grads.as_mut_ptr().add(lo + 4);
+            let p_lc_m = grads.as_mut_ptr().add(lc);
+            let p_lc_e = grads.as_mut_ptr().add(lc + 4);
+
+            (Vf64x4::loadu(p_lo_m) + v_diff * v_d_om).storeu(p_lo_m);
+            (Vf64x4::loadu(p_lo_e) + v_diff * v_d_oe).storeu(p_lo_e);
+            (Vf64x4::loadu(p_lc_m) + v_diff * v_d_cm).storeu(p_lc_m);
+            (Vf64x4::loadu(p_lc_e) + v_diff * v_d_ce).storeu(p_lc_e);
+        }
     }
 }
 
-/// Scatter gradients for king-safety linear parameters (shield, ortho, diag,
-/// attacker-weights).
-///
-/// # Derivation
-///
-/// `SafetyMetrics::score` is `shelter − exposure − pressure`, then the whole
-/// diff is tapered by `phase/24`, so every param in this block has an outer
-/// `t_mg` factor.
-///
-///   `∂score/∂w_shield  =  t_mg · (shield_us − shield_them)`
-///   `∂score/∂w_ortho   = −t_mg · (ortho_us  − ortho_them)`
-///   `∂score/∂w_diag    = −t_mg · (diag_us   − diag_them)`
-///
-/// Attacker weights are indexed by per-side attacker counts: only the two
-/// active indices (`idx_us`, `idx_them`) receive non-zero contribution, each
-/// proportional to that side's `weak / 10`. Pressure is subtracted from
-/// "us"'s score, so `∂score/∂atk_weights[idx_us] = −t_mg · (weak_us / 10)`
-/// (opposite sign for `idx_them`). When both sides share an attacker index,
-/// contributions sum.
-#[inline]
-pub fn scatter_king_safety_grad(safety_us: &SafetyMetrics, safety_them: &SafetyMetrics, d: f64, t_mg: f64, grads: &mut [f64]) {
-    use crate::core::psqt::LAYOUT;
+/// Shelter, ortho/diag exposure, attacker-weight curve.
+/// Writes `acc.safety_us` and `acc.safety_them` from the same pair of
+/// `SafetyMetrics::score` calls; `scatter` emits 3 shared + 6 attacker slots.
+pub struct KingSafetyTerm;
 
-    let ks = LAYOUT.king_safety_offset;
-    let ao = LAYOUT.attacker_offset;
+impl LinearTerm for KingSafetyTerm {
+    /// Scalar upstream; combiner's single MG taper already folds in loss
+    /// derivative and STM sign. Per-side signs stay inside scatter.
+    type Upstream = f64;
 
-    let safety_coeff = d * t_mg;
+    #[inline(always)]
+    fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, _phase: T, acc: &mut Accumulators<T>) {
+        let w_atk_us = params.atk_weights[features.data.safety_us.attackers.min(ATTACKER_WEIGHTS.len() - 1)];
+        let w_atk_them = params.atk_weights[features.data.safety_them.attackers.min(ATTACKER_WEIGHTS.len() - 1)];
 
-    let shield_diff = (safety_us.shield - safety_them.shield) as f64;
-    let ortho_diff = (safety_us.ortho_exposure - safety_them.ortho_exposure) as f64;
-    let diag_diff = (safety_us.diag_exposure - safety_them.diag_exposure) as f64;
+        acc.safety_us = features.data.safety_us.score(params.w_shield, params.w_ortho, params.w_diag, w_atk_us);
+        acc.safety_them = features
+            .data
+            .safety_them
+            .score(params.w_shield, params.w_ortho, params.w_diag, w_atk_them);
+    }
 
-    grads[ks] += safety_coeff * shield_diff;
-    grads[ks + 1] -= safety_coeff * ortho_diff;
-    grads[ks + 2] -= safety_coeff * diag_diff;
+    /// # Derivation
+    ///
+    /// `SafetyMetrics::score` is `shelter − exposure − pressure`.
+    /// The combiner tapers the whole `us − them + xray` differential by `phase / 24`,
+    /// and that taper is pre-multiplied into `upstream`.
+    ///
+    ///   `∂score/∂w_shield  =  upstream · (shield_us − shield_them)`
+    ///   `∂score/∂w_ortho   = −upstream · (ortho_us  − ortho_them)`
+    ///   `∂score/∂w_diag    = −upstream · (diag_us   − diag_them)`
+    ///
+    /// Attacker weights;
+    /// Only the two active indices (per-side attacker counts) receive contribution,
+    /// each proportional to that side's `weak / 10`. Pressure is subtracted from "us"'s score,
+    /// so that `∂score/∂atk_weights[idx_us] = −upstream · (weak_us / 10)`
+    /// (opposite sign for `idx_them`). Shared indices sum.
+    #[inline]
+    fn scatter(features: &SharedFeatures, upstream: f64, grads: &mut [f64]) {
+        use crate::core::psqt::LAYOUT;
 
-    let idx_us = safety_us.attackers.min(ATTACKER_WEIGHTS.len() - 1);
-    let idx_them = safety_them.attackers.min(ATTACKER_WEIGHTS.len() - 1);
-    for atk_k in 0..ATTACKER_WEIGHTS.len() {
-        let mut atk_deriv = 0.0;
-        if atk_k == idx_us {
-            atk_deriv -= safety_us.weak as f64 / 10.0;
-        }
-        if atk_k == idx_them {
-            atk_deriv += safety_them.weak as f64 / 10.0;
-        }
-        if atk_deriv != 0.0 {
-            grads[ao + atk_k] += safety_coeff * atk_deriv;
+        let ks = LAYOUT.king_safety_offset;
+        let ao = LAYOUT.attacker_offset;
+
+        let safety_us = &features.data.safety_us;
+        let safety_them = &features.data.safety_them;
+
+        let shield_diff = (safety_us.shield - safety_them.shield) as f64;
+        let ortho_diff = (safety_us.ortho_exposure - safety_them.ortho_exposure) as f64;
+        let diag_diff = (safety_us.diag_exposure - safety_them.diag_exposure) as f64;
+
+        grads[ks] += upstream * shield_diff;
+        grads[ks + 1] -= upstream * ortho_diff;
+        grads[ks + 2] -= upstream * diag_diff;
+
+        let idx_us = safety_us.attackers.min(ATTACKER_WEIGHTS.len() - 1);
+        let idx_them = safety_them.attackers.min(ATTACKER_WEIGHTS.len() - 1);
+        for atk_k in 0..ATTACKER_WEIGHTS.len() {
+            let mut atk_deriv = 0.0;
+            if atk_k == idx_us {
+                atk_deriv -= safety_us.weak as f64 / 10.0;
+            }
+            if atk_k == idx_them {
+                atk_deriv += safety_them.weak as f64 / 10.0;
+            }
+            if atk_deriv != 0.0 {
+                grads[ao + atk_k] += upstream * atk_deriv;
+            }
         }
     }
 }

--- a/src/engine/mobility.rs
+++ b/src/engine/mobility.rs
@@ -134,6 +134,136 @@ pub fn compute_openness_raw(us_pawns: u64, them_pawns: u64) -> i32 {
         .clamp(0, OPEN_UNITY)
 }
 
+// ──────── Tuner Gradient Scatter ────────
+//
+// Per-term, linear-parameter gradient scatter. Each function lives next to
+// its score counterpart so the formula and its derivative stay together —
+// edit one, edit the other, no cross-file hunting.
+//
+// Contract for every `scatter_*_grad`:
+// - `d`  = outer loss derivative folded with STM sign (`2·err·sig·(1−sig)·k · stm_sign`).
+// - `t_mg`, `t_eg` = tapered-phase fractions (`phase/24`, `(24−phase)/24`).
+// - The function writes `d · ∂score_white/∂param` into `grads` at each param's
+//   LAYOUT offset. PSQT/material stay out of band (handled in the tuner tape).
+
+/// Scatter gradients for the four mobility weight vectors
+/// (MG/EG × open/closed, 4 lanes each = 16 params).
+///
+/// # Derivation
+///
+/// `evaluate_score_diff` interpolates open/closed weight vectors by `openness`,
+/// then tapers MG↔EG. For lane `j`:
+///
+///   `∂score/∂mg_mob_open[j]    = t_mg · diff[j] · (openness / 1024)`
+///   `∂score/∂mg_mob_closed[j]  = t_mg · diff[j] · (closedness / 1024)`
+///
+/// same pattern for EG weights with `t_eg`. Scatter multiplies by `d`.
+#[inline]
+pub fn scatter_mobility_grad(
+    metrics_us: &SideMetrics,
+    metrics_them: &SideMetrics,
+    openness: i32,
+    d: f64,
+    t_mg: f64,
+    t_eg: f64,
+    grads: &mut [f64],
+) {
+    use crate::{core::psqt::LAYOUT, weave::Vf64x4};
+
+    let lo = LAYOUT.mobility_open_offset;
+    let lc = LAYOUT.mobility_closed_offset;
+
+    let o_frac = openness as f64 / f64::from(OPEN_UNITY);
+    let c_frac = (OPEN_UNITY - openness) as f64 / f64::from(OPEN_UNITY);
+
+    let diff = [
+        (metrics_us.mobility - metrics_them.mobility) as f64,
+        (metrics_us.shadow_mobility - metrics_them.shadow_mobility) as f64,
+        (metrics_us.threats - metrics_them.threats) as f64,
+        (metrics_us.shadow_threats - metrics_them.shadow_threats) as f64,
+    ];
+
+    let v_diff = Vf64x4::from(diff);
+    let v_d_om = Vf64x4::splat(d * t_mg * o_frac);
+    let v_d_oe = Vf64x4::splat(d * t_eg * o_frac);
+    let v_d_cm = Vf64x4::splat(d * t_mg * c_frac);
+    let v_d_ce = Vf64x4::splat(d * t_eg * c_frac);
+
+    // SAFETY: LAYOUT offsets place all four 4-wide mobility blocks (lo, lo+4,
+    // lc, lc+4) contiguously within the tunable region. Caller guarantees
+    // `grads.len() >= LAYOUT.xray_offset + 1` (asserted in the tape), which
+    // covers this range.
+    unsafe {
+        let p_lo_m = grads.as_mut_ptr().add(lo);
+        let p_lo_e = grads.as_mut_ptr().add(lo + 4);
+        let p_lc_m = grads.as_mut_ptr().add(lc);
+        let p_lc_e = grads.as_mut_ptr().add(lc + 4);
+
+        (Vf64x4::loadu(p_lo_m) + v_diff * v_d_om).storeu(p_lo_m);
+        (Vf64x4::loadu(p_lo_e) + v_diff * v_d_oe).storeu(p_lo_e);
+        (Vf64x4::loadu(p_lc_m) + v_diff * v_d_cm).storeu(p_lc_m);
+        (Vf64x4::loadu(p_lc_e) + v_diff * v_d_ce).storeu(p_lc_e);
+    }
+}
+
+/// Scatter gradients for king-safety linear parameters (shield, ortho, diag,
+/// attacker-weights).
+///
+/// # Derivation
+///
+/// `SafetyMetrics::score` is `shelter − exposure − pressure`, then the whole
+/// diff is tapered by `phase/24`, so every param in this block has an outer
+/// `t_mg` factor.
+///
+///   `∂score/∂w_shield  =  t_mg · (shield_us − shield_them)`
+///   `∂score/∂w_ortho   = −t_mg · (ortho_us  − ortho_them)`
+///   `∂score/∂w_diag    = −t_mg · (diag_us   − diag_them)`
+///
+/// Attacker weights are indexed by per-side attacker counts: only the two
+/// active indices (`idx_us`, `idx_them`) receive non-zero contribution, each
+/// proportional to that side's `weak / 10`. Pressure is subtracted from
+/// "us"'s score, so `∂score/∂atk_weights[idx_us] = −t_mg · (weak_us / 10)`
+/// (opposite sign for `idx_them`). When both sides share an attacker index,
+/// contributions sum.
+#[inline]
+pub fn scatter_king_safety_grad(
+    safety_us: &SafetyMetrics,
+    safety_them: &SafetyMetrics,
+    d: f64,
+    t_mg: f64,
+    grads: &mut [f64],
+) {
+    use crate::core::psqt::LAYOUT;
+
+    let ks = LAYOUT.king_safety_offset;
+    let ao = LAYOUT.attacker_offset;
+
+    let safety_coeff = d * t_mg;
+
+    let shield_diff = (safety_us.shield - safety_them.shield) as f64;
+    let ortho_diff = (safety_us.ortho_exposure - safety_them.ortho_exposure) as f64;
+    let diag_diff = (safety_us.diag_exposure - safety_them.diag_exposure) as f64;
+
+    grads[ks] += safety_coeff * shield_diff;
+    grads[ks + 1] -= safety_coeff * ortho_diff;
+    grads[ks + 2] -= safety_coeff * diag_diff;
+
+    let idx_us = safety_us.attackers.min(ATTACKER_WEIGHTS.len() - 1);
+    let idx_them = safety_them.attackers.min(ATTACKER_WEIGHTS.len() - 1);
+    for atk_k in 0..ATTACKER_WEIGHTS.len() {
+        let mut atk_deriv = 0.0;
+        if atk_k == idx_us {
+            atk_deriv -= safety_us.weak as f64 / 10.0;
+        }
+        if atk_k == idx_them {
+            atk_deriv += safety_them.weak as f64 / 10.0;
+        }
+        if atk_deriv != 0.0 {
+            grads[ao + atk_k] += safety_coeff * atk_deriv;
+        }
+    }
+}
+
 // ──────── Mobility Data ────────
 
 /// Spatial metrics for one side: `[mobility, shadow_mobility, threats, shadow_threats]`.

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod adjudication;
 pub mod autograd;
+pub mod combiner;
 pub mod eval;
 pub mod eval_params;
 pub mod history;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -12,6 +12,7 @@ pub mod movepicker;
 pub mod search;
 pub mod search_params;
 pub mod see;
+pub mod term;
 pub mod tm;
 pub mod tt;
 pub mod wdl;

--- a/src/engine/term.rs
+++ b/src/engine/term.rs
@@ -63,6 +63,7 @@ pub struct TaperPair {
 pub struct BucketUpstreams {
     pub mg_eg: TaperPair,
     pub mobility: TaperPair,
+    pub bonus: TaperPair,
     pub king_safety: f64,
     pub xray: f64,
 }

--- a/src/engine/term.rs
+++ b/src/engine/term.rs
@@ -1,0 +1,118 @@
+//! Per-term forward/backward trait and registration macro.
+//!
+//! # Architecture
+//!
+//! Every eval term implements [`LinearTerm`]:
+//!
+//! - `apply` reads [`SharedFeatures`] and writes the term's bucket(s) on
+//!   [`Accumulators`] — the forward contribution.
+//! - `scatter` consumes the combiner-derived upstream for those bucket(s)
+//!   and writes parameter gradients — the backward pass.
+//!
+//! The [`register_terms!`] macro stitches impls into two unrolled
+//! dispatch functions:
+//!
+//! - `apply_all_terms` — forward pass, called by
+//!   [`crate::engine::eval::fill_accumulators`].
+//! - `scatter_all_terms` — backward pass, called by the tuner's linear-
+//!   grad tape.
+//!
+//! Adding a term is one macro line plus the impl — no plumbing edits
+//! across `eval.rs` / `tape.rs`.
+//!
+//! # Scope
+//!
+//! `LinearTerm` assumes `∂bucket/∂param` is a pure feature coefficient.
+//! i.e. the term is linear in its parameters. All non-linearities
+//! (sigmoid gates, quadratic pressure curves, winnable scale factors)
+//! belong in the [`crate::engine::combiner::Combiner`] layer, which
+//! composes bucket values into the final score. Exotic per-term shapes
+//! (param-param products, per-term activations) should land in a future
+//! `NonlinearTerm` escape hatch rather than bending this trait.
+
+use crate::engine::{
+    autograd::EvalMath,
+    combiner::Accumulators,
+    eval::{EvalParams, SharedFeatures},
+};
+
+/// MG/EG upstream derivative pair for a bucket whose value is pre-tapered
+/// inside the term (mobility's openness·phase blend, the PSQT accumulator's
+/// `tapered` call). The combiner hands each term its MG and EG multipliers
+/// pre-multiplied, so scatter code walks parameter slots in one pass
+/// without re-deriving the phase fractions.
+#[derive(Clone, Copy)]
+pub struct TaperPair {
+    pub d_mg: f64,
+    pub d_eg: f64,
+}
+
+/// Per-term upstream derivatives emitted by the combiner's backward pass.
+/// Each field is consumed by the term(s) [`register_terms!`] routes to it.
+///
+/// `king_safety` and `xray` carry equal values under [`LinearCombiner`]
+/// today but sit in separate fields so a future combiner (sigmoid king
+/// danger, independent xray scale) can diverge them without touching
+/// any term.
+///
+/// `mg_eg` is consumed out-of-band by the tuner's PSQT / material
+/// scatter, since PSQT lives in the accumulator rather than in any
+/// registered term.
+///
+/// [`LinearCombiner`]: crate::engine::combiner::LinearCombiner
+pub struct BucketUpstreams {
+    pub mg_eg: TaperPair,
+    pub mobility: TaperPair,
+    pub king_safety: f64,
+    pub xray: f64,
+}
+
+/// Parameter-linear evaluation term.
+pub trait LinearTerm {
+    /// Upstream derivative this term's scatter consumes. Typical shapes:
+    ///
+    /// - [`TaperPair`] — bucket is pre-tapered inside the term (e.g. mobility).
+    /// - `f64` — bucket runs through one scalar combiner multiplier (e.g.
+    ///   king-safety's single MG taper).
+    type Upstream: Copy;
+
+    /// Forward contribution; read features and params, write bucket(s).
+    /// A term may write more than one bucket if they share the same feature
+    /// extraction (e.g. `KingSafetyTerm` fills both `safety_us` and
+    /// `safety_them` from one `SafetyMetrics::score` pass per side).
+    fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, phase: T, acc: &mut Accumulators<T>);
+
+    /// Gradient scatter: `∂loss/∂bucket · ∂bucket/∂param` written into the
+    /// term's owned slot range in `grads`.
+    fn scatter(features: &SharedFeatures, upstream: Self::Upstream, grads: &mut [f64]);
+}
+
+/// Expand to `apply_all_terms` and `scatter_all_terms` dispatch functions
+/// covering every registered term.
+///
+/// Each entry pairs a term type with the [`BucketUpstreams`] field whose
+/// value is handed to that term's `scatter` — the compiler type-checks
+/// the pairing against the term's associated `Upstream` type.
+#[macro_export]
+macro_rules! register_terms {
+    ( $( $term:path => $upstream_field:ident ),* $(,)? ) => {
+        #[inline]
+        pub fn apply_all_terms<T: $crate::engine::autograd::EvalMath<Scalar = T>>(
+            features: &$crate::engine::eval::SharedFeatures,
+            params: &$crate::engine::eval::EvalParams<T>,
+            phase: T,
+            acc: &mut $crate::engine::combiner::Accumulators<T>,
+        ) {
+            $( <$term as $crate::engine::term::LinearTerm>::apply::<T>(features, params, phase, acc); )*
+        }
+
+        #[inline]
+        pub fn scatter_all_terms(
+            features: &$crate::engine::eval::SharedFeatures,
+            upstreams: &$crate::engine::term::BucketUpstreams,
+            grads: &mut [f64],
+        ) {
+            $( <$term as $crate::engine::term::LinearTerm>::scatter(features, upstreams.$upstream_field, grads); )*
+        }
+    };
+}

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -294,6 +294,7 @@ fn process_command(state: &mut UciState, input: &str) -> bool {
             let res = crate::engine::eval::detailed_eval(&state.board, &state.accumulator);
             println!("PSQT:     {:>5}", res.psqt);
             println!("Mobility: {:>5}", res.mobility);
+            println!("Bonus:    {:>5}", res.bonus);
             println!("Safety:   {:>5}", res.safety);
             println!("───────────────");
             println!("Total:    {:>5}", res.total);

--- a/tuner/ADDING_EVAL_TERMS.md
+++ b/tuner/ADDING_EVAL_TERMS.md
@@ -1,16 +1,46 @@
 # Adding New Eval Terms
 
-*The step-by-step recipe for wiring new evaluation parameters.*
+Step-by-step recipe for wiring a new linear eval term.
 
-**→ See [EVAL_TUNER.md](EVAL_TUNER.md) for the architecture overview.**
+See [`EVAL_TUNER.md`](EVAL_TUNER.md) for the tuner architecture.
 
 ---
 
-## The Recipe
+## What a term is
 
-Say you're adding a **bishop pair bonus**: a weight that rewards having both bishops.
+A term is a zero-sized type implementing `LinearTerm`:
 
-### 1. Add the parameter to `define_tunables!`
+- `fn apply<T: EvalMath>` — forward pass. Reads features and params, writes its contribution into `Accumulators`.
+- `fn scatter` — backward pass. Consumes the combiner-derived upstream for its bucket and writes `∂loss/∂param` into the term's param slots.
+- `type Upstream` — `TaperPair` for pre-tapered buckets (`bonus`, `mobility`); `f64` for scalar buckets (`king_safety`, `xray`).
+
+The `register_terms!` macro in `src/engine/eval.rs` wires terms into `apply_all_terms` and `scatter_all_terms`.
+
+Adding a term is one macro line plus the impl — no edits to the eval pipeline or to `tape.rs`.
+
+---
+
+## Linearity rule
+
+`LinearTerm` assumes `∂bucket/∂param` is a pure feature coefficient: `bucket += param · feature_expr`. The feature expression can be any combination of features; the parameter must appear linearly.
+
+| Pattern | Fast tape works? |
+|---|---|
+| `param · feature_count` | Yes |
+| `param · (feature_a * feature_b)` | Yes — feature non-linearity is free |
+| `param · (feature² / threshold)` | Yes |
+| `param_a · param_b · feature` | **No** — parameter non-linearity, breaks scatter |
+| `sigmoid(param_a + const) · feature` | **No** — param inside an activation |
+
+Parameter non-linearity belongs in the `Combiner` (as a bucket-level activation) or a future `NonlinearTerm` escape hatch. The oracle test will catch drift if you cross the line.
+
+---
+
+## Recipe: bishop pair
+
+A tapered bonus for holding both bishops. When white has the pair and black doesn't, add `mg_bonus · phase + eg_bonus · eg_phase` (and mirror for black).
+
+### 1. Add the params to `define_tunables!`
 
 In `src/engine/eval_params.rs`:
 
@@ -19,128 +49,173 @@ In `src/engine/eval_params.rs`:
 macro_rules! define_tunables {
     ($macro:ident) => {
         $macro! {
-            // ... existing fields ...
-            (w_bishop_pair, Scalar, $crate::engine::eval_params::LAYOUT.bishop_pair_offset)
+            // ...
+            (w_bishop_pair_mg, Scalar, $crate::engine::eval_params::LAYOUT.bishop_pair_offset),
+            (w_bishop_pair_eg, Scalar, $crate::engine::eval_params::LAYOUT.bishop_pair_offset + 1),
         }
     }
 }
 ```
 
-This macro automatically synchronizes the engine and autograd types.
+One entry feeds all three sites: the engine's `EvalParams<i32>`, the autograd `EvalParams<DualNode>`, and the tuner's f64 loader.
 
-Update `EvalParams::<i32>::from_const()` in `src/engine/eval.rs` to load from your new constant.
+### 2. Extend `Layout`
 
-### 2. Add the constant to `eval_params.rs`
-
-```rust
-pub const BISHOP_PAIR_BONUS: i32 = 30; // initial guess, tuner will optimize
-```
-
-### 3. Use it in `evaluate_generic`
-
-```rust
-let bp_bonus = if board.has_bishop_pair(Color::White) && !board.has_bishop_pair(Color::Black) {
-    params.w_bishop_pair
-} else if board.has_bishop_pair(Color::Black) && !board.has_bishop_pair(Color::White) {
-    -params.w_bishop_pair
-} else {
-    T::zero()
-};
-
-score += bp_bonus;
-```
-
-The feature here is `+1` if white has both bishops and black doesn't,\
-`-1` if reversed,\
-`0` if symmetric.\
-It comes from the board, not from the weight value.
-
-### 4. Register in the parameter layout
-
-The tuner optimizes a flat `&[f64]` array. To map your parameter into this contiguous block, add its length and offset to `Layout` in `src/engine/eval_params.rs`:
+Same file:
 
 ```rust
 pub struct Layout {
-    // ... existing fields ...
-    pub xray_offset:        usize,
-    pub xray_len:           usize,
+    // ...
+    pub xray_offset: usize,
+    pub xray_len: usize,
     pub bishop_pair_offset: usize,
-    pub bishop_pair_len:    usize,
+    pub bishop_pair_len: usize,
 }
 
 const fn calc_layout() -> Layout {
     // ...
-    let bishop_pair_len = 1;
-
-    // ...
     let xray_offset = king_safety_offset + safety_len;
+    let xray_len = 1;
     let bishop_pair_offset = xray_offset + xray_len;
+    let bishop_pair_len = 2;
 
     Layout {
         // ...
+        xray_offset,
+        xray_len,
         bishop_pair_offset,
         bishop_pair_len,
     }
 }
 ```
 
-### 5. Add the gradient formula in `eval_linear_grad`
+Then update `EvalParams::<i32>::from_const()` in `src/engine/eval.rs` to load the compile-time defaults for the new params.
 
-This is the production training path (`tuner/src/evaltune/tape.rs`). We bypass dual-number automatic differentiation here purely for speed. 
+### 3. Write the term
 
-Because the evaluation is a strictly linear combination of its parameters ($score = \sum w_i \cdot x_i$), the partial derivative with respect to any weight ($\frac{\partial y}{\partial w_i}$) is simply its feature coefficient ($x_i$). Doing this explicitly in `f64` arithmetic avoids the massive overhead of allocating and tracking dual numbers for millions of positions.
-
-In `eval_linear_grad`, compute the feature coefficient and multiply it by the upstream loss derivative `d` (which already wraps the sigmoid derivative and STM perspective flip):
+Place it in a sensible file — new module `src/engine/terms/bishop_pair.rs`, or co-located if it belongs with existing logic (e.g. pawn terms beside other pawn code):
 
 ```rust
-// Bishop pair gradient
-let bp_offset = psqt::LAYOUT.bishop_pair_offset;
-let bp_feature = if board
-    .pieces(PieceType::Bishop, Color::White)
-    .more_than_one()
-    && !board
-        .pieces(PieceType::Bishop, Color::Black)
-        .more_than_one()
-{
-    1.0
-} else if board
-    .pieces(PieceType::Bishop, Color::Black)
-    .more_than_one()
-    && !board
-        .pieces(PieceType::Bishop, Color::White)
-        .more_than_one()
-{
-    -1.0
-} else {
-    0.0
+use crate::{
+    core::{defs::TOTAL_PHASE, psqt::LAYOUT},
+    engine::{
+        autograd::EvalMath,
+        combiner::Accumulators,
+        eval::{EvalParams, SharedFeatures},
+        term::{LinearTerm, TaperPair},
+    },
 };
 
-param_grads[bp_offset] += d * bp_feature;
+pub struct BishopPairTerm;
+
+impl LinearTerm for BishopPairTerm {
+    type Upstream = TaperPair;
+
+    #[inline(always)]
+    fn apply<T: EvalMath<Scalar = T>>(
+        features: &SharedFeatures,
+        params: &EvalParams<T>,
+        phase: T,
+        acc: &mut Accumulators<T>,
+    ) {
+        let feature = T::from_i32(features.bishop_pair_diff);
+        let eg_phase = T::from_i32(TOTAL_PHASE) - phase;
+        let tapered = params.w_bishop_pair_mg * phase + params.w_bishop_pair_eg * eg_phase;
+        acc.bonus += (tapered * feature / T::from_i32(TOTAL_PHASE)).trunc();
+    }
+
+    #[inline]
+    fn scatter(features: &SharedFeatures, upstream: TaperPair, grads: &mut [f64]) {
+        let feature = features.bishop_pair_diff as f64;
+        grads[LAYOUT.bishop_pair_offset] += upstream.d_mg * feature;
+        grads[LAYOUT.bishop_pair_offset + 1] += upstream.d_eg * feature;
+    }
+}
 ```
 
-### 6. The oracle is automatic
+`apply` uses `+=` on `acc.bonus` because the bonus bucket is shared across every simple tapered term. `scatter` reads `upstream.d_mg` / `upstream.d_eg` directly — the combiner already folded in the phase fractions and loss derivative, so scatter is just `upstream · ∂bucket/∂param`.
 
-You don't need to write backward passes or manually seed dual numbers. Because you registered the parameter in the `define_tunables!` macro (Step 1), `eval_dual_fused` (the AD correctness oracle) automatically instantiates your parameter as a `DualNode` with its gradient tracking slot initialized.
+### 4. Extend `SharedFeatures`
 
-The dual path is slow but mathematically perfect. The linear path (Step 5) is blazing fast but requires hand-written feature extraction.
+Both `apply` and `scatter` read `features.bishop_pair_diff`, so it lives on `SharedFeatures` (single source, computed once per position). In `src/engine/eval.rs`:
 
-### 7. Verify
+```rust
+pub struct SharedFeatures {
+    pub openness: i32,
+    pub data: MobilityData,
+    pub xray_ortho: i32,
+    pub bishop_pair_diff: i32,
+}
 
-Run the tuner. Before the first epoch, the training loop runs a Split-Brain Gradient Trap: it evaluates a batch of positions using both `eval_linear_grad` and `eval_dual_fused`. 
+impl SharedFeatures {
+    pub fn compute(board: &Position) -> Self {
+        // ... existing extraction ...
+        let bishop_pair_diff = pair_i32(board.pieces(PieceType::Bishop, Color::White))
+                             - pair_i32(board.pieces(PieceType::Bishop, Color::Black));
+        Self { /* ... */ bishop_pair_diff }
+    }
+}
 
-If your hand-derived feature coefficient in Step 5 deviates from the AD oracle by even `1e-4`, the tuner panics and identifies the exact parameter index. If it boots, your math is proven correct.
+fn pair_i32(bb: Bitboard) -> i32 { i32::from(bb.more_than_one()) }
+```
+
+### 5. Register the term
+
+In `src/engine/eval.rs`:
+
+```rust
+crate::register_terms! {
+    crate::engine::mobility::MobilityTerm => mobility,
+    crate::engine::mobility::KingSafetyTerm => king_safety,
+    crate::engine::terms::bishop_pair::BishopPairTerm => bonus,
+    XrayTerm => xray,
+}
+```
+
+The right-hand side names the `BucketUpstreams` field that feeds this term's `scatter`. A tapered bonus routes to `bonus`.
+
+### 6. Verify
+
+```sh
+cargo test -p tuner --release oracle
+```
+
+The per-term oracle tests in `tuner/src/evaltune/tape.rs` run each `LinearTerm` in isolation. If your scatter disagrees with the `DualNode` AD oracle by more than `1e-3` on any fen, the matching test fails and names the term.
+
+### 7. SPRT
+
+Commit with a `Bench: XXXXX` trailer (CI and OB requires it). Then SPRT the branch against base :)
 
 ---
 
-## The Gradient Cheat Sheet
+## Choosing the right bucket
 
-For a term parameterized as `params.foo · feature`:
+For a pre-tapered, pure linear-sum term, route to `bonus`. No new bucket needed.
 
-| Context | Gradient applied to `param_grads` |
-|---------|----------------|
-| **Direct addition** | `d · feature` |
-| **Tapered** | `d · feature · t_mg` (MG) <br> `d · feature · t_eg` (EG) |
-| **Mobility (Openness interpolated)** | `d · t_mg · feature · (openness / 1024.0)` (Open MG) <br> `d · t_eg · feature · (openness / 1024.0)` (Open EG) <br> `d · t_mg · feature · (closedness / 1024.0)` (Closed MG) <br> `d · t_eg · feature · (closedness / 1024.0)` (Closed EG) |
-| **King Safety** | `d · t_mg · feature_diff` |
+If the term has its own combiner shape — a separate activation, its own taper logic — then it earns a new bucket.<br>
+Add a field to `Accumulators`, a matching field to `BucketUpstreams`, and update `LinearCombiner::forward` + `backward`.<br>
+Bucket additions touch every combiner impl, so only add one when a term's combiner treatment is genuinely different.
 
-*(Where `d = outer_deriv · stm_sign`, precomputed at the top of `eval_linear_grad`)*
+Multi-bucket terms (one term writing several accumulator fields from shared features) already exist — `KingSafetyTerm` writes both `safety_us` and `safety_them`.
+Scatter handles the per-side sign; `Upstream` is whatever the combiner produces for the shared block.
+
+---
+
+## Gradient cheat sheet
+
+For a term routed to bucket `B` with upstream `U`, where `bucket += param · feature_expr(p)`:
+
+```
+grads[p] += U · feature_expr(p)
+```
+
+| Bucket routing | `Upstream` type | Scatter formula |
+|---|---|---|
+| `bonus` (shared tapered bonus) | `TaperPair { d_mg, d_eg }` | `grads[mg] += d_mg · feature`, `grads[eg] += d_eg · feature` |
+| `mobility` (internal openness+phase blend) | `TaperPair` | Same shape, multiply by openness fraction — see `MobilityTerm::scatter` |
+| `king_safety` (raw bucket, combiner tapers) | `f64` | `grads[p] += upstream · feature_diff` |
+| `xray` (raw bucket, combiner tapers) | `f64` | `grads[xray] += upstream · feature` |
+
+The combiner's `backward` has already folded in the loss derivative, STM sign, and taper. Scatter's only job is `upstream · ∂bucket/∂param`.
+
+If the shape isn't on the table, derive `∂bucket/∂param` by hand from your `apply` formula. The oracle test catches mistakes — run it.

--- a/tuner/src/evaltune/tape.rs
+++ b/tuner/src/evaltune/tape.rs
@@ -507,41 +507,105 @@ pub fn eval_f64_with_acc(board: &Board, values: &[f64]) -> (f64, [f64; 8], [f64;
 
 #[cfg(test)]
 mod tests {
-    use soul::core::board::Position;
+    use std::ops::Range;
+
+    use soul::core::{board::Position, psqt::LAYOUT};
 
     use super::*;
 
-    #[test]
-    fn test_linear_oracle_verification() {
-        let fens = [
-            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
-            "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
-            "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
-        ];
+    const FENS: &[&str] = &[
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+        "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+        "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+    ];
 
-        let mut values = vec![0.0f64; soul::core::psqt::LAYOUT.xray_offset + 1];
-        for (n, v) in values.iter_mut().enumerate() {
-            *v = (n % 17) as f64 - 8.0;
+    const TARGET: f64 = 0.5;
+    const K: f64 = 0.005;
+
+    /// Return the eval layer (`LinearTerm` impl or accumulator-level scatter)
+    /// that owns a given param slot. Used to name term-level gradient drift
+    /// in oracle failure messages.
+    fn term_for(slot: usize) -> &'static str {
+        if slot < LAYOUT.mobility_open_offset {
+            "PSQT/material (accumulator-level)"
+        } else if slot < LAYOUT.king_safety_offset {
+            "MobilityTerm"
+        } else if slot < LAYOUT.attacker_offset {
+            "KingSafetyTerm (shield/ortho/diag)"
+        } else if slot < LAYOUT.xray_offset {
+            "KingSafetyTerm (attackers)"
+        } else {
+            "XrayTerm"
         }
+    }
 
-        let target = 0.5;
-        let k = 0.005;
-
-        for fen in &fens {
+    /// Compare `eval_linear_grad` against `eval_dual_fused` on every test FEN
+    /// under the given `values` vector. Identifies drift by term name.
+    fn assert_oracle_matches(context: &str, values: &[f64]) {
+        for fen in FENS {
             let pos = Position::from_fen(fen);
 
             let mut linear_grad = vec![0.0f64; values.len()];
-            let linear_eval = eval_linear_grad(&pos, &values, target, k, &mut linear_grad);
+            let linear_eval = eval_linear_grad(&pos, values, TARGET, K, &mut linear_grad);
 
             let mut dual_grad = vec![0.0f64; values.len()];
-            let dual_eval = eval_dual_fused(&pos, &values, target, k, &mut dual_grad);
+            let dual_eval = eval_dual_fused(&pos, values, TARGET, K, &mut dual_grad);
 
-            assert!((linear_eval - dual_eval).abs() < 1e-4, "Eval mismatch on fn: {}", fen);
+            assert!(
+                (linear_eval - dual_eval).abs() < 1e-4,
+                "[{context}] eval mismatch on '{fen}': linear={linear_eval} dual={dual_eval}",
+            );
 
             for (i, (&lg, &dg)) in linear_grad.iter().zip(dual_grad.iter()).enumerate() {
-                assert!((lg - dg).abs() < 1e-3, "Gradient mismatch at index {} on {}", i, fen);
+                assert!(
+                    (lg - dg).abs() < 1e-3,
+                    "[{context}] {} scatter drift at slot {i} on '{fen}': linear={lg} dual={dg}",
+                    term_for(i),
+                );
             }
         }
+    }
+
+    fn full_values() -> Vec<f64> {
+        let mut values = vec![0.0f64; LAYOUT.xray_offset + 1];
+        for (n, v) in values.iter_mut().enumerate() {
+            *v = (n % 17) as f64 - 8.0;
+        }
+        values
+    }
+
+    /// Populate only a contiguous slice of `values`; everything else stays zero.
+    /// Used to isolate a single `LinearTerm` — only its param range drives the
+    /// score, so `eval_linear_grad`'s scatter on that range is the only thing
+    /// being verified against the `DualNode` oracle.
+    fn values_in_range(range: Range<usize>) -> Vec<f64> {
+        let mut values = vec![0.0f64; LAYOUT.xray_offset + 1];
+        for i in range {
+            values[i] = (i % 17) as f64 - 8.0;
+        }
+        values
+    }
+
+    /// Pipeline-sum oracle: every term active, every bucket contributing.
+    /// Failure names the owning term, so drift localizes without bisection.
+    #[test]
+    fn test_linear_oracle_verification() {
+        assert_oracle_matches("pipeline", &full_values());
+    }
+
+    #[test]
+    fn test_mobility_term_oracle() {
+        assert_oracle_matches("MobilityTerm alone", &values_in_range(LAYOUT.mobility_open_offset..LAYOUT.king_safety_offset));
+    }
+
+    #[test]
+    fn test_king_safety_term_oracle() {
+        assert_oracle_matches("KingSafetyTerm alone", &values_in_range(LAYOUT.king_safety_offset..LAYOUT.xray_offset));
+    }
+
+    #[test]
+    fn test_xray_term_oracle() {
+        assert_oracle_matches("XrayTerm alone", &values_in_range(LAYOUT.xray_offset..LAYOUT.xray_offset + 1));
     }
 }

--- a/tuner/src/evaltune/tape.rs
+++ b/tuner/src/evaltune/tape.rs
@@ -12,7 +12,6 @@ use soul::{
         psqt,
     },
     engine::autograd::{EnvVec8, EvalMath},
-    weave::Vf64x4,
 };
 
 /// Active piece entry for PSQT gradient scatter.
@@ -228,22 +227,7 @@ pub fn eval_dual_forward(board: &Board, values: &[f64]) -> DualEvalResult {
 
     let params = soul::engine::eval::EvalParams::<DualNode>::load_tunable(values);
 
-    // Build the macroscopic features boundary
-    let openness = soul::engine::mobility::Mobility::compute_openness(board);
-    let pinned_w = board.pinned_pieces(Color::White);
-    let pinned_b = board.pinned_pieces(Color::Black);
-    let tensor = soul::core::board::spatial::SpatialTensor::compute(board, pinned_w.0, pinned_b.0);
-    let data = soul::engine::mobility::Mobility::compute_all(board, Color::White, &tensor, pinned_w, pinned_b);
-
-    let w_ksq = board.pieces(PieceType::King, Color::White).lsb();
-    let b_ksq = board.pieces(PieceType::King, Color::Black).lsb();
-    let w_king_ring = soul::core::board::bitboard::atk_king(w_ksq).0;
-    let b_king_ring = soul::core::board::bitboard::atk_king(b_ksq).0;
-
-    let xray_ortho =
-        (tensor.w_ortho_xray() & b_king_ring).count_ones() as i32 - (tensor.b_ortho_xray() & w_king_ring).count_ones() as i32;
-
-    let features = soul::engine::eval::MacroFeatures { openness, data, xray_ortho };
+    let features = soul::engine::eval::SharedFeatures::compute(board);
 
     // Forward pass with dual numbers
     let result = soul::engine::eval::evaluate_generic::<DualNode>(board, &dual_acc, phase, &params, Some(&features));
@@ -294,22 +278,7 @@ pub fn eval_dual_fused(board: &Board, values: &[f64], target: f64, k: f64, param
 
     let params = soul::engine::eval::EvalParams::<DualNode>::load_tunable(values);
 
-    // Build the macroscopic features boundary
-    let openness = soul::engine::mobility::Mobility::compute_openness(board);
-    let pinned_w = board.pinned_pieces(Color::White);
-    let pinned_b = board.pinned_pieces(Color::Black);
-    let tensor = soul::core::board::spatial::SpatialTensor::compute(board, pinned_w.0, pinned_b.0);
-    let data = soul::engine::mobility::Mobility::compute_all(board, Color::White, &tensor, pinned_w, pinned_b);
-
-    let w_ksq = board.pieces(PieceType::King, Color::White).lsb();
-    let b_ksq = board.pieces(PieceType::King, Color::Black).lsb();
-    let w_king_ring = soul::core::board::bitboard::atk_king(w_ksq).0;
-    let b_king_ring = soul::core::board::bitboard::atk_king(b_ksq).0;
-
-    let xray_ortho =
-        (tensor.w_ortho_xray() & b_king_ring).count_ones() as i32 - (tensor.b_ortho_xray() & w_king_ring).count_ones() as i32;
-
-    let features = soul::engine::eval::MacroFeatures { openness, data, xray_ortho };
+    let features = soul::engine::eval::SharedFeatures::compute(board);
 
     // Forward pass
     let result = soul::engine::eval::evaluate_generic::<DualNode>(board, &dual_acc, phase, &params, Some(&features));
@@ -384,7 +353,10 @@ pub fn eval_dual_fused(board: &Board, values: &[f64], target: f64, k: f64, param
 /// Returns squared error for loss tracking.
 #[inline]
 pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, param_grads: &mut [f64]) -> f64 {
-    use soul::engine::mobility::Mobility;
+    use soul::engine::{
+        eval::{SharedFeatures, scatter_xray_grad},
+        mobility::{scatter_king_safety_grad, scatter_mobility_grad},
+    };
 
     // PSQT + Material accumulator (for lane values + PSQT scatter)
     let mut lane_vals = [0.0f64; 8];
@@ -408,45 +380,15 @@ pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, para
     let t_eg = (24.0 - phase as f64) / 24.0;
     let score = eval_f64(board, values);
 
-    // Sigmoid + loss derivative
+    // Sigmoid + loss derivative. `d` folds the STM sign into the outer
+    // derivative once, so every downstream scatter can stay STM-agnostic.
     let sig = 1.0 / (1.0 + (-k * score).clamp(-700.0, 700.0).exp());
     let err = sig - target;
     let outer = 2.0 * err * sig * (1.0 - sig) * k;
-
     let stm_sign: f64 = if board.stm == Color::White { 1.0 } else { -1.0 };
     let d = outer * stm_sign;
 
-    // Mobility + safety features
-    let pinned_w = board.pinned_pieces(Color::White);
-    let pinned_b = board.pinned_pieces(Color::Black);
-    let tensor = soul::core::board::spatial::SpatialTensor::compute(board, pinned_w.0, pinned_b.0);
-    let mob_data = Mobility::compute_all(board, Color::White, &tensor, pinned_w, pinned_b);
-    let openness = Mobility::compute_openness(board);
-    let o = openness as f64;
-    let c = (1024 - openness) as f64;
-
-    let lo = psqt::LAYOUT.mobility_open_offset;
-    let lc = psqt::LAYOUT.mobility_closed_offset;
-    let ks = psqt::LAYOUT.king_safety_offset;
-    let ao = psqt::LAYOUT.attacker_offset;
-    let xr = psqt::LAYOUT.xray_offset;
-
-    // Feature difference vector (same as evaluate_score_diff builds)
-    let idx_us = mob_data.safety_us.attackers.min(5);
-    let idx_them = mob_data.safety_them.attackers.min(5);
-
-    let diff = [
-        (mob_data.metrics_us.mobility - mob_data.metrics_them.mobility) as f64,
-        (mob_data.metrics_us.shadow_mobility - mob_data.metrics_them.shadow_mobility) as f64,
-        (mob_data.metrics_us.threats - mob_data.metrics_them.threats) as f64,
-        (mob_data.metrics_us.shadow_threats - mob_data.metrics_them.shadow_threats) as f64,
-    ];
-
-    // Scatter gradients
-
-    // PSQT gradients
-    let d_mg = d * t_mg;
-    let d_eg = d * t_eg;
+    let features = SharedFeatures::compute(board);
 
     debug_assert!(
         param_grads.len() >= psqt::LAYOUT.mobility_open_offset,
@@ -454,6 +396,14 @@ pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, para
         param_grads.len(),
         psqt::LAYOUT.mobility_open_offset,
     );
+
+    // ── PSQT + material (out-of-band, not a term) ──
+    //
+    // Stays in the tape because it lives in the accumulator, not the
+    // per-term parameter block. One board sweep writes both PSQT and
+    // material gradients for every active piece.
+    let d_mg = d * t_mg;
+    let d_eg = d * t_eg;
 
     for piece in PieceType::ALL {
         let pt = piece.as_usize();
@@ -489,73 +439,15 @@ pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, para
         }
     }
 
-    // Mobility weight gradients
-    // d(score)/d(mg_mob_open[j]) = t_mg · diff[j] · (openness/1024)
-    // d(score)/d(mg_mob_closed[j]) = t_mg · diff[j] · (closedness/1024)
-    // Same pattern for EG weights with t_eg
-    let o_frac = o / 1024.0;
-    let c_frac = c / 1024.0;
-
-    let v_diff = Vf64x4::from(diff);
-    let v_d_om = Vf64x4::splat(d * t_mg * o_frac);
-    let v_d_oe = Vf64x4::splat(d * t_eg * o_frac);
-    let v_d_cm = Vf64x4::splat(d * t_mg * c_frac);
-    let v_d_ce = Vf64x4::splat(d * t_eg * c_frac);
-
-    // SAFETY: The params array layout strictly guarantees that mobility parameter blocks
-    // (lo, lo+4, lc, lc+4) are contiguous 4-float arrays fully within the param_grads buffer.
-    unsafe {
-        let p_lo_m = param_grads.as_mut_ptr().add(lo);
-        let p_lo_e = param_grads.as_mut_ptr().add(lo + 4);
-        let p_lc_m = param_grads.as_mut_ptr().add(lc);
-        let p_lc_e = param_grads.as_mut_ptr().add(lc + 4);
-
-        (Vf64x4::loadu(p_lo_m) + v_diff * v_d_om).storeu(p_lo_m);
-        (Vf64x4::loadu(p_lo_e) + v_diff * v_d_oe).storeu(p_lo_e);
-        (Vf64x4::loadu(p_lc_m) + v_diff * v_d_cm).storeu(p_lc_m);
-        (Vf64x4::loadu(p_lc_e) + v_diff * v_d_ce).storeu(p_lc_e);
-    }
-
-    // King safety gradients
-    // Safety params are tapered (mg only), so coeff is d · t_mg.
-    let safety_coeff = d * t_mg;
-
-    let shield_diff = (mob_data.safety_us.shield - mob_data.safety_them.shield) as f64;
-    let ortho_diff = (mob_data.safety_us.ortho_exposure - mob_data.safety_them.ortho_exposure) as f64;
-    let diag_diff = (mob_data.safety_us.diag_exposure - mob_data.safety_them.diag_exposure) as f64;
-
-    param_grads[ks] += safety_coeff * shield_diff;
-    param_grads[ks + 1] -= safety_coeff * ortho_diff;
-    param_grads[ks + 2] -= safety_coeff * diag_diff;
-
-    // Attacker weight gradients
-    for atk_k in 0..6 {
-        let mut atk_deriv = 0.0;
-        if atk_k == idx_us {
-            atk_deriv -= mob_data.safety_us.weak as f64 / 10.0;
-        }
-        if atk_k == idx_them {
-            atk_deriv += mob_data.safety_them.weak as f64 / 10.0;
-        }
-        if atk_deriv != 0.0 {
-            param_grads[ao + atk_k] += safety_coeff * atk_deriv;
-        }
-    }
-
-    // X-Ray features
-    let w_ksq = board.pieces(PieceType::King, Color::White).lsb();
-    let b_ksq = board.pieces(PieceType::King, Color::Black).lsb();
-    let w_king_ring = soul::core::board::bitboard::atk_king(w_ksq).0;
-    let b_king_ring = soul::core::board::bitboard::atk_king(b_ksq).0;
-
-    // NOTE: The symmetrical subtraction here correctly yields the difference.
-    // When multiplying by d (which incorporates stm_sign and loss derivative),
-    // the sign flips correctly cancel out exactly. This ensures that the gradient applied to
-    // param_grads[xr] naturally aligns with the STM-relative score evaluation!
-    let w_xray_ortho =
-        (tensor.w_ortho_xray() & b_king_ring).count_ones() as i32 - (tensor.b_ortho_xray() & w_king_ring).count_ones() as i32;
-
-    param_grads[xr] += d * t_mg * w_xray_ortho as f64;
+    // ── Per-term scatter ──
+    //
+    // Each term owns its derivative formula next to its score formula.
+    // Adding a new linear term here is a single call; migrating a term to
+    // a non-linear parameterization (patch 2) swaps the scatter body, not
+    // the dispatch.
+    scatter_mobility_grad(&features.data.metrics_us, &features.data.metrics_them, features.openness, d, t_mg, t_eg, param_grads);
+    scatter_king_safety_grad(&features.data.safety_us, &features.data.safety_them, d, t_mg, param_grads);
+    scatter_xray_grad(features.xray_ortho, d * t_mg, param_grads);
 
     err * err
 }
@@ -610,22 +502,7 @@ pub fn eval_f64_with_acc(board: &Board, values: &[f64]) -> (f64, [f64; 8], [f64;
         w_xray_ortho: values[xr],
     };
 
-    // Build the macroscopic features boundary
-    let openness = soul::engine::mobility::Mobility::compute_openness(board);
-    let pinned_w = board.pinned_pieces(Color::White);
-    let pinned_b = board.pinned_pieces(Color::Black);
-    let tensor = soul::core::board::spatial::SpatialTensor::compute(board, pinned_w.0, pinned_b.0);
-    let data = soul::engine::mobility::Mobility::compute_all(board, Color::White, &tensor, pinned_w, pinned_b);
-
-    let w_ksq = board.pieces(PieceType::King, Color::White).lsb();
-    let b_ksq = board.pieces(PieceType::King, Color::Black).lsb();
-    let w_king_ring = soul::core::board::bitboard::atk_king(w_ksq).0;
-    let b_king_ring = soul::core::board::bitboard::atk_king(b_ksq).0;
-
-    let xray_ortho =
-        (tensor.w_ortho_xray() & b_king_ring).count_ones() as i32 - (tensor.b_ortho_xray() & w_king_ring).count_ones() as i32;
-
-    let features = soul::engine::eval::MacroFeatures { openness, data, xray_ortho };
+    let features = soul::engine::eval::SharedFeatures::compute(board);
 
     (evaluate_generic::<f64>(board, &trace_acc, phase, &params, Some(&features)), trace_acc.0, piece_counts)
 }

--- a/tuner/src/evaltune/tape.rs
+++ b/tuner/src/evaltune/tape.rs
@@ -354,8 +354,8 @@ pub fn eval_dual_fused(board: &Board, values: &[f64], target: f64, k: f64, param
 #[inline]
 pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, param_grads: &mut [f64]) -> f64 {
     use soul::engine::{
+        combiner::{Combiner, LinearCombiner},
         eval::{SharedFeatures, scatter_all_terms},
-        term::{BucketUpstreams, TaperPair},
     };
 
     // ── PSQT + Material accumulator ──
@@ -376,9 +376,7 @@ pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, para
     // NOTE: dJ/dPhaseWeight is intentionally omitted from the gradient
     // scattering process below because the tuner architecture requires
     // the game phase thresholds to be strictly fixed constants.
-    let phase = phase_raw.clamp(0.0, 24.0) as i32;
-    let t_mg = phase as f64 / 24.0;
-    let t_eg = (24.0 - phase as f64) / 24.0;
+    let phase = phase_raw.clamp(0.0, 24.0).trunc();
     let score = eval_f64(board, values);
 
     // ── Sigmoid + loss derivative ──
@@ -399,13 +397,18 @@ pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, para
         psqt::LAYOUT.mobility_open_offset,
     );
 
+    // Combiner owns every upstream derivative. PSQT / material scatter
+    // (out-of-band, accumulator-level) pulls `mg_eg`; term scatter reads
+    // the rest via `scatter_all_terms`.
+    let upstreams = LinearCombiner::backward(phase, d, param_grads);
+
     // ── PSQT + material (out-of-band, not a term) ──
     //
     // Stays in the tape because it lives in the accumulator, not the
     // per-term parameter block. One board sweep writes both PSQT
     // and material gradients for every active piece.
-    let d_mg = d * t_mg;
-    let d_eg = d * t_eg;
+    let d_mg = upstreams.mg_eg.d_mg;
+    let d_eg = upstreams.mg_eg.d_eg;
 
     for piece in PieceType::ALL {
         let pt = piece.as_usize();
@@ -441,12 +444,7 @@ pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, para
         }
     }
 
-    // ── Per-term scatter ──
-    //
-    // `scatter_all_terms` dispatches to every registered `LinearTerm`'s scatter.
-    // Adding a new term = one line in `register_terms!`; the tape is untouched.
-    let upstreams =
-        BucketUpstreams { mg_eg: TaperPair { d_mg, d_eg }, mobility: TaperPair { d_mg, d_eg }, king_safety: d_mg, xray: d_mg };
+    // Adding a new term = one line in `register_terms!`
     scatter_all_terms(&features, &upstreams, param_grads);
 
     err * err

--- a/tuner/src/evaltune/tape.rs
+++ b/tuner/src/evaltune/tape.rs
@@ -101,9 +101,9 @@ fn accumulate_lane_vals(board: &Board, values: &[f64], lane_vals: &mut [f64], pi
 /// Result of a forward-mode dual evaluation.
 ///
 /// Captures the score and raw gradient array from the dual forward pass,
-/// plus the piece locations needed to scatter PSQT gradients. Designed
-/// as a snapshot that can be consumed later once the outer loss derivative
-/// is known.
+/// plus the piece locations needed to scatter PSQT gradients.
+/// Designed as a snapshot that can be consumed later once the outer loss
+/// derivative is known.
 pub struct DualEvalResult {
     pub score: f64,
     /// Raw partial derivatives from the dual pass (29 active slots in 32).
@@ -354,11 +354,12 @@ pub fn eval_dual_fused(board: &Board, values: &[f64], target: f64, k: f64, param
 #[inline]
 pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, param_grads: &mut [f64]) -> f64 {
     use soul::engine::{
-        eval::{SharedFeatures, scatter_xray_grad},
-        mobility::{scatter_king_safety_grad, scatter_mobility_grad},
+        eval::{SharedFeatures, scatter_all_terms},
+        term::{BucketUpstreams, TaperPair},
     };
 
-    // PSQT + Material accumulator (for lane values + PSQT scatter)
+    // ── PSQT + Material accumulator ──
+    // (for lane values + PSQT scatter)
     let mut lane_vals = [0.0f64; 8];
     let mut piece_counts = [0.0f64; 6];
 
@@ -372,16 +373,17 @@ pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, para
         }
     }
 
-    // NOTE: dJ/dPhaseWeight is intentionally omitted from the
-    // gradient scattering process below because the tuner architecture requires
+    // NOTE: dJ/dPhaseWeight is intentionally omitted from the gradient
+    // scattering process below because the tuner architecture requires
     // the game phase thresholds to be strictly fixed constants.
     let phase = phase_raw.clamp(0.0, 24.0) as i32;
     let t_mg = phase as f64 / 24.0;
     let t_eg = (24.0 - phase as f64) / 24.0;
     let score = eval_f64(board, values);
 
-    // Sigmoid + loss derivative. `d` folds the STM sign into the outer
-    // derivative once, so every downstream scatter can stay STM-agnostic.
+    // ── Sigmoid + loss derivative ──
+    // `d` folds the STM sign into the outer derivative once,
+    // so every downstream scatter can stay STM-agnostic.
     let sig = 1.0 / (1.0 + (-k * score).clamp(-700.0, 700.0).exp());
     let err = sig - target;
     let outer = 2.0 * err * sig * (1.0 - sig) * k;
@@ -400,8 +402,8 @@ pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, para
     // ── PSQT + material (out-of-band, not a term) ──
     //
     // Stays in the tape because it lives in the accumulator, not the
-    // per-term parameter block. One board sweep writes both PSQT and
-    // material gradients for every active piece.
+    // per-term parameter block. One board sweep writes both PSQT
+    // and material gradients for every active piece.
     let d_mg = d * t_mg;
     let d_eg = d * t_eg;
 
@@ -441,13 +443,11 @@ pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, para
 
     // ── Per-term scatter ──
     //
-    // Each term owns its derivative formula next to its score formula.
-    // Adding a new linear term here is a single call; migrating a term to
-    // a non-linear parameterization (patch 2) swaps the scatter body, not
-    // the dispatch.
-    scatter_mobility_grad(&features.data.metrics_us, &features.data.metrics_them, features.openness, d, t_mg, t_eg, param_grads);
-    scatter_king_safety_grad(&features.data.safety_us, &features.data.safety_them, d, t_mg, param_grads);
-    scatter_xray_grad(features.xray_ortho, d * t_mg, param_grads);
+    // `scatter_all_terms` dispatches to every registered `LinearTerm`'s scatter.
+    // Adding a new term = one line in `register_terms!`; the tape is untouched.
+    let upstreams =
+        BucketUpstreams { mg_eg: TaperPair { d_mg, d_eg }, mobility: TaperPair { d_mg, d_eg }, king_safety: d_mg, xray: d_mg };
+    scatter_all_terms(&features, &upstreams, param_grads);
 
     err * err
 }


### PR DESCRIPTION
Reorganizes the HCE pipeline around explicit forward/backward symmetry.

Accumulators — a per-bucket score struct (`mg_eg`, `mobility`, `bonus`,
`safety_us`, `safety_them`, `xray`) that eval terms write into directly.

Combiner — collapses buckets into the final score. `forward` runs in search
and the tuner; `backward` produces per-bucket upstream derivatives for the tuner.
Non-linearities (sigmoid king danger, endgame scale, winnable eg) slot in by
swapping `LinearCombiner` without touching any term.

LinearTerm trait + `register_terms!` macro — each eval term owns `apply`
(forward) and `scatter` (analytic backward) in one impl block, co-located with
its score math. Adding a term is one macro line plus the impl, with no edits to
`eval.rs` or `tape.rs`.

Shared `bonus` bucket — a pre-tapered routing target for simple linear
bonuses (bishop pair, rook-on-open, outposts).

Per-term oracle tests — each registered `LinearTerm` is verified in
isolation against the `DualNode` AD oracle, so scatter drift localizes to the
offending term.

Bench: 5022196