### PR TITLE
Compose TimeManager soft from per-signal factors

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -205,7 +205,7 @@ impl<'cfg> Searcher<'cfg> {
         // Only one legal move. Slash the budget to 5% so we exit the depth
         // loop almost instantly, banking the saved time.
         if self.root_moves.len() == 1 {
-            self.tm.apply_stability_factor(5);
+            self.tm.set_bm_stab_factor(0.05);
         }
 
         for depth in 1..=depth_limit {
@@ -294,18 +294,23 @@ impl<'cfg> Searcher<'cfg> {
                 let total_nodes = self.nodes.max(1);
                 let effort_discount = sp.bm_stab_scale as u64 * best_nodes / total_nodes;
                 let percent = (sp.bm_stab_base as u64).saturating_sub(effort_discount).max(sp.bm_stab_floor as u64);
-                self.tm.apply_stability_factor(percent as u32);
+                self.tm.set_bm_stab_factor(percent as f64 / 100.0);
             }
 
             // ── Score Drop Extension (~27 Elo) ──
             // A sharp drop from the previous iteration signals instability:
             // a refutation just surfaced, or the best move changed.
             // Stretch the soft budget so this iteration (and possibly one more)
-            // can resolve the swing before we commit. Applied on top of the
-            // stability factor; hard cap still bounds the result.
-            if depth >= sp.score_drop_depth && new_score < self.prev_score - sp.score_drop_cp {
-                self.tm.extend_soft_limit(sp.score_drop_factor as u32);
-            }
+            // can resolve the swing before we commit. The factor composes
+            // multiplicatively with the stability factor; hard cap still
+            // bounds the result. Re-asserted every iteration so a stretch
+            // from the previous one doesn't carry over.
+            let score_factor = if depth >= sp.score_drop_depth && new_score < self.prev_score - sp.score_drop_cp {
+                sp.score_drop_factor as f64 / 100.0
+            } else {
+                1.0
+            };
+            self.tm.set_score_factor(score_factor);
 
             self.prev_pv = *self.root_moves[0].pv;
             self.prev_score = self.root_moves[0].score;

--- a/src/engine/tm.rs
+++ b/src/engine/tm.rs
@@ -27,18 +27,21 @@ pub const TIME_HARD_CAP: f64 = 0.5;
 
 /// Tracks elapsed time against precomputed soft / hard budgets.
 ///
-/// Constructed once at the start of a search; queried from the search loop
-/// to decide when to stop iterating (`soft`) and when to bail mid-search
+/// Constructed once at the start of a search; queried each iteration to
+/// decide when to stop iterating (`soft`) and when to bail mid-search
 /// regardless of progress (`hard`).
+///
+/// Soft is composable: each dynamic signal owns one multiplicative factor.
+/// `soft = base_soft · ∏ factors`, clamped to `hard`. Every setter
+/// recomputes from `base_soft`, so factors never compound across
+/// iterations — adding a new signal is one field plus one setter.
 pub struct TimeManager {
     start: Instant,
     hard: Duration,
     soft: Duration,
-    /// Immutable baseline from the initial budget computation.
-    /// Dynamic scalers are always applied relative to this,
-    /// never to an already-scaled `soft` — so factors don't compound
-    /// across iterations.
     base_soft: Duration,
+    bm_stab: f64,
+    score: f64,
 }
 
 impl TimeManager {
@@ -46,11 +49,10 @@ impl TimeManager {
     ///
     /// `phase` is the current game phase (0 = endgame, `TOTAL_PHASE` = opening)
     /// and feeds the moves-to-go interpolation. `overhead` is shaved off both
-    /// budgets to leave room for I/O and GUI lag — never enough to drop a
-    /// budget below 1 ms.
+    /// budgets to leave room for I/O and GUI lag — never enough to drop a budget below 1 ms.
     pub fn new(limits: &Limits, start: Instant, stm: Color, overhead: u64, phase: i32, params: &SearchParams) -> Self {
         let (soft, hard) = compute_budget(limits, stm, overhead, phase, params);
-        Self { start, soft, hard, base_soft: soft }
+        Self { start, soft, hard, base_soft: soft, bm_stab: 1.0, score: 1.0 }
     }
 
     #[inline]
@@ -78,31 +80,32 @@ impl TimeManager {
         self.start.elapsed()
     }
 
-    /// Stretch the current soft budget by `percent / 100`, clamped to hard.
+    /// Update the best-move-stability factor and refresh `soft`.
     ///
-    /// Called when iterative deepening detects instability that warrants more
-    /// time on this move — e.g. the root score just dropped sharply. The hard
-    /// clamp is the invariant: soft may grow, but never past the clock cap.
+    /// Concentrated root-node effort on one move (high best/total ratio)
+    /// passes a factor below 1 to shrink the budget;
+    /// scattered effort passes a factor above 1 to stretch it.
     #[inline]
-    pub fn extend_soft_limit(&mut self, percent: u32) {
-        let current_ms = self.soft.as_millis() as u64;
-        let extended = Duration::from_millis(current_ms.saturating_mul(percent as u64) / 100);
-        self.soft = extended.min(self.hard);
+    pub fn set_bm_stab_factor(&mut self, factor: f64) {
+        self.bm_stab = factor;
+        self.recompute_soft();
     }
 
-    /// Rescale the soft budget relative to the original baseline.
+    /// Update the score-response factor and refresh `soft`.
     ///
-    ///   `soft = min(base_soft · percent / 100, hard)`
-    ///
-    /// Called once per ID iteration with a factor derived from per-root-move node effort:
-    /// concentrated effort shrinks the budget, scattered effort stretches it.
-    /// Anchoring on `base_soft` (not current `soft`) keeps the factor
-    /// from compounding across iterations.
+    /// Caller picks the factor from this iteration's score change relative
+    /// to the previous one. A factor of 1.0 means no response — pass it to
+    /// clear a stretch from the previous iteration.
     #[inline]
-    pub fn apply_stability_factor(&mut self, percent: u32) {
-        let base_ms = self.base_soft.as_millis() as u64;
-        let scaled = Duration::from_millis(base_ms.saturating_mul(percent as u64) / 100);
-        self.soft = scaled.min(self.hard);
+    pub fn set_score_factor(&mut self, factor: f64) {
+        self.score = factor;
+        self.recompute_soft();
+    }
+
+    #[inline]
+    fn recompute_soft(&mut self) {
+        let scaled = self.base_soft.as_millis() as f64 * self.bm_stab * self.score;
+        self.soft = Duration::from_millis(scaled as u64).min(self.hard);
     }
 }
 


### PR DESCRIPTION
```
Elo   | 1.50 +- 3.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.26 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 12522 W: 3776 L: 3722 D: 5024
Penta | [331, 1227, 3058, 1347, 298]
```
https://asylum.red/test/4231/

Bench: 5722768