### PR TITLE
Propagate TT pv flag

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -843,7 +843,7 @@ impl Worker {
         // If a previous search already explored it to sufficient depth,
         // we can reuse its result and skip the entire subtree.
         // This is what makes iterative deepening fast — earlier iterations populate the table for later ones.
-        let tt_move = if let Some((mv, score, depth_stored, bound, _pv)) = searcher.tt.probe(self.pos.hash, ply) {
+        let (tt_move, tt_pv) = if let Some((mv, score, depth_stored, bound, pv)) = searcher.tt.probe(self.pos.hash, ply) {
             // Hash collisions can inject moves from unrelated positions.
             // Full pseudo-legality check rejects garbage before it reaches
             // the move picker or triggers a cutoff with a bogus score.
@@ -858,9 +858,10 @@ impl Worker {
                 return Ok(score);
             }
 
-            if valid && !mv.is_null() { Some(mv) } else { None }
+            let tt_move = if valid && !mv.is_null() { Some(mv) } else { None };
+            (tt_move, pv)
         } else {
-            None
+            (None, false)
         };
 
         // ── TT Move Ordering (~56 Elo) ──
@@ -1281,7 +1282,9 @@ impl Worker {
         };
 
         // ── TT store ──
-        searcher.tt.store(self.pos.hash, ply, depth, res.best_eval, res.best_move, bound, N::PV);
+        searcher
+            .tt
+            .store(self.pos.hash, ply, depth, res.best_eval, res.best_move, bound, N::PV || tt_pv);
 
         // ── Correction History Update ──
         // Only learn from positions resolved by quiet moves — tactical

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -181,10 +181,14 @@ impl TranspositionTable {
         entry.key = hash;
 
         let mut store_mv = mv.inner();
-        // Preserve an existing highly-valued move if we hit a beta-cutoff
-        // and the new bound provided an empty (null) move.
+        let mut store_pv = pv as u8;
+        // Preserve an existing highly-valued move if the new store provides
+        // `Move::null()` and the hash matches. The pv flag rides with the
+        // move it describes — losing it would erase the position's
+        // PV-history context.
         if mv.is_null() && is_exact_match {
             store_mv = entry.mv;
+            store_pv |= entry.pv;
         }
 
         entry.mv = store_mv;
@@ -192,7 +196,7 @@ impl TranspositionTable {
         entry.depth = depth as u8;
         entry.bound = bound;
         entry.age = cur;
-        entry.pv = pv as u8;
+        entry.pv = store_pv;
     }
 
     /// Stores a qsearch result (depth = 0).


### PR DESCRIPTION
**1. Overwrite on null-move exact-match.**
`tt.rs:store` preserves an existing high-value move when the caller passes `Move::null()`
and the hash matches — but the `pv` field was still being clobbered by the new (often `false`) value,
erasing the preserved move's PV-history context. Now ORs with the existing flag.
The bit rides with the move it describes.

**2. No propagation across iterations.**
Negamax was storing raw `N::PV` — a compile-time constant per node type.
Reference engines store `PvNode || (ttHit && ttData.is_pv)`, propagating the bit forward through TT hits.
Soul's pv bit decayed to nothing across iterations. Now stores the propagated value.

Non-functional right now; no code reads the `pv` bit. Bench identical, naturally.
Preparation for `tt_pv` carveout work — without these fixes the signal would lie in both subtle and frequent ways.

Bench: 6136983