### PR TITLE
Pass `tt_pv` through qsearch store

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1479,13 +1479,14 @@ impl Worker {
         // sequence for accurate PV reporting.
         //
         // Quiescence TT Move (~9 Elo)
-        let qs_tt_move = if let Some((mv, score, _depth, bound, _pv)) = searcher.tt.probe(self.pos.hash, ply) {
+        let (qs_tt_move, qs_tt_pv) = if let Some((mv, score, _depth, bound, pv)) = searcher.tt.probe(self.pos.hash, ply) {
             if !N::PV && tt::can_cutoff(bound, score, alpha, beta) {
                 return Ok(score);
             }
-            if !mv.is_null() && is_pseudo_legal(&self.pos, mv) { Some(mv) } else { None }
+            let mv = if !mv.is_null() && is_pseudo_legal(&self.pos, mv) { Some(mv) } else { None };
+            (mv, pv)
         } else {
-            None
+            (None, false)
         };
 
         let checkers = self.pos.checkers();
@@ -1611,7 +1612,7 @@ impl Worker {
         } else {
             tt::BOUND_UPPER
         };
-        searcher.tt.store_qs(self.pos.hash, ply, best_eval, best_move, bound, false);
+        searcher.tt.store_qs(self.pos.hash, ply, best_eval, best_move, bound, N::PV || qs_tt_pv);
 
         Ok(best_eval)
     }


### PR DESCRIPTION
Third pv-propagation patch in a row. Should've been one PR; here we are.

#54 propagated `N::PV || tt_pv` in the negamax store.
#55 stopped `store_qs` from clobbering existing pv on key-match.
The piece I missed; the QS caller still passes a literal `false`.
On empty slots or low-quality eviction — paths #55's preserve doesn't cover — the propagated bit dies anyway. Congratulations Aeth.

Same shape as #54: capture `qs_tt_pv` from the probe, store `N::PV || qs_tt_pv`
(N::PV in QS is effectively zero, so it's really just the propagated bit riding through).

Non-functional. Nothing reads it. Bench identical, naturally.
With this, the pv bit actually survives end-to-end.

Bench: 6136983