### PR TITLE
Singular Move Bailout

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -201,6 +201,13 @@ impl<'cfg> Searcher<'cfg> {
 
         let mut last_iter_elapsed = 0;
 
+        // ── Singular Bailout ──
+        // Only one legal move. Slash the budget to 5% so we exit the depth
+        // loop almost instantly, banking the saved time.
+        if self.root_moves.len() == 1 {
+            self.tm.apply_stability_factor(5);
+        }
+
         for depth in 1..=depth_limit {
             self.iter_depth = depth;
 


### PR DESCRIPTION
```
Elo   | -0.20 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.30 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 32980 W: 9874 L: 9893 D: 13213
Penta | [799, 3531, 7891, 3428, 841]
```
https://asylum.red/test/4220/

Bench: 5722768