### PR TITLE
Use 80% of increment for soft budget

### DIFF
--- a/src/engine/tm.rs
+++ b/src/engine/tm.rs
@@ -206,13 +206,16 @@ impl Clock {
     }
 
     /// Soft target: `time / mtg`, capped at `TIME_SOFT_CAP` of the clock,
-    /// plus half the increment as a small bonus, never above `hard_ms`.
+    /// plus 80% of the increment as a bonus — the increment is treated as
+    /// guaranteed refill, so spending it aggressively improves move quality.
+    /// Never above `hard_ms`.
     /// In a classical (movestogo) control, also runs a tightening pass —
     /// see `classical_adjustment`.
     fn soft_ms(&self, mtg: u64, hard_ms: u64) -> u64 {
         let base = (self.time as f64 / mtg as f64) as u64;
         let cap = (self.time as f64 * TIME_SOFT_CAP) as u64;
-        let raw = (base.min(cap) + self.inc / 2).min(hard_ms);
+        let inc_contrib = (self.inc as f64 * 0.8) as u64;
+        let raw = (base.min(cap) + inc_contrib).min(hard_ms);
 
         if self.movestogo > 0 { self.classical_adjustment(raw) } else { raw }
     }


### PR DESCRIPTION
```
Elo   | 17.64 +- 8.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.47, 2.91) [0.00, 5.00]
Games | N: 3154 W: 1021 L: 861 D: 1272
Penta | [80, 329, 639, 409, 120]
```
https://asylum.red/test/4217/

```
Elo   | 16.76 +- 8.03 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.47, 2.91) [0.00, 5.00]
Games | N: 3154 W: 932 L: 780 D: 1442
Penta | [67, 329, 653, 441, 87]
```
https://asylum.red/test/4218/

Bench: 5722768