### PR TITLE
Correct the mate-horizon blind spot

### DIFF
--- a/src/core/defs.rs
+++ b/src/core/defs.rs
@@ -26,7 +26,7 @@ pub const INF: i32 = 32_000;
 /// Checkmate at the root. Actual mates are scored `MATE - ply_distance`.
 pub const MATE: i32 = 30_000;
 /// Any |score| above this threshold is a forced mate, not merely a large eval.
-pub const MATE_BOUND: i32 = MATE - 100;
+pub const MATE_BOUND: i32 = MATE - MAX_PLY as i32 - 1;
 /// Total game phase material: N=1, B=1, R=2, Q=4 → 2·(1+1+2+4) = 24
 pub const TOTAL_PHASE: i32 = 24;
 /// Middlegame terms


### PR DESCRIPTION
```
Elo   | 6.96 +- 6.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.26 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 4046 W: 1198 L: 1117 D: 1731
Penta | [65, 418, 1000, 451, 89]
```
https://asylum.red/test/4696/

Bench: 5770782