### PR TITLE
Just lowering the MTG to much saner values

### DIFF
--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -150,16 +150,16 @@ search_params! {
 
         /// Estimated moves-to-go in opening (phase=24) (ply)
         pub mtg_opening: i32 {
-            default: 280,
+            default:  80,
             min:      40,
             max:     300,
             step:      2,
         },
         /// Estimated moves-to-go in endgame (phase=0) (ply)
         pub mtg_endgame: i32 {
-            default: 100,
+            default:  40,
             min:      10,
-            max:     150,
+            max:     100,
             step:      2,
         },
 


### PR DESCRIPTION
```
Elo   | 32.64 +- 11.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.47, 2.91) [0.00, 5.00]
Games | N: 1580 W: 555 L: 407 D: 618
Penta | [30, 145, 330, 217, 68]
```
https://asylum.red/test/4212/

```
Elo   | 27.15 +- 10.24 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.47, 2.91) [0.00, 5.00]
Games | N: 1808 W: 562 L: 421 D: 825
Penta | [33, 156, 400, 267, 48]
```
https://asylum.red/test/4213/

Bench: 5722768