### PR TITLE
Search tuner; bounds reporter, param-bound DSL, self-play perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ name = "tuner"
 version = "0.2.1"
 dependencies = [
  "clap",
+ "ctrlc",
  "fastrand",
  "parking_lot",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tuner"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,26 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "linkme"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
-dependencies = [
- "linkme-impl",
-]
-
-[[package]]
-name = "linkme-impl"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,11 +416,10 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ctrlc",
  "fastrand",
- "linkme",
  "parking_lot",
  "paste",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.2"
+version = "0.5.3"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]
@@ -41,7 +41,6 @@ zstd = { version = "0.13.3", default-features = false }
 fastrand = "2.4.1"
 ctrlc = "3.5.2"
 zerocopy = { version = "0.8.48", default-features = false, features = ["derive", "simd"] }
-linkme = "0.3.36"
 
 [features]
 searchtune = []

--- a/src/core/defs.rs
+++ b/src/core/defs.rs
@@ -117,7 +117,7 @@ impl Color {
     }
 }
 
-impl const From<u8> for Color {
+const impl From<u8> for Color {
     #[inline(always)]
     fn from(val: u8) -> Self {
         // SAFETY: val & 1 is always 0 or 1 — both valid Color variants.
@@ -125,14 +125,14 @@ impl const From<u8> for Color {
     }
 }
 
-impl const From<Color> for usize {
+const impl From<Color> for usize {
     #[inline(always)]
     fn from(val: Color) -> Self {
         val as usize
     }
 }
 
-impl const Not for Color {
+const impl Not for Color {
     type Output = Self;
 
     #[inline(always)]
@@ -225,7 +225,7 @@ impl PieceType {
     }
 }
 
-impl const From<u8> for PieceType {
+const impl From<u8> for PieceType {
     #[inline(always)]
     fn from(val: u8) -> Self {
         // SAFETY: The engine guarantees that pieces are strictly within 0..=6.
@@ -243,7 +243,7 @@ impl const From<u8> for PieceType {
     }
 }
 
-impl const From<PieceType> for usize {
+const impl From<PieceType> for usize {
     #[inline(always)]
     fn from(val: PieceType) -> Self {
         val as usize
@@ -289,7 +289,7 @@ impl Direction {
     }
 }
 
-impl const From<u8> for Direction {
+const impl From<u8> for Direction {
     #[inline(always)]
     fn from(val: u8) -> Self {
         // SAFETY: val & 7 is 0..=7, matching all eight Direction variants.

--- a/src/core/primitives.rs
+++ b/src/core/primitives.rs
@@ -276,42 +276,42 @@ impl Square {
     }
 }
 
-impl const From<u8> for Square {
+const impl From<u8> for Square {
     #[inline(always)]
     fn from(val: u8) -> Self {
         Self(val)
     }
 }
 
-impl const From<Square> for u8 {
+const impl From<Square> for u8 {
     #[inline(always)]
     fn from(sq: Square) -> Self {
         sq.0
     }
 }
 
-impl const From<Square> for u16 {
+const impl From<Square> for u16 {
     #[inline(always)]
     fn from(sq: Square) -> Self {
         sq.0 as u16
     }
 }
 
-impl const From<Square> for u64 {
+const impl From<Square> for u64 {
     #[inline(always)]
     fn from(sq: Square) -> Self {
         sq.0 as u64
     }
 }
 
-impl const From<Square> for usize {
+const impl From<Square> for usize {
     #[inline(always)]
     fn from(sq: Square) -> Self {
         sq.0 as usize
     }
 }
 
-impl const Shl<Square> for u64 {
+const impl Shl<Square> for u64 {
     type Output = u64;
     #[inline(always)]
     fn shl(self, rhs: Square) -> u64 {
@@ -319,7 +319,7 @@ impl const Shl<Square> for u64 {
     }
 }
 
-impl const Shr<Square> for u64 {
+const impl Shr<Square> for u64 {
     type Output = u64;
     #[inline(always)]
     fn shr(self, rhs: Square) -> u64 {
@@ -355,7 +355,7 @@ impl PartialOrd<Square> for u8 {
     }
 }
 
-impl const BitXor<u8> for Square {
+const impl BitXor<u8> for Square {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: u8) -> Self {
@@ -363,7 +363,7 @@ impl const BitXor<u8> for Square {
     }
 }
 
-impl const BitXor for Square {
+const impl BitXor for Square {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self {
@@ -441,21 +441,21 @@ impl IntoIterator for Bitboard {
     }
 }
 
-impl const From<u64> for Bitboard {
+const impl From<u64> for Bitboard {
     #[inline(always)]
     fn from(val: u64) -> Self {
         Self(val)
     }
 }
 
-impl const From<Bitboard> for u64 {
+const impl From<Bitboard> for u64 {
     #[inline(always)]
     fn from(bb: Bitboard) -> Self {
         bb.0
     }
 }
 
-impl const From<Square> for Bitboard {
+const impl From<Square> for Bitboard {
     /// Converts a square into a bitboard with exactly that bit set.
     #[inline(always)]
     fn from(sq: Square) -> Self {
@@ -465,14 +465,14 @@ impl const From<Square> for Bitboard {
 
 macro_rules! impl_bb_op {
     ($trait:ident, $func:ident, $assign_trait:ident, $assign_func:ident) => {
-        impl const $trait for Bitboard {
+        const impl $trait for Bitboard {
             type Output = Self;
             #[inline(always)]
             fn $func(self, rhs: Self) -> Self {
                 Self(self.0.$func(rhs.0))
             }
         }
-        impl const $trait<u64> for Bitboard {
+        const impl $trait<u64> for Bitboard {
             type Output = Self;
             #[inline(always)]
             fn $func(self, rhs: u64) -> Self {
@@ -498,7 +498,7 @@ impl_bb_op!(BitAnd, bitand, BitAndAssign, bitand_assign);
 impl_bb_op!(BitOr, bitor, BitOrAssign, bitor_assign);
 impl_bb_op!(BitXor, bitxor, BitXorAssign, bitxor_assign);
 
-impl const Not for Bitboard {
+const impl Not for Bitboard {
     type Output = Self;
     #[inline(always)]
     fn not(self) -> Self {
@@ -506,7 +506,7 @@ impl const Not for Bitboard {
     }
 }
 
-impl const Shl<u8> for Bitboard {
+const impl Shl<u8> for Bitboard {
     type Output = Self;
     #[inline(always)]
     fn shl(self, rhs: u8) -> Self {
@@ -514,7 +514,7 @@ impl const Shl<u8> for Bitboard {
     }
 }
 
-impl const Shr<u8> for Bitboard {
+const impl Shr<u8> for Bitboard {
     type Output = Self;
     #[inline(always)]
     fn shr(self, rhs: u8) -> Self {
@@ -522,7 +522,7 @@ impl const Shr<u8> for Bitboard {
     }
 }
 
-impl const Shl<Square> for Bitboard {
+const impl Shl<Square> for Bitboard {
     type Output = Self;
     #[inline(always)]
     fn shl(self, rhs: Square) -> Self {
@@ -530,7 +530,7 @@ impl const Shl<Square> for Bitboard {
     }
 }
 
-impl const Shr<Square> for Bitboard {
+const impl Shr<Square> for Bitboard {
     type Output = Self;
     #[inline(always)]
     fn shr(self, rhs: Square) -> Self {
@@ -538,7 +538,7 @@ impl const Shr<Square> for Bitboard {
     }
 }
 
-impl const Sub for Bitboard {
+const impl Sub for Bitboard {
     type Output = Self;
     #[inline(always)]
     fn sub(self, rhs: Self) -> Self {
@@ -546,7 +546,7 @@ impl const Sub for Bitboard {
     }
 }
 
-impl const Sub<u64> for Bitboard {
+const impl Sub<u64> for Bitboard {
     type Output = Self;
     #[inline(always)]
     fn sub(self, rhs: u64) -> Self {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1051,7 +1051,7 @@ impl Worker<'_> {
 
             // Interior: staged move generation via MovePicker.
             let mut picker = MovePicker::new(hash_move, searcher.cfg, self.stack[ply].killers, cont1, cont2, cont4);
-            while let Some(mv) = picker.next(&self.pos, &self.history) {
+            while let Some(mv) = picker.next(&self.pos, self.history) {
                 if !is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
                     continue;
                 }
@@ -1533,7 +1533,7 @@ impl Worker<'_> {
 
         let recapture_only = !in_check && qs_ply >= qs_recapture_ply();
 
-        while let Some(mv) = picker.next(&self.pos, &self.history) {
+        while let Some(mv) = picker.next(&self.pos, self.history) {
             if !is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
                 continue;
             }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -436,7 +436,7 @@ impl<'cfg> Searcher<'cfg> {
         // Only one legal move. Slash the budget to 5% so we exit the depth
         // loop almost instantly, banking the saved time.
         if self.root_moves.len() == 1 {
-            self.tm.set_bm_stab_factor(0.05);
+            self.tm.set_bm_stab_factor(tm_single_root() as f64 / 100.0);
         }
 
         for depth in 1..=depth_limit {
@@ -455,7 +455,7 @@ impl<'cfg> Searcher<'cfg> {
             // so if we can't afford that estimate we stop before starting it.
             if depth > 1
                 && (elapsed >= self.tm.soft_limit().as_millis() as u64
-                    || elapsed + (prev_depth_time * 2) > self.tm.hard_limit().as_millis() as u64
+                    || elapsed + (prev_depth_time * tm_iter_scale() as u64 / 100) > self.tm.hard_limit().as_millis() as u64
                     || (self.cfg.limits.softnodes > 0 && self.nodes >= self.cfg.limits.softnodes))
             {
                 break;
@@ -467,8 +467,8 @@ impl<'cfg> Searcher<'cfg> {
 
             // ── Aspiration Windows (~42 Elo) ──
             let mut delta = asp_initial();
-            let mut alpha = if depth >= 4 { (self.prev_score - delta).max(-INF) } else { -INF };
-            let mut beta = if depth >= 4 { (self.prev_score + delta).min(INF) } else { INF };
+            let mut alpha = if depth >= asp_depth() { (self.prev_score - delta).max(-INF) } else { -INF };
+            let mut beta = if depth >= asp_depth() { (self.prev_score + delta).min(INF) } else { INF };
 
             let mut aborted = false;
             loop {
@@ -490,7 +490,7 @@ impl<'cfg> Searcher<'cfg> {
                     break;
                 }
 
-                delta += delta / 3;
+                delta += delta / asp_widen_div();
             }
 
             if aborted {
@@ -540,7 +540,7 @@ impl<'cfg> Searcher<'cfg> {
             // in [0.5, 2.0]. Gated below `score_drop_depth` because aspiration
             // churn at low depth produces noise, not signal.
             let score_factor = if depth >= score_drop_depth() {
-                let scale = score_factor_scale() as f64;
+                let scale = score_swing_scale() as f64;
                 let diff = ((self.prev_score - new_score) as f64).clamp(-scale, scale);
                 2.0_f64.powf(diff / scale)
             } else {
@@ -952,15 +952,16 @@ impl Worker {
             self.stack[ply + 1].is_null = true;
             let undo = self.pos.make_null_move();
             searcher.zobrist_trail.push(self.pos.hash);
-            let score = match self.negamax::<NonPvNode>(searcher, (depth - r - 1).max(0), -beta, -beta + 1, ply + 1, None) {
-                Ok(v) => -v,
-                Err(e) => {
-                    searcher.zobrist_trail.pop();
-                    self.pos.unmake_null_move(&undo);
-                    self.stack[ply + 1].is_null = false;
-                    return Err(e);
-                },
-            };
+            let score =
+                match self.negamax::<NonPvNode>(searcher, (depth - r - nmp_ply_offset()).max(0), -beta, -beta + 1, ply + 1, None) {
+                    Ok(v) => -v,
+                    Err(e) => {
+                        searcher.zobrist_trail.pop();
+                        self.pos.unmake_null_move(&undo);
+                        self.stack[ply + 1].is_null = false;
+                        return Err(e);
+                    },
+                };
             searcher.zobrist_trail.pop();
             self.pos.unmake_null_move(&undo);
             self.stack[ply + 1].is_null = false;
@@ -980,7 +981,7 @@ impl Worker {
                 }
 
                 self.is_nmp_verif = true;
-                let verif = self.negamax::<NonPvNode>(searcher, (depth - r - 1).max(0), beta - 1, beta, ply, None);
+                let verif = self.negamax::<NonPvNode>(searcher, (depth - r - nmp_ply_offset()).max(0), beta - 1, beta, ply, None);
                 self.is_nmp_verif = false;
 
                 if verif? >= beta {
@@ -994,7 +995,7 @@ impl Worker {
         // that, guesses. Reduce by one ply to acknowledge the uncertainty
         // and avoid investing full depth into an unguided search.
         // The next iteration will have a TT move and do it properly.
-        let depth = if depth >= 4 && tt_move.is_none() { depth - 1 } else { depth };
+        let depth = if depth >= iir_depth() && tt_move.is_none() { depth - iir_reduction() } else { depth };
 
         // ──────── Move loop ────────
 
@@ -1170,11 +1171,11 @@ impl Worker {
                     let hist = self.history.score_quiet(self.pos.stm, pt, mv.from(), mv.to(), cont1, cont2, cont4);
 
                     if mv == self.stack[ply].killers[0] || mv == self.stack[ply].killers[1] {
-                        r -= LMR_SCALE;
+                        r -= killer_lmr_bonus();
                     }
 
-                    let max_r = (depth - 1) * LMR_SCALE;
-                    (r - hist / 8).clamp(0, max_r) / LMR_SCALE
+                    let max_r = (depth - lmr_retained()) * LMR_SCALE;
+                    (r - hist / lmr_hist_div()).clamp(0, max_r) / LMR_SCALE
                 } else {
                     0
                 };
@@ -1195,7 +1196,7 @@ impl Worker {
                     // scaled 4x and capped at 1600 to push entries toward the
                     // nominal ±16384 attractor without a single deep search
                     // permanently dominating the history table.
-                    let bonus = (depth.pow(2) * 4).min(1600);
+                    let bonus = (depth.pow(2) * hist_bonus_mult()).min(hist_bonus_cap());
 
                     // Only reward if the cutoff itself was caused by a quiet move.
                     // Captures and structural moves (castling) are handled differently.
@@ -1333,7 +1334,7 @@ impl Worker {
         // but to respond. Don't reduce it as aggressively; give it a bit more
         // depth so the resulting tactics are properly resolved.
         if self.pos.checkers().is_not_empty() {
-            reduction = (reduction - 1).max(0);
+            reduction = (reduction - check_lmr_bonus()).max(0);
         }
 
         res.move_count += 1;

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -136,16 +136,15 @@ pub struct Searcher<'cfg> {
     pub iter_depth: i32,
     pub last_print: u128,
     pub pv_history: VecDeque<(u128, Line, i32)>,
-    pub history_table: History,
     pub tt: Arc<TranspositionTable>,
 }
 
 #[repr(align(32))]
-pub struct Worker {
+pub struct Worker<'h> {
     pub pos: Position,
     pub accumulator: Vi16x8,
     pub stack: Box<[Stack; MAX_PLY + 1]>,
-    pub history: History,
+    pub history: &'h mut History,
     /// Set while a null-move verification search is on the stack.
     /// Suppresses nested NMP, which would otherwise recurse forever on
     /// the same position at ever-shrinking depth.
@@ -379,7 +378,7 @@ impl<'cfg> Searcher<'cfg> {
     ///   2. Natural anytime algorithm: always have a best move ready from the
     ///      last completed iteration.
     #[inline]
-    pub fn iterative_deepening(&mut self) -> History {
+    pub fn iterative_deepening(&mut self, history: &mut History) {
         self.nodes = 0;
 
         if self.cfg.display.go_pretty && self.cfg.limits.protocol == Protocol::Uci {
@@ -391,14 +390,14 @@ impl<'cfg> Searcher<'cfg> {
             let mut board = self.root_pos;
             let mut acc = board.get_initial_accumulator();
             println!("Nodes searched: {}", perft(&mut board, perft_depth, &mut acc));
-            return self.history_table.clone();
+            return;
         }
 
         if self.root_moves.is_empty() {
             if !self.cfg.limits.silent {
                 println!("bestmove 0000");
             }
-            return self.history_table.clone();
+            return;
         }
 
         if !self.cfg.limits.searchmoves.is_empty() {
@@ -408,7 +407,7 @@ impl<'cfg> Searcher<'cfg> {
                 if !self.cfg.limits.silent {
                     println!("bestmove 0000");
                 }
-                return self.history_table.clone();
+                return;
             }
         }
 
@@ -426,7 +425,7 @@ impl<'cfg> Searcher<'cfg> {
                 .into_boxed_slice()
                 .try_into()
                 .unwrap_or_else(|_| unreachable!()),
-            history: self.history_table.clone(),
+            history,
             is_nmp_verif: false,
         };
 
@@ -577,18 +576,10 @@ impl<'cfg> Searcher<'cfg> {
             }
             let _ = io::stdout().flush();
         }
-
-        worker.history
     }
 
     #[inline]
-    pub fn new(
-        cfg: &'cfg SearchConfig,
-        pos: &Position,
-        history: &[u64],
-        history_table: History,
-        tt: Arc<TranspositionTable>,
-    ) -> Self {
+    pub fn new(cfg: &'cfg SearchConfig, pos: &Position, history: &[u64], tt: Arc<TranspositionTable>) -> Self {
         let phase = i32::from(pos.get_initial_accumulator().to_array()[2]);
         let tm =
             TimeManager::new(&cfg.limits, cfg.start_time, pos.stm, cfg.overhead, phase, history.len() as u64, &cfg.search_params);
@@ -621,12 +612,11 @@ impl<'cfg> Searcher<'cfg> {
             sel_depth: 0,
             iter_depth: 0,
             last_print: 0,
-            history_table,
             tt,
         }
     }
 
-    /// Per-move reset. Keeps `history_table` — clear it between games via [`Self::clear_history`].
+    /// Per-move reset. History lives at the caller; clear it between games via `History::clear`.
     #[inline]
     pub fn reset(&mut self, cfg: &'cfg SearchConfig, pos: &Position, history: &[u64]) {
         let phase = i32::from(pos.get_initial_accumulator().to_array()[2]);
@@ -653,12 +643,6 @@ impl<'cfg> Searcher<'cfg> {
         self.pv_history.clear();
         self.prev_score = -INF;
         self.prev_pv = Line::new();
-    }
-
-    /// Zero the history table in place.
-    #[inline]
-    pub fn clear_history(&mut self) {
-        self.history_table.clear();
     }
 
     #[inline]
@@ -779,7 +763,7 @@ impl<'cfg> Searcher<'cfg> {
     }
 }
 
-impl Worker {
+impl Worker<'_> {
     /// Negamax with alpha-beta pruning. Since chess is zero-sum, we maximize the
     /// score from the current side's perspective at every node, negating the score
     /// as it returns up the tree.

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -626,8 +626,9 @@ impl<'cfg> Searcher<'cfg> {
         }
     }
 
+    /// Per-move reset. Keeps `history_table` — clear it between games via [`Self::clear_history`].
     #[inline]
-    pub fn reset(&mut self, cfg: &'cfg SearchConfig, pos: &Position, history: &[u64], history_table: History) {
+    pub fn reset(&mut self, cfg: &'cfg SearchConfig, pos: &Position, history: &[u64]) {
         let phase = i32::from(pos.get_initial_accumulator().to_array()[2]);
 
         self.zobrist_trail.clear();
@@ -650,9 +651,14 @@ impl<'cfg> Searcher<'cfg> {
         self.iter_depth = 0;
         self.last_print = 0;
         self.pv_history.clear();
-        self.history_table = history_table;
         self.prev_score = -INF;
         self.prev_pv = Line::new();
+    }
+
+    /// Zero the history table in place.
+    #[inline]
+    pub fn clear_history(&mut self) {
+        self.history_table.clear();
     }
 
     #[inline]

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -1,14 +1,22 @@
 //! Search-specific tunable parameters.
 //!
-//! One line per parameter generates: a struct field, a `pub fn` accessor,
-//! and a `linkme` distributed slice entry for CMA-ES iteration.
+//! Each entry generates a struct field, a `pub fn` accessor, and a
+//! `PARAM_DEFS` slice entry in declaration order — the tuner shows and
+//! iterates params in the order they appear in this file.
 //!
-//! Callers `use crate::engine::search_params::*;` for zero-prefix access
-//! like `rfp_margin()`.
+//! Entry forms:
+//!
+//!   `T (name, default)`                      tune; auto-derive bounds + step
+//!   `T (name, default, min)`                 tune; explicit min, auto max + step
+//!   `T (name, default, min, max)`            tune; explicit bounds, auto step
+//!   `T (name, default, min, max, step)`      tune; fully explicit
+//!   `NT(name, default)`                      frozen; auto-derive still applies but tuner skips
+//!
+//! Auto-derive: `min = 0`, `max = default + default/2 + 10`, `step = max/20` (≥ 1).
+//!
+//! Callers `use crate::engine::search_params::*;` for zero-prefix accessors like `rfp_margin()`.
 
 use std::sync::atomic::{AtomicI32, Ordering};
-
-use linkme::distributed_slice;
 
 /// Metadata + live value pointer for one tunable parameter.
 #[derive(Debug)]
@@ -19,6 +27,8 @@ pub struct ParamDef {
     pub max: f64,
     pub step: f64,
     pub default: f64,
+    /// Tuner skips frozen entries when assembling the search vector.
+    pub frozen: bool,
 }
 
 impl ParamDef {
@@ -30,10 +40,13 @@ impl ParamDef {
     }
 
     /// Denormalize a `[0, 1]` value back to the parameter's range.
+    /// Snap grid is anchored at `min` so both endpoints round-trip exactly,
+    /// then clamped to `[min, max]` against any drift from the rounding.
     #[inline]
     pub fn denormalize(&self, normalized: f64) -> f64 {
         let val = normalized.mul_add(self.max - self.min, self.min);
-        if self.step > 1e-9 { (val / self.step).round() * self.step } else { val }
+        let snapped = if self.step > 1e-9 { self.min + ((val - self.min) / self.step).round() * self.step } else { val };
+        snapped.clamp(self.min, self.max)
     }
 
     #[inline]
@@ -47,135 +60,265 @@ impl ParamDef {
     }
 }
 
+/// Default-derived upper bound; symmetric around 1.5× magnitude with a floor.
+pub const fn auto_max(default: i32) -> i32 {
+    let abs_d = if default < 0 { -default } else { default };
+    abs_d + 10 + abs_d / 2
+}
+
+/// Default-derived step. Floor of 1 prevents zero-step on tiny defaults.
+pub const fn auto_step(max: i32) -> i32 {
+    let s = max / 20;
+    if s < 1 { 1 } else { s }
+}
+
 macro_rules! search_params {
-    (
-        pub struct $struct_name:ident {
-            $(
-                $(#[doc = $doc:expr])*
-                pub $field:ident: $type:ty = $default:literal, min $min:literal, max $max:literal, step $step:literal
-            ),* $(,)?
-        }
-    ) => {
+    ( pub struct $name:ident { $($body:tt)* } ) => {
+        search_params!(@collect [$name] [] $($body)*);
+    };
+
+    // Final emit
+    (@collect [$name:ident] [$($entries:tt)*]) => {
+        search_params!(@emit $name [$($entries)*]);
+    };
+
+    // T(name, default) — auto bounds + step
+    (@collect [$name:ident] [$($entries:tt)*] T($field:ident, $def:literal) , $($rest:tt)*) => {
+        search_params!(@collect [$name] [$($entries)*
+            ($field, $def, 0, $crate::engine::search_params::auto_max($def),
+             $crate::engine::search_params::auto_step($crate::engine::search_params::auto_max($def)), false)
+        ] $($rest)*);
+    };
+
+    // T(name, default, min) — auto max + step
+    (@collect [$name:ident] [$($entries:tt)*] T($field:ident, $def:literal, $min:literal) , $($rest:tt)*) => {
+        search_params!(@collect [$name] [$($entries)*
+            ($field, $def, $min, $crate::engine::search_params::auto_max($def),
+             $crate::engine::search_params::auto_step($crate::engine::search_params::auto_max($def) - $min), false)
+        ] $($rest)*);
+    };
+
+    // NT(name, default, min) — auto max + step
+    (@collect [$name:ident] [$($entries:tt)*] NT($field:ident, $def:literal, $min:literal) , $($rest:tt)*) => {
+        search_params!(@collect [$name] [$($entries)*
+            ($field, $def, $min, $crate::engine::search_params::auto_max($def),
+             $crate::engine::search_params::auto_step($crate::engine::search_params::auto_max($def) - $min), true)
+        ] $($rest)*);
+    };
+
+    // T(name, default, min, max) — auto step
+    (@collect [$name:ident] [$($entries:tt)*] T($field:ident, $def:literal, $min:literal, $max:literal) , $($rest:tt)*) => {
+        search_params!(@collect [$name] [$($entries)*
+            ($field, $def, $min, $max, $crate::engine::search_params::auto_step($max - $min), false)
+        ] $($rest)*);
+    };
+
+    // T(name, default, min, max, step) — fully explicit
+    (@collect [$name:ident] [$($entries:tt)*] T($field:ident, $def:literal, $min:literal, $max:literal, $step:literal) , $($rest:tt)*) => {
+        search_params!(@collect [$name] [$($entries)*
+            ($field, $def, $min, $max, $step, false)
+        ] $($rest)*);
+    };
+
+    // NT(name, default) — frozen, auto bounds
+    (@collect [$name:ident] [$($entries:tt)*] NT($field:ident, $def:literal) , $($rest:tt)*) => {
+        search_params!(@collect [$name] [$($entries)*
+            ($field, $def, 0, $crate::engine::search_params::auto_max($def),
+             $crate::engine::search_params::auto_step($crate::engine::search_params::auto_max($def)), true)
+        ] $($rest)*);
+    };
+
+    // NT(name, default, min, max)
+    (@collect [$name:ident] [$($entries:tt)*] NT($field:ident, $def:literal, $min:literal, $max:literal) , $($rest:tt)*) => {
+        search_params!(@collect [$name] [$($entries)*
+            ($field, $def, $min, $max, $crate::engine::search_params::auto_step($max - $min), true)
+        ] $($rest)*);
+    };
+
+    // NT(name, default, min, max, step)
+    (@collect [$name:ident] [$($entries:tt)*] NT($field:ident, $def:literal, $min:literal, $max:literal, $step:literal) , $($rest:tt)*) => {
+        search_params!(@collect [$name] [$($entries)*
+            ($field, $def, $min, $max, $step, true)
+        ] $($rest)*);
+    };
+
+    (@emit $name:ident [$( ($field:ident, $def:literal, $min:expr, $max:expr, $step:expr, $frozen:expr) )*]) => {
         #[derive(Clone, Copy, Debug)]
-        pub struct $struct_name {
-            $(
-                $(#[doc = $doc])*
-                pub $field: $type,
-            )*
+        pub struct $name {
+            $( pub $field: i32, )*
         }
 
-        impl Default for $struct_name {
+        impl Default for $name {
             fn default() -> Self {
-                Self { $($field: $default,)* }
+                Self { $( $field: $def, )* }
             }
         }
 
         $(
             paste::paste! {
                 #[allow(non_upper_case_globals)]
-                static [<__VAL_ $field>]: AtomicI32 = AtomicI32::new($default as i32);
+                static [<__VAL_ $field>]: AtomicI32 = AtomicI32::new($def);
 
-                $(#[doc = $doc])*
                 #[inline(always)]
                 pub fn $field() -> i32 {
                     [<__VAL_ $field>].load(Ordering::Relaxed)
                 }
+            }
+        )*
 
-                #[allow(non_upper_case_globals)]
-                #[distributed_slice(PARAM_DEFS)]
-                static [<__REG_ $field>]: ParamDef = ParamDef {
+        /// All registered params in source-declaration order, frozen + tunable mixed.
+        /// Use [`tunable_param_defs`] when the tuner only needs the active set.
+        pub static PARAM_DEFS: &[ParamDef] = &[
+            $( paste::paste! {
+                ParamDef {
                     name: stringify!($field),
                     value: &[<__VAL_ $field>],
                     min: $min as f64,
                     max: $max as f64,
                     step: $step as f64,
-                    default: $default as f64,
-                };
-            }
-        )*
+                    default: $def as f64,
+                    frozen: $frozen,
+                }
+            } ),*
+        ];
 
-        #[distributed_slice]
-        pub static PARAM_DEFS: [ParamDef] = [..];
-
-        pub fn flush_into(sp: &$struct_name) {
-            $( paste::paste! { [<__VAL_ $field>].store(sp.$field as i32, Ordering::Relaxed); } )*
+        pub fn flush_into(sp: &$name) {
+            $( paste::paste! { [<__VAL_ $field>].store(sp.$field, Ordering::Relaxed); } )*
         }
 
-        pub fn collect_as() -> $struct_name {
-            let mut sp = $struct_name::default();
+        pub fn collect_as() -> $name {
+            let mut sp = $name::default();
             $( paste::paste! { sp.$field = [<__VAL_ $field>].load(Ordering::Relaxed); } )*
             sp
         }
 
-        impl $struct_name {
+        impl $name {
             pub fn from_normalized(values: &[f64]) -> Self {
-                for (def, &norm) in PARAM_DEFS.iter().zip(values) {
+                for (def, &norm) in tunable_param_defs().iter().zip(values) {
                     def.write(def.denormalize(norm).round() as i32);
                 }
                 collect_as()
             }
 
             pub fn to_normalized() -> Vec<f64> {
-                PARAM_DEFS.iter().map(|def| def.normalize(def.read() as f64)).collect()
+                tunable_param_defs().iter().map(|def| def.normalize(def.read() as f64)).collect()
             }
         }
     };
 }
 
+/// Active tunable params (frozen entries filtered out) in source-declaration order.
+/// Tuner uses this as the canonical view; `PARAM_DEFS` is the unfiltered list.
+pub fn tunable_param_defs() -> Vec<&'static ParamDef> {
+    PARAM_DEFS.iter().filter(|p| !p.frozen).collect()
+}
+
 search_params! {
     pub struct SearchParams {
-        pub lazy_eval_margin:      i32 = 160,   min 60,   max 200,   step 2,
-        pub lazy_eval_divisor:     i32 = 32,    min 8,    max 128,   step 1,
-        pub mtg_opening:           i32 = 80,    min 40,   max 300,   step 2,
-        pub mtg_endgame:           i32 = 40,    min 10,   max 100,   step 2,
-        pub vol_pawn:              i32 = 5,     min 0,    max 15,    step 1,
-        pub vol_knight:            i32 = 10,    min 0,    max 15,    step 1,
-        pub vol_bishop:            i32 = 9,     min 0,    max 10,    step 1,
-        pub vol_rook:              i32 = 5,     min 0,    max 10,    step 1,
-        pub vol_queen:             i32 = 13,    min 0,    max 15,    step 1,
-        pub vol_king:              i32 = 0,     min 0,    max 5,     step 1,
-        pub nmp_base_r:            i32 = 3,     min 2,    max 5,     step 1,
-        pub nmp_depth_divisor:     i32 = 3,     min 2,    max 6,     step 1,
-        pub nmp_eval_divisor:      i32 = 200,   min 50,   max 400,   step 10,
-        pub nmp_eval_max:          i32 = 3,     min 1,    max 5,     step 1,
-        pub nmp_verif_min_depth:   i32 = 14,    min 6,    max 20,    step 1,
-        pub lmr_base:              i32 = 100,   min 50,   max 200,   step 5,
-        pub lmr_divisor:           i32 = 225,   min 150,  max 350,   step 5,
-        pub asp_initial:           i32 = 15,    min 8,    max 50,    step 1,
-        pub rfp_margin:            i32 = 45,    min 30,   max 150,   step 5,
-        pub rfp_depth:             i32 = 8,     min 3,    max 10,    step 1,
-        pub lmp_base:              i32 = 2,     min 1,    max 6,     step 1,
-        pub lmp_depth:             i32 = 5,     min 2,    max 8,     step 1,
-        pub hist_prune_depth:      i32 = 6,     min 2,    max 10,    step 1,
-        pub hist_prune_margin:     i32 = 3000,  min 500,  max 4000,  step 100,
-        pub fp_margin:             i32 = 100,   min 50,   max 300,   step 5,
-        pub fp_depth:              i32 = 6,     min 1,    max 8,     step 1,
-        pub razoring_margin:       i32 = 300,   min 100,  max 600,   step 10,
-        pub razoring_depth:        i32 = 3,     min 1,    max 5,     step 1,
-        pub delta_margin:          i32 = 200,   min 50,   max 400,   step 10,
-        pub qs_recapture_ply:      i32 = 4,     min 2,    max 10,    step 1,
-        pub see_capture_margin:    i32 = 80,    min 20,   max 200,   step 2,
-        pub see_quiet_margin:      i32 = 60,    min 15,   max 150,   step 2,
-        pub mvvlva_ep:             i32 = 100,   min 50,   max 200,   step 10,
-        pub mvvlva_v_pawn:         i32 = 100,   min 50,   max 200,   step 2,
-        pub mvvlva_v_knight:       i32 = 300,   min 100,  max 600,   step 5,
-        pub mvvlva_v_bishop:       i32 = 300,   min 100,  max 600,   step 5,
-        pub mvvlva_v_rook:         i32 = 500,   min 200,  max 1000,  step 5,
-        pub mvvlva_v_queen:        i32 = 900,   min 400,  max 1800,  step 10,
-        pub mvvlva_v_king:         i32 = 10000, min 5000, max 20000, step 100,
-        pub mvvlva_a_pawn:         i32 = 10,    min 0,    max 50,    step 1,
-        pub mvvlva_a_knight:       i32 = 30,    min 0,    max 100,   step 1,
-        pub mvvlva_a_bishop:       i32 = 30,    min 0,    max 100,   step 1,
-        pub mvvlva_a_rook:         i32 = 50,    min 0,    max 200,   step 2,
-        pub mvvlva_a_queen:        i32 = 90,    min 0,    max 300,   step 2,
-        pub mvvlva_a_king:         i32 = 0,     min 0,    max 0,     step 0,
-        pub capt_hist_divisor:     i32 = 32,    min 8,    max 256,   step 8,
-        pub score_drop_depth:      i32 = 5,     min 3,    max 10,    step 1,
-        pub score_factor_scale:    i32 = 100,   min 40,   max 200,   step 4,
-        pub bm_stab_depth:         i32 = 5,     min 3,    max 10,    step 1,
-        pub bm_stab_base:          i32 = 270,   min 150,  max 400,   step 5,
-        pub bm_stab_scale:         i32 = 220,   min 100,  max 350,   step 5,
-        pub bm_stab_floor:         i32 = 56,    min 30,   max 96,    step 2,
-        pub np_corr_weight:        i32 = 128,   min 0,    max 512,   step 8,
+        //            default   min  max  step
+        NT(asp_depth,       4,   1,    6),
+        T (asp_initial,    15,   1,   32),
+        T (asp_widen_div,   3,   1,   14),
+
+        //                default   min  max  step
+        T (lazy_eval_margin,  160,  140, 300),
+        T (lazy_eval_divisor,  32,    1,  64),
+
+        //         default   min  max  step
+        NT(vol_pawn,     5),
+        NT(vol_knight,  10),
+        NT(vol_bishop,   9),
+        NT(vol_rook,     5),
+        NT(vol_queen,   13),
+        NT(vol_king,     0),
+
+        //              default   min  max  step
+        NT(mtg_opening,      80),
+        NT(mtg_endgame,      40),
+        NT(tm_iter_scale,   200),
+        NT(tm_single_root,    5),
+
+        //                 default min  max  step
+        NT(score_drop_depth,     5),
+        T (score_swing_scale,  100, 10),
+
+        //             default   min  max  step
+        NT(bm_stab_depth,    5),
+        NT(bm_stab_base,   270),
+        NT(bm_stab_scale,  220),
+        NT(bm_stab_floor,   56),
+
+        //                default  min   max  step
+        NT(mvvlva_ep,         100,  60,  150),
+        NT(mvvlva_v_pawn,     100,  60,  150),
+        NT(mvvlva_v_knight,   300, 200,  350),
+        NT(mvvlva_v_bishop,   300, 200,  350),
+        NT(mvvlva_v_rook,     500, 400,  600),
+        NT(mvvlva_v_queen,    900, 700, 1100),
+        NT(mvvlva_v_king,   10000),
+        NT(mvvlva_a_pawn,      10,   0,   20),
+        NT(mvvlva_a_knight,    30,  20,   60),
+        NT(mvvlva_a_bishop,    30,  20,   60),
+        NT(mvvlva_a_rook,      50,  40,  100),
+        NT(mvvlva_a_queen,     90,  70,  150),
+        NT(mvvlva_a_king,       0),
+
+        //             default  min  max  step
+        T (qs_recapture_ply, 4,   2),
+
+        //            default  min  max  step
+        T (delta_margin,  200,  50),
+
+        //                 default min  max  step
+        T (see_capture_margin,  80,  1),
+        T (see_quiet_margin,    60,  1),
+
+        //              default  min  max  step
+        NT(razoring_depth,    3),
+        T (razoring_margin, 300,  50),
+
+        //         default  min  max  step
+        NT(rfp_depth,    8),
+        T (rfp_margin,  45,  15),
+
+        //                  default min   max  step
+        T (nmp_base_r,            3,  1,    6),
+        T (nmp_depth_divisor,     3,  1,   14),
+        T (nmp_eval_divisor,    200,  1,  320),
+        T (nmp_eval_max,          3,  1,    6),
+        NT(nmp_ply_offset,        1),
+        NT(nmp_verif_min_depth,  14),
+
+        //           default min  max  step
+        NT(iir_depth,      4),
+        T (iir_reduction,  1,  1,  3),
+
+        //        default min  max  step
+        NT(fp_depth,    6),
+        T (fp_margin, 100, 25),
+
+        //        default min  max  step
+        NT(lmp_depth,   5),
+        T (lmp_base,    2,  1,  6),
+
+        //                 default   min  max  step
+        NT(hist_prune_depth,     6),
+        T (hist_prune_margin, 3000,  100),
+
+        //                default   min  max  step
+        T (lmr_base,          100,  10),
+        T (lmr_divisor,       225,   1,  350),
+        T (lmr_hist_div,        8,   1,   24),
+        T (killer_lmr_bonus, 1024,  64),
+        T (check_lmr_bonus,     1,   1,    3),
+        NT(lmr_retained,        1),
+
+        //                default   min  max  step
+        NT(capt_hist_divisor,  32),
+        NT(hist_bonus_mult,     4),
+        NT(hist_bonus_cap,   1600),
+
+        //             default min  max  step
+        T (np_corr_weight, 128,  8),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,8 +82,9 @@ fn main() {
                 let display =
                     SearchDisplay { show_wdl: true, go_pretty: true, pretty_print: false, show_currmove: true, use_ansi: true };
                 let cfg = SearchConfig::new_full(limits, Instant::now(), stop, 0, display, SearchParams::default());
-                let mut searcher = Searcher::new(&cfg, &board, &[], History::new(), Arc::new(TranspositionTable::new(16)));
-                searcher.iterative_deepening();
+                let mut history_table = History::new();
+                let mut searcher = Searcher::new(&cfg, &board, &[], Arc::new(TranspositionTable::new(16)));
+                searcher.iterative_deepening(&mut history_table);
                 if let Some(best_move) = searcher.best_move() {
                     println!("bestmove {}", best_move.to_uci(board.is_frc));
                 }

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -97,11 +97,11 @@ impl UciState {
         thread::spawn(move || {
             while let Ok(cmd) = rx.recv() {
                 match cmd {
-                    SearchCommand::Go(cfg, board, history, history_table, tt, result_tx) => {
-                        let mut ctx = Searcher::new(&cfg, &board, &history, history_table, tt);
-                        let final_history = ctx.iterative_deepening();
+                    SearchCommand::Go(cfg, board, history, mut history_table, tt, result_tx) => {
+                        let mut ctx = Searcher::new(&cfg, &board, &history, tt);
+                        ctx.iterative_deepening(&mut history_table);
                         is_searching_worker.store(false, Ordering::Release);
-                        let _ = result_tx.send(final_history);
+                        let _ = result_tx.send(history_table);
                     },
                     SearchCommand::Quit => break,
                 }

--- a/src/protocols/xboard.rs
+++ b/src/protocols/xboard.rs
@@ -137,16 +137,16 @@ impl XBoardState {
         let overhead = self.overhead;
         let show_wdl = self.show_wdl;
         let history_arc = Arc::clone(&self.persistent_history);
-        let persistent_history = history_arc.lock().clone();
+        let mut persistent_history = history_arc.lock().clone();
 
         let tt = self.tt.clone();
 
         self.search_thread = Some(thread::spawn(move || {
             let display = SearchDisplay { show_wdl, ..SearchDisplay::DEFAULT };
             let cfg = SearchConfig::new_full(limits, Instant::now(), stop, overhead, display, SearchParams::default());
-            let mut ctx = Searcher::new(&cfg, &board, &history, persistent_history, tt);
-            let final_history = ctx.iterative_deepening();
-            *history_arc.lock() = final_history;
+            let mut ctx = Searcher::new(&cfg, &board, &history, tt);
+            ctx.iterative_deepening(&mut persistent_history);
+            *history_arc.lock() = persistent_history;
         }));
     }
 }

--- a/src/tools/bench.rs
+++ b/src/tools/bench.rs
@@ -42,8 +42,9 @@ pub fn run(depth: i32) {
         io::stdout().flush().ok();
 
         let cfg = SearchConfig::new(limits.clone(), Instant::now(), stop_signal.clone(), 0, SearchParams::default());
-        let mut searcher = Searcher::new(&cfg, &board, &history, History::new(), Arc::new(TranspositionTable::new(16)));
-        searcher.iterative_deepening();
+        let mut history_table = History::new();
+        let mut searcher = Searcher::new(&cfg, &board, &history, Arc::new(TranspositionTable::new(16)));
+        searcher.iterative_deepening(&mut history_table);
 
         let nodes = searcher.nodes;
         total_nodes += nodes;

--- a/src/tools/genfens/worker.rs
+++ b/src/tools/genfens/worker.rs
@@ -451,15 +451,11 @@ impl WorkerState {
             SearchParams::default(),
         );
 
-        // Move history out with a zero-cost default (empty cont Box).
-        // The history accumulates across positions within a game for better ordering.
-        let mut searcher =
-            Searcher::new(&cfg, &self.board, &self.search_history, mem::take(&mut self.history_table), Arc::clone(&self.tt));
-        searcher.iterative_deepening();
+        // History accumulates across positions within a game for better ordering.
+        let mut searcher = Searcher::new(&cfg, &self.board, &self.search_history, Arc::clone(&self.tt));
+        searcher.iterative_deepening(&mut self.history_table);
         let best_score = searcher.best_score().unwrap_or(0);
         let best_move = searcher.best_move();
-        // Move the enriched history back; the empty sentinel gets dropped (0 bytes freed).
-        self.history_table = searcher.history_table;
 
         (static_eval, best_score, best_move)
     }

--- a/src/tools/speedtest.rs
+++ b/src/tools/speedtest.rs
@@ -62,9 +62,10 @@ pub fn run(limit: usize) {
         stop_signal.store(false, Ordering::Release);
 
         let cfg = SearchConfig::new(limits.clone(), Instant::now(), stop_signal.clone(), 0, SearchParams::default());
-        let mut searcher = Searcher::new(&cfg, &board, &history, History::new(), Arc::new(TranspositionTable::new(16)));
+        let mut history_table = History::new();
+        let mut searcher = Searcher::new(&cfg, &board, &history, Arc::new(TranspositionTable::new(16)));
 
-        searcher.iterative_deepening();
+        searcher.iterative_deepening(&mut history_table);
         total_nodes += searcher.nodes;
 
         let bar_width = 40;

--- a/tuner/Cargo.toml
+++ b/tuner/Cargo.toml
@@ -27,6 +27,7 @@ zstd = { version = "0.13.3", default-features = false }
 toml = "1.1.2"
 paste = "1.0.15"
 thiserror = "2.0.18"
+ctrlc = "3.5.2"
 
 [features]
 default = []

--- a/tuner/Cargo.toml
+++ b/tuner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuner"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.95.0"
 

--- a/tuner/src/core/config.rs
+++ b/tuner/src/core/config.rs
@@ -246,6 +246,38 @@ pub struct SearchTuneConfig {
     pub centering_penalty: f64,
     pub active_softness: f64,
     pub sigma_boost_factor: f64,
+
+    /// Generations between bounds-report snapshots (also written on SIGINT).
+    #[serde(default = "default_bounds_report_interval")]
+    pub bounds_report_interval: usize,
+    /// Sliding-window size (generations) for clamp-rate detection.
+    #[serde(default = "default_bounds_window_gens")]
+    pub bounds_window_gens: usize,
+    /// Observed clamp rate must exceed `expected_rate * multiplier + floor` to flag a widen.
+    #[serde(default = "default_bounds_alarm_multiplier")]
+    pub bounds_alarm_multiplier: f64,
+    /// Absolute floor for alarm, prevents flagging when expected rate ≈ 0.
+    #[serde(default = "default_bounds_alarm_floor")]
+    pub bounds_alarm_floor: f64,
+    /// File path for the bounds report, relative to CWD.
+    #[serde(default = "default_bounds_report_path")]
+    pub bounds_report_path: String,
+}
+
+fn default_bounds_report_interval() -> usize {
+    5
+}
+fn default_bounds_window_gens() -> usize {
+    20
+}
+fn default_bounds_alarm_multiplier() -> f64 {
+    2.0
+}
+fn default_bounds_alarm_floor() -> f64 {
+    0.02
+}
+fn default_bounds_report_path() -> String {
+    "bounds_report.txt".to_string()
 }
 
 fn default_smoothing_radius() -> f64 {
@@ -328,6 +360,11 @@ impl Default for TunerConfig {
                 centering_penalty: 100.0,
                 active_softness: 0.5,
                 sigma_boost_factor: 2.0,
+                bounds_report_interval: 5,
+                bounds_window_gens: 20,
+                bounds_alarm_multiplier: 2.0,
+                bounds_alarm_floor: 0.02,
+                bounds_report_path: "bounds_report.txt".to_string(),
             },
             general: GeneralConfig {
                 checkpoint_interval: 50,

--- a/tuner/src/searchtune/bounds.rs
+++ b/tuner/src/searchtune/bounds.rs
@@ -239,4 +239,3 @@ impl BoundsTracker {
         "ok".to_string()
     }
 }
-

--- a/tuner/src/searchtune/bounds.rs
+++ b/tuner/src/searchtune/bounds.rs
@@ -1,0 +1,242 @@
+//! Per-parameter bounds reporter.
+//!
+//! Each generation we record raw (pre-clamp) normalized samples to detect when the
+//! tuner repeatedly proposes values outside `[min, max]` — that's the signal that a
+//! declared bound is too tight. We also track elite mean/variance and compare the
+//! observed clamping rate against the *expected* clamp rate under the current CMA-ES
+//! proposal (Gaussian with σ = sigma · √variance_i, mean = mean_i). Observed
+//! substantially > expected → the tuner is genuinely fighting the bound, not just
+//! Gaussian tail noise → recommend widening.
+//!
+//! Reports are appended to a text file every N epochs and on SIGINT, preserving
+//! per-epoch history so you can scrub back through the run.
+
+use std::{
+    collections::VecDeque,
+    fs::OpenOptions,
+    io::{self, Write},
+    path::Path,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use soul::engine::search_params::ParamDef;
+
+use super::{cmaes::CmaEs, optimizer::normal_cdf};
+
+/// Per-generation per-parameter raw observations (pre-clamp).
+#[derive(Clone, Default)]
+struct GenSample {
+    lo_hits: u32,
+    hi_hits: u32,
+    n_samples: u32,
+}
+
+#[derive(Clone)]
+pub struct BoundsConfig {
+    /// Generations retained for sliding-window clamp-rate analysis.
+    pub window_gens: usize,
+    /// Observed rate must exceed `expected * multiplier + floor` to flag widen.
+    pub alarm_multiplier: f64,
+    /// Absolute floor for alarm; prevents flags when expected ≈ 0 and a single sample slips out.
+    pub alarm_floor: f64,
+    /// EMA smoothing for elite mean / variance tracking.
+    pub elite_beta: f64,
+}
+
+impl Default for BoundsConfig {
+    fn default() -> Self {
+        Self { window_gens: 20, alarm_multiplier: 2.0, alarm_floor: 0.02, elite_beta: 0.2 }
+    }
+}
+
+pub struct BoundsTracker {
+    n: usize,
+    config: BoundsConfig,
+
+    observed_lo: Vec<f64>, // smallest raw normalized value ever proposed
+    observed_hi: Vec<f64>, // largest
+
+    window: VecDeque<Vec<GenSample>>,
+
+    elite_mean_ema: Vec<f64>, // denormalized (raw param units)
+    elite_var_ema: Vec<f64>,
+    have_elite_init: bool,
+}
+
+impl BoundsTracker {
+    #[must_use]
+    pub fn new(n: usize, config: BoundsConfig) -> Self {
+        Self {
+            n,
+            observed_lo: vec![f64::INFINITY; n],
+            observed_hi: vec![f64::NEG_INFINITY; n],
+            window: VecDeque::with_capacity(config.window_gens.max(1)),
+            elite_mean_ema: vec![0.0; n],
+            elite_var_ema: vec![0.0; n],
+            have_elite_init: false,
+            config,
+        }
+    }
+
+    /// Record one generation. `population_normalized` is the raw proposal (may stray
+    /// outside `[0, 1]`); `elite_indices` are the top-μ winners by penalized fitness.
+    pub fn observe(&mut self, population_normalized: &[Vec<f64>], elite_indices: &[usize], params: &[&ParamDef]) {
+        let mut cur = vec![GenSample::default(); self.n];
+
+        for sample in population_normalized {
+            for (i, &v) in sample.iter().enumerate() {
+                cur[i].n_samples += 1;
+                if v < 0.0 {
+                    cur[i].lo_hits += 1;
+                }
+                if v > 1.0 {
+                    cur[i].hi_hits += 1;
+                }
+                if v < self.observed_lo[i] {
+                    self.observed_lo[i] = v;
+                }
+                if v > self.observed_hi[i] {
+                    self.observed_hi[i] = v;
+                }
+            }
+        }
+
+        self.window.push_back(cur);
+        while self.window.len() > self.config.window_gens {
+            self.window.pop_front();
+        }
+
+        // Elite denormalized mean + variance (population stats over the elite subset)
+        let n_elite = elite_indices.len().max(1) as f64;
+        let mut means = vec![0.0; self.n];
+        for &idx in elite_indices {
+            for (i, &v) in population_normalized[idx].iter().enumerate() {
+                means[i] += params[i].denormalize(v.clamp(0.0, 1.0)) / n_elite;
+            }
+        }
+        let mut vars = vec![0.0; self.n];
+        for &idx in elite_indices {
+            for (i, &v) in population_normalized[idx].iter().enumerate() {
+                let raw = params[i].denormalize(v.clamp(0.0, 1.0));
+                vars[i] += (raw - means[i]).powi(2) / n_elite;
+            }
+        }
+
+        if !self.have_elite_init {
+            self.elite_mean_ema = means;
+            self.elite_var_ema = vars;
+            self.have_elite_init = true;
+        } else {
+            let b = self.config.elite_beta;
+            for i in 0..self.n {
+                self.elite_mean_ema[i] = (1.0 - b).mul_add(self.elite_mean_ema[i], b * means[i]);
+                self.elite_var_ema[i] = (1.0 - b).mul_add(self.elite_var_ema[i], b * vars[i]);
+            }
+        }
+    }
+
+    /// Append one report snapshot to `path`.
+    ///
+    /// # Errors
+    /// Forwards any filesystem error from opening or writing.
+    pub fn write_report(&self, path: &Path, params: &[&ParamDef], cmaes: &CmaEs, epoch: usize, label: &str) -> io::Result<()> {
+        let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+        let ts = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+
+        writeln!(file)?;
+        writeln!(file, "{}", "=".repeat(150))?;
+        writeln!(file, "TUNER BOUNDS REPORT — {label} — epoch {epoch} — unix={ts}")?;
+        writeln!(file, "{}", "=".repeat(150))?;
+        writeln!(file)?;
+        writeln!(
+            file,
+            "{:<22} {:>8} {:>16} {:>18} {:>16} {:>9} {:>9} {:>20}  {}",
+            "param", "default", "cur[min,max]", "observed[lo,hi]", "elite[μ±σ]", "lo_clmp", "hi_clmp", "expected[lo,hi]", "verdict"
+        )?;
+        writeln!(file, "{}", "-".repeat(150))?;
+
+        let mean = cmaes.mean();
+        let variances = cmaes.variances();
+        let sigma = cmaes.sigma();
+
+        for (i, p) in params.iter().enumerate() {
+            let (window_lo, window_hi, window_n) = self.window.iter().fold((0u64, 0u64, 0u64), |(lo, hi, n), g| {
+                (lo + u64::from(g[i].lo_hits), hi + u64::from(g[i].hi_hits), n + u64::from(g[i].n_samples))
+            });
+            let lo_rate = if window_n > 0 { window_lo as f64 / window_n as f64 } else { 0.0 };
+            let hi_rate = if window_n > 0 { window_hi as f64 / window_n as f64 } else { 0.0 };
+
+            let proposal_sigma = (sigma * variances[i].sqrt()).max(1e-9);
+            let expected_lo = normal_cdf(-mean[i] / proposal_sigma);
+            let expected_hi = 1.0 - normal_cdf((1.0 - mean[i]) / proposal_sigma);
+
+            let obs_lo_raw = p.denormalize(self.observed_lo[i].clamp(0.0, 1.0));
+            let obs_hi_raw = p.denormalize(self.observed_hi[i].clamp(0.0, 1.0));
+            let elite_std = self.elite_var_ema[i].sqrt();
+
+            let verdict = self.verdict(p, i, lo_rate, hi_rate, expected_lo, expected_hi, obs_lo_raw, obs_hi_raw, elite_std);
+
+            writeln!(
+                file,
+                "{:<22} {:>8.0} {:>16} {:>18} {:>16} {:>8.1}% {:>8.1}% {:>20}  {}",
+                p.name,
+                p.default,
+                format!("[{:.0}, {:.0}]", p.min, p.max),
+                format!("[{:.0}, {:.0}]", obs_lo_raw, obs_hi_raw),
+                format!("{:.1}±{:.1}", self.elite_mean_ema[i], elite_std),
+                lo_rate * 100.0,
+                hi_rate * 100.0,
+                format!("[{:.2}%, {:.2}%]", expected_lo * 100.0, expected_hi * 100.0),
+                verdict,
+            )?;
+        }
+
+        writeln!(file)?;
+        file.flush()?;
+        Ok(())
+    }
+
+    fn verdict(
+        &self,
+        p: &ParamDef,
+        i: usize,
+        lo_rate: f64,
+        hi_rate: f64,
+        expected_lo: f64,
+        expected_hi: f64,
+        obs_lo_raw: f64,
+        obs_hi_raw: f64,
+        elite_std: f64,
+    ) -> String {
+        let alarm = self.config.alarm_multiplier;
+        let floor = self.config.alarm_floor;
+        let range = (p.max - p.min).max(1.0);
+        let step = p.step.max(1.0);
+
+        if lo_rate > alarm.mul_add(expected_lo, floor) {
+            let suggest = (p.min - step * (lo_rate / 0.05).ceil()).max(0.0);
+            return format!("LOWER MIN -> ~{suggest:.0}");
+        }
+        if hi_rate > alarm.mul_add(expected_hi, floor) {
+            let suggest = step.mul_add((hi_rate / 0.05).ceil(), p.max);
+            return format!("RAISE MAX -> ~{suggest:.0}");
+        }
+        if !self.have_elite_init {
+            return "warmup".to_string();
+        }
+        let near_default = (self.elite_mean_ema[i] - p.default).abs() < 0.05 * range;
+        if elite_std < 0.02 * range && near_default {
+            return "LOW SIGNAL".to_string();
+        }
+        if elite_std < 0.02 * range {
+            return format!("CONVERGED -> {:.1}", self.elite_mean_ema[i]);
+        }
+        let interior_lo = obs_lo_raw > 0.10f64.mul_add(range, p.min);
+        let interior_hi = obs_hi_raw < p.max - 0.10 * range;
+        if interior_lo && interior_hi {
+            return format!("TIGHTEN -> [{:.0}, {:.0}]", obs_lo_raw - 0.05 * range, 0.05f64.mul_add(range, obs_hi_raw));
+        }
+        "ok".to_string()
+    }
+}
+

--- a/tuner/src/searchtune/cache.rs
+++ b/tuner/src/searchtune/cache.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use parking_lot::Mutex;
-use soul::engine::search_params::{PARAM_DEFS, SearchParams};
+use soul::engine::search_params::{SearchParams, tunable_param_defs};
 
 use super::{pentanomial::Pentanomial, selfplay};
 use crate::core::fnv::Fnv1a;
@@ -122,17 +122,15 @@ impl MatchCache {
 fn hash_discrete_params(candidate_norm: &[f64], opponent_norm: &[f64], openings: &[String]) -> u64 {
     let mut fnv = Fnv1a::new();
 
-    // Hash candidate
+    let params = tunable_param_defs();
+
     for (i, &v) in candidate_norm.iter().enumerate() {
-        let param = &PARAM_DEFS[i];
-        let discrete_val = param.denormalize(v);
+        let discrete_val = params[i].denormalize(v);
         fnv.write_bytes(&discrete_val.to_bits().to_le_bytes());
     }
 
-    // Hash opponent
     for (i, &v) in opponent_norm.iter().enumerate() {
-        let param = &PARAM_DEFS[i];
-        let discrete_val = param.denormalize(v);
+        let discrete_val = params[i].denormalize(v);
         fnv.write_bytes(&discrete_val.to_bits().to_le_bytes());
     }
 

--- a/tuner/src/searchtune/cmaes.rs
+++ b/tuner/src/searchtune/cmaes.rs
@@ -48,14 +48,20 @@
 //!    inferiority. If the covariance shrinks in response to such noise, the search
 //!    space can collapse prematurely around noise.
 //!    We apply the Law of Total Variance (`Var(Obs) = Var(True) + Var(Noise)`) using
-//!    the empirical standard error of the matches. The resulting Reliability Coefficient
-//!    (`R = Var(True) / Var(Obs)`) estimates the fraction of observed variance
-//!    attributable to genuine parameter differences. A smoothstep of `R` gates the
-//!    negative covariance updates, so that noisy generations have little effect on the
-//!    covariance shape.
-//!    *Note: This is an original derivation for chess engine tuning. It is conceptually
-//!    related to the SNR-maintenance goal of LRA-CMA-ES, but operates at the level of
-//!    individual covariance updates rather than the global learning rate.*
+//!    the average per-candidate match variance (mean of `SE²`, not `mean(SE)²` —
+//!    Jensen's inequality would systematically under-state noise the other way).
+//!    The Reliability Coefficient `R = Var(True) / Var(Obs)` — the classical
+//!    psychometric measure of signal fraction — is smoothed across generations, and
+//!    a cubic smoothstep of the EMA gates the *negative* covariance updates only.
+//!    Positive updates pass through at full strength so noisy gens still move toward
+//!    observed winners; only the destructive (search-space contracting) updates are
+//!    throttled, since their failure mode (premature collapse) is unrecoverable.
+//!    *Ref: Spearman, C. (1904). The Proof and Measurement of Association between
+//!    Two Things. The American Journal of Psychology, 15(1), 72–101.*
+//!    *Note: applying this classical coefficient to gate Active CMA-ES negative-weight
+//!    updates is, to our knowledge, unused elsewhere in chess engine tuning. Related
+//!    to LRA-CMA-ES's SNR-maintenance but acts on individual covariance updates rather
+//!    than the global learning rate.*
 //!
 //! 5. SNR-Adaptive Learning Rate (LRA-CMA-ES)
 //!    The global update scale `η` is adapted each generation to maintain a stable
@@ -112,14 +118,19 @@ pub struct CmaEs {
     active_softness: f64,
 
     // ── Adaptation State ──
-    eta: f64,        // Global learning rate factor
-    lra_e: Vec<f64>, // Moving average of updates (Signal)
-    lra_v: f64,      // Moving average of update magnitudes (Noise)
-    g_norm: f64,     // Current natural gradient norm
+    eta: f64,             // Global learning rate factor
+    lra_e: Vec<f64>,      // Moving average of updates (Signal)
+    lra_v: f64,           // Moving average of update magnitudes (Noise)
+    g_norm: f64,          // Current natural gradient norm
+    reliability_ema: f64, // Smoothed reliability coefficient for negative-weight gating
 }
 
 /// The smoothing factor for the SNR-adaptive learning rate moving averages.
 const LRA_BETA: f64 = 0.1;
+
+/// Smoothing factor for the reliability EMA.
+/// Lower = more stable, slower to react to genuine noise regime changes.
+const RELIABILITY_BETA: f64 = 0.2;
 
 /// Clamps normalized values to [0, 1].
 ///
@@ -273,6 +284,7 @@ impl CmaEs {
             lra_e: vec![0.0; n],
             lra_v: 0.0,
             g_norm: 0.0,
+            reliability_ema: 0.0,
         }
     }
 
@@ -314,33 +326,34 @@ impl CmaEs {
     /// The elite subset (μ) tugs the mean toward victory. The entire population (λ) expands
     /// or shrinks our uncertainty (covariance) along their respective vectors.
     /// Crucially, negative update vectors are gated by Signal-to-Noise Ratio (SNR).
-    pub fn update(&mut self, population_normalized: &[Vec<f64>], penalized_elo: &[f64], raw_elo: &[f64], avg_std_err: f64) {
+    pub fn update(&mut self, population_normalized: &[Vec<f64>], penalized_elo: &[f64], raw_elo: &[f64], avg_var_noise: f64) {
         let mut indices: Vec<usize> = (0..self.lambda).collect();
         indices.sort_unstable_by(|&a, &b| penalized_elo[b].total_cmp(&penalized_elo[a]));
 
         // ── SNR Gating (Reliability Coefficient) ──
         // Raw match variance combines true engine strength (signal) and match luck (noise).
-        // If we gate updates on raw variance, we punish candidates for unlucky pairings.
-        //
-        // Using the Law of Total Variance: Var(Observed) = Var(True) + Var(Noise).
-        // We know the standard error (Var(Noise)), so we can isolate Var(True).
-        // The ratio Var(True) / Var(Observed) gives the Reliability Coefficient —
-        // the fraction of variance that represents actual strength differences
-        // rather than match noise.
+        // Gating on raw variance alone punishes candidates for unlucky pairings, so we
+        // decompose: Var(Observed) = Var(True) + Var(Noise). The noise term is the
+        // average per-candidate match variance (mean of SE², not SE-of-mean squared —
+        // Jensen would systematically under-state noise the other way).
+        // R = Var(True) / Var(Observed) is the reliability coefficient (Spearman, 1904).
         let mean_raw = raw_elo.iter().sum::<f64>() / self.lambda as f64;
         let var_observed = raw_elo.iter().map(|e| (e - mean_raw).powi(2)).sum::<f64>() / (self.lambda.max(2) - 1) as f64;
-
-        let var_noise = avg_std_err.powi(2);
-
-        // ── Law of Total Variance ──
-        // Var(Observed) = Var(True) + Var(Noise)
-        let var_signal = (var_observed - var_noise).max(0.0);
-
-        // Reliability R = Var(True) / Var(Observed)
+        let var_signal = (var_observed - avg_var_noise).max(0.0);
         let reliability = if var_observed > 1e-6 { (var_signal / var_observed).clamp(0.0, 1.0) } else { 0.0 };
 
-        // Cubic smoothstep the reliability to gracefully fade out noise-driven negative updates
-        let neg_scale = reliability * reliability * (3.0 - 2.0 * reliability);
+        // Smooth across generations: a single quiet gen shouldn't mute all negative
+        // updates. Lazy init on the first call so we don't bias toward 1.0 (trust)
+        // or 0.0 (paranoia) before we've measured anything.
+        self.reliability_ema = if self.generation == 0 {
+            reliability
+        } else {
+            (1.0 - RELIABILITY_BETA).mul_add(self.reliability_ema, RELIABILITY_BETA * reliability)
+        };
+
+        // Cubic smoothstep the EMA reliability to gracefully fade out noise-driven negative updates
+        let r = self.reliability_ema;
+        let neg_scale = r * r * (3.0 - 2.0 * r);
 
         self.generation += 1;
 

--- a/tuner/src/searchtune/mod.rs
+++ b/tuner/src/searchtune/mod.rs
@@ -1,3 +1,4 @@
+pub mod bounds;
 pub mod cache;
 pub mod cmaes;
 pub mod elo;

--- a/tuner/src/searchtune/optimizer.rs
+++ b/tuner/src/searchtune/optimizer.rs
@@ -63,6 +63,7 @@ fn approx_erf(x: f64) -> f64 {
 
 /// Gaussian Cumulative Distribution Function,
 /// using Abramowitz & Stegun 7.1.26 approximation
-fn normal_cdf(x: f64) -> f64 {
+#[must_use]
+pub fn normal_cdf(x: f64) -> f64 {
     0.5 * (1.0 + approx_erf(x / SQRT_2))
 }

--- a/tuner/src/searchtune/run.rs
+++ b/tuner/src/searchtune/run.rs
@@ -35,7 +35,7 @@ const H2H_ELO_THRESHOLD: f64 = 4.0;
 /// # Panics
 /// if opening file cannot be read or if internal logic fails.
 pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
-    let params = search_params::PARAM_DEFS;
+    let params = search_params::tunable_param_defs();
     let n = params.len();
 
     let lambda = default_lambda(n, config.population_scale);
@@ -101,7 +101,7 @@ pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
     println!("  Step size (σ₀):  {:.2}", cmaes.sigma());
     println!();
     println!("\x1b[90m ─── Parameters ({n}) ───\x1b[0m");
-    for p in params {
+    for p in &params {
         println!(
             " \x1b[38;5;250m{:<22}\x1b[0m \x1b[1;37m{:>6}\x1b[0m   \x1b[90m{:>6} .. {:<6}\x1b[0m",
             p.name, p.default as i32, p.min as i32, p.max as i32

--- a/tuner/src/searchtune/run.rs
+++ b/tuner/src/searchtune/run.rs
@@ -696,9 +696,11 @@ pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
         }
     }
 
-    // Final report on natural completion (in case last epoch wasn't a periodic boundary).
-    if let Err(e) = bounds.write_report(bounds_path_ref, &params, &cmaes, config.epochs, "final") {
-        eprintln!("\x1b[31m[!] Failed to write final bounds report: {e}\x1b[0m");
+    // Final report on natural completion only; a SIGINT exit already wrote its own.
+    if !stop_flag.load(Ordering::SeqCst) {
+        if let Err(e) = bounds.write_report(bounds_path_ref, &params, &cmaes, config.epochs, "final") {
+            eprintln!("\x1b[31m[!] Failed to write final bounds report: {e}\x1b[0m");
+        }
     }
 
     println!("\n\x1b[1;36m>> Search Tuning Complete ({:.1}s)\x1b[0m", total_start.elapsed().as_secs_f64());

--- a/tuner/src/searchtune/run.rs
+++ b/tuner/src/searchtune/run.rs
@@ -143,15 +143,12 @@ pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
         // Fresh run: prior report's [min, max] interpretation may no longer apply.
         let _ = fs::remove_file(bounds_path_ref);
     }
-    let mut bounds = BoundsTracker::new(
-        n,
-        BoundsConfig {
-            window_gens: config.bounds_window_gens,
-            alarm_multiplier: config.bounds_alarm_multiplier,
-            alarm_floor: config.bounds_alarm_floor,
-            elite_beta: 0.2,
-        },
-    );
+    let mut bounds = BoundsTracker::new(n, BoundsConfig {
+        window_gens: config.bounds_window_gens,
+        alarm_multiplier: config.bounds_alarm_multiplier,
+        alarm_floor: config.bounds_alarm_floor,
+        elite_beta: 0.2,
+    });
 
     // SIGINT: finish current epoch, write final report, then exit. Second Ctrl-C = hard exit.
     let stop_flag = Arc::new(AtomicBool::new(false));

--- a/tuner/src/searchtune/run.rs
+++ b/tuner/src/searchtune/run.rs
@@ -12,15 +12,22 @@
 
 use std::{
     collections::BTreeMap,
+    fs,
     io::{Write, stdout},
-    sync::atomic::{AtomicUsize, Ordering},
-    time::Instant,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
 };
 
+use parking_lot::Mutex;
 use rayon::prelude::*;
 use soul::engine::search_params::{self, SearchParams};
 
 use super::{
+    bounds::{BoundsConfig, BoundsTracker},
     cache::MatchCache,
     cmaes::{CmaEs, clamp_normalized, default_lambda},
     elo::{EloCache, elo_color},
@@ -128,6 +135,36 @@ pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
 
     let mut rng = fastrand::Rng::new();
     let total_start = Instant::now();
+
+    // ── Bounds Reporter ──
+    let bounds_path = config.bounds_report_path.clone();
+    let bounds_path_ref = Path::new(&bounds_path);
+    if !resume {
+        // Fresh run: prior report's [min, max] interpretation may no longer apply.
+        let _ = fs::remove_file(bounds_path_ref);
+    }
+    let mut bounds = BoundsTracker::new(
+        n,
+        BoundsConfig {
+            window_gens: config.bounds_window_gens,
+            alarm_multiplier: config.bounds_alarm_multiplier,
+            alarm_floor: config.bounds_alarm_floor,
+            elite_beta: 0.2,
+        },
+    );
+
+    // SIGINT: finish current epoch, write final report, then exit. Second Ctrl-C = hard exit.
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    {
+        let stop_flag = Arc::clone(&stop_flag);
+        let _ = ctrlc::set_handler(move || {
+            if stop_flag.swap(true, Ordering::SeqCst) {
+                eprintln!("\n\x1b[91m>> Second Ctrl-C, hard exit.\x1b[0m");
+                std::process::exit(130);
+            }
+            eprintln!("\n\x1b[93m>> Ctrl-C received — finishing current epoch, writing bounds report, then exiting.\x1b[0m");
+        });
+    }
 
     let mut verified_elite_params = best_params.clone();
     // On resume, verified_elite_state is the loaded CMA-ES state (same as cmaes).
@@ -257,22 +294,29 @@ pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
         let progress = AtomicUsize::new(0);
         let total_to_play = needs_play.len() * effective_pairs;
 
+        let play_start = Instant::now();
+        // ~33Hz cap on stdout writes. Tight enough to look continuous on 60Hz+ displays;
+        // loose enough that workers don't serialize on the print mutex at high pair throughput.
+        let last_print = Mutex::new(play_start);
+        const PRINT_INTERVAL: Duration = Duration::from_millis(30);
+
         macro_rules! fmt_progress {
-            ($done:expr) => {
+            ($done:expr, $eta:expr) => {
                 format!(
-                    "  Epoch {:>3}/{} | Budget: {:>3} | Pairs {:>3}/{} | Imputed: {:>2} | SE: {:>4.1} | Elo: ...",
+                    "  Epoch {:>3}/{} | Budget: {:>3} | Pairs {:>4}/{} | ETA {:>6} | Imputed: {:>2} | SE: {:>4.1} | Elo: ...",
                     epoch,
                     config.epochs,
                     effective_pairs,
                     $done,
                     total_to_play,
+                    format_eta($eta),
                     lambda - needs_play.len(),
                     min_surrogate_err
                 )
             };
         }
 
-        print!("{}", fmt_progress!(0));
+        print!("{}", fmt_progress!(0, f64::INFINITY));
         let _ = stdout().flush();
 
         // Physically play the matches for unknown candidates
@@ -284,11 +328,26 @@ pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
                 let candidate_params = SearchParams::from_normalized(&clamped);
 
                 let progress_ref = &progress;
+                let last_print_ref = &last_print;
                 let on_pair = || {
                     let done = progress_ref.fetch_add(1, Ordering::Relaxed) + 1;
-                    // Throttle updates to minimize lock contention on stdout().flush()
-                    if done.is_multiple_of(10) || done == total_to_play {
-                        print!("\r{}", fmt_progress!(done));
+                    let now = Instant::now();
+
+                    // Cheap unlocked precheck under the time gate; uncontended hot path skips the lock entirely.
+                    let should_print = done == total_to_play
+                        || last_print_ref
+                            .try_lock()
+                            .filter(|guard| now.duration_since(**guard) >= PRINT_INTERVAL)
+                            .map(|mut guard| {
+                                *guard = now;
+                                true
+                            })
+                            .unwrap_or(false);
+
+                    if should_print {
+                        let elapsed_s = now.duration_since(play_start).as_secs_f64();
+                        let eta_s = if done > 0 { elapsed_s * (total_to_play - done) as f64 / done as f64 } else { f64::INFINITY };
+                        print!("\r{}", fmt_progress!(done, eta_s));
                         let _ = stdout().flush();
                     }
                 };
@@ -314,7 +373,10 @@ pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
             elo_cache.add(population[idx].clone(), opponent_norm.clone(), elo, weight);
         }
 
-        let avg_std_err: f64 = fitness_results.iter().map(|&(_, err, ..)| err).sum::<f64>() / lambda as f64;
+        // Pass mean(SE²), not mean(SE)² — Law of Total Variance wants the average
+        // variance contribution from noise. Jensen's inequality: mean(SE)² ≤ mean(SE²),
+        // so squaring the mean would systematically under-state noise variance.
+        let avg_var_noise: f64 = fitness_results.iter().map(|&(_, err, ..)| err * err).sum::<f64>() / lambda as f64;
 
         // ── Penalization & Bayesian Consensus ──
         let penalized_elo: Vec<f64> = population
@@ -370,7 +432,17 @@ pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
             .collect();
 
         let raw_elos: Vec<f64> = fitness_results.iter().map(|&(r, ..)| r).collect();
-        cmaes.update(&population, &penalized_elo, &raw_elos, avg_std_err);
+        cmaes.update(&population, &penalized_elo, &raw_elos, avg_var_noise);
+
+        // ── Bounds observation ──
+        // Replays CMA-ES's ranking locally (top-μ by penalized fitness) to feed elite stats.
+        {
+            let mu = lambda / 2;
+            let mut elite_indices: Vec<usize> = (0..lambda).collect();
+            elite_indices.sort_unstable_by(|&a, &b| penalized_elo[b].total_cmp(&penalized_elo[a]));
+            elite_indices.truncate(mu);
+            bounds.observe(&population, &elite_indices, &params);
+        }
 
         // ── Learning Rate Adaptation (LRA) ──
         // Scale the global learning rate based on the estimated Signal-to-Noise Ratio.
@@ -612,6 +684,24 @@ pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
         if let Err(e) = ckpt.save() {
             eprintln!("\n\x1b[31m[!] Failed to save checkpoint: {e}\x1b[0m");
         }
+
+        // ── Bounds report: periodic + on SIGINT ──
+        let stop_requested = stop_flag.load(Ordering::SeqCst);
+        if stop_requested || (config.bounds_report_interval > 0 && epoch % config.bounds_report_interval == 0) {
+            let label = if stop_requested { "SIGINT" } else { "periodic" };
+            if let Err(e) = bounds.write_report(bounds_path_ref, &params, &cmaes, epoch, label) {
+                eprintln!("\x1b[31m[!] Failed to write bounds report: {e}\x1b[0m");
+            }
+        }
+        if stop_requested {
+            eprintln!("\x1b[93m>> Bounds report flushed to {bounds_path}; exiting.\x1b[0m");
+            break;
+        }
+    }
+
+    // Final report on natural completion (in case last epoch wasn't a periodic boundary).
+    if let Err(e) = bounds.write_report(bounds_path_ref, &params, &cmaes, config.epochs, "final") {
+        eprintln!("\x1b[31m[!] Failed to write final bounds report: {e}\x1b[0m");
     }
 
     println!("\n\x1b[1;36m>> Search Tuning Complete ({:.1}s)\x1b[0m", total_start.elapsed().as_secs_f64());
@@ -693,4 +783,19 @@ pub fn run(openings_path: &str, config: &SearchTuneConfig, resume: bool) {
         println!("{:<14} = {value},", param.name);
     }
     println!("// -------------------------------\n");
+}
+
+/// `Hh Mm`, `Mm Ss`, `S.s s`, or `--` if unknown.
+fn format_eta(secs: f64) -> String {
+    if !secs.is_finite() || secs < 0.0 {
+        return "--".to_string();
+    }
+    let s = secs as u64;
+    if s >= 3600 {
+        format!("{}h{:02}m", s / 3600, (s % 3600) / 60)
+    } else if s >= 60 {
+        format!("{}m{:02}s", s / 60, s % 60)
+    } else {
+        format!("{secs:.1}s")
+    }
 }

--- a/tuner/src/searchtune/selfplay.rs
+++ b/tuner/src/searchtune/selfplay.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     io::Error,
     sync::{
         Arc,
@@ -24,6 +25,9 @@ use soul::{
 };
 
 use super::pentanomial::{GameResult, Pentanomial, pair_to_pentanomial};
+
+/// Per-worker TT pool size.
+const TT_POOL_MB: usize = 16;
 
 /// Executes a full suite of candidate vs. baseline paired matches.
 ///
@@ -136,6 +140,25 @@ fn aggregate_results(results: Vec<(Pentanomial, u64, u64)>) -> (Pentanomial, u64
     (penta, total_candidate_nodes, total_baseline_nodes)
 }
 
+thread_local! {
+    /// One pair of TTs per rayon worker, alive for the worker's lifetime.
+    /// Cleared (not reallocated) between pairs so we pay 32 MB of malloc *once*
+    /// per worker instead of per opening pair.
+    static TT_POOL: RefCell<Option<(Arc<TranspositionTable>, Arc<TranspositionTable>)>> = const { RefCell::new(None) };
+}
+
+/// Hand out the worker-local TT pair, lazy-initialized and cleared on each call.
+fn acquire_tts() -> (Arc<TranspositionTable>, Arc<TranspositionTable>) {
+    TT_POOL.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        let pair = slot
+            .get_or_insert_with(|| (Arc::new(TranspositionTable::new(TT_POOL_MB)), Arc::new(TranspositionTable::new(TT_POOL_MB))));
+        pair.0.clear();
+        pair.1.clear();
+        (Arc::clone(&pair.0), Arc::clone(&pair.1))
+    })
+}
+
 fn play_match_pair<F: Fn()>(
     fen: &str,
     limits: &Limits,
@@ -152,8 +175,7 @@ fn play_match_pair<F: Fn()>(
     // Thread local heap-allocated stacks
     let dummy_board = Board::default();
     let dummy_hist = vec![dummy_board.hash];
-    let tt_a = Arc::new(TranspositionTable::new(16));
-    let tt_b = Arc::new(TranspositionTable::new(16));
+    let (tt_a, tt_b) = acquire_tts();
     let mut searcher_a = Box::new(Searcher::new(&cfg_a, &dummy_board, &dummy_hist, History::new(), tt_a));
     let mut searcher_b = Box::new(Searcher::new(&cfg_b, &dummy_board, &dummy_hist, History::new(), tt_b));
 

--- a/tuner/src/searchtune/selfplay.rs
+++ b/tuner/src/searchtune/selfplay.rs
@@ -158,6 +158,19 @@ fn acquire_tts() -> (Arc<TranspositionTable>, Arc<TranspositionTable>) {
     })
 }
 
+thread_local! {
+    /// Owned histories per worker; ~MB each. Taken at pair start, returned after.
+    static HISTORY_POOL: RefCell<Option<(History, History)>> = const { RefCell::new(None) };
+}
+
+fn acquire_histories() -> (History, History) {
+    HISTORY_POOL.with(|cell| cell.borrow_mut().take().unwrap_or_else(|| (History::new(), History::new())))
+}
+
+fn release_histories(hist_a: History, hist_b: History) {
+    HISTORY_POOL.with(|cell| *cell.borrow_mut() = Some((hist_a, hist_b)));
+}
+
 fn play_match_pair<F: Fn()>(
     fen: &str,
     limits: &Limits,
@@ -175,18 +188,25 @@ fn play_match_pair<F: Fn()>(
     let dummy_board = Board::default();
     let dummy_hist = vec![dummy_board.hash];
     let (tt_a, tt_b) = acquire_tts();
-    let mut searcher_a = Box::new(Searcher::new(&cfg_a, &dummy_board, &dummy_hist, History::new(), tt_a));
-    let mut searcher_b = Box::new(Searcher::new(&cfg_b, &dummy_board, &dummy_hist, History::new(), tt_b));
+    let (mut hist_a, mut hist_b) = acquire_histories();
+    // Pooled histories may carry state from a prior pair — start each pair clean.
+    hist_a.clear();
+    hist_b.clear();
+
+    let mut searcher_a = Box::new(Searcher::new(&cfg_a, &dummy_board, &dummy_hist, tt_a));
+    let mut searcher_b = Box::new(Searcher::new(&cfg_b, &dummy_board, &dummy_hist, tt_b));
 
     // Round 1: A (White) vs B (Black)
-    let (result_as_white, nodes_a_1, nodes_b_1) = play_game(fen, &cfg_a, &cfg_b, &mut searcher_a, &mut searcher_b);
+    let (result_as_white, nodes_a_1, nodes_b_1) =
+        play_game(fen, &cfg_a, &cfg_b, &mut searcher_a, &mut searcher_b, &mut hist_a, &mut hist_b);
 
     // ucinewgame-equivalent between the two games of the pair.
-    searcher_a.clear_history();
-    searcher_b.clear_history();
+    hist_a.clear();
+    hist_b.clear();
 
     // Round 2: B (White) vs A (Black)
-    let (result_for_b, nodes_b_2, nodes_a_2) = play_game(fen, &cfg_b, &cfg_a, &mut searcher_b, &mut searcher_a);
+    let (result_for_b, nodes_b_2, nodes_a_2) =
+        play_game(fen, &cfg_b, &cfg_a, &mut searcher_b, &mut searcher_a, &mut hist_b, &mut hist_a);
 
     // Invert result (B's POV → A's POV)
     let result_as_black_perspective = match result_for_b {
@@ -196,6 +216,8 @@ fn play_match_pair<F: Fn()>(
     };
 
     on_finish();
+
+    release_histories(hist_a, hist_b);
 
     (
         pair_to_pentanomial(result_as_white, result_as_black_perspective),
@@ -215,6 +237,8 @@ fn play_game<'a>(
     cfg_black: &'a SearchConfig,
     searcher_white: &mut Searcher<'a>,
     searcher_black: &mut Searcher<'a>,
+    hist_white: &mut History,
+    hist_black: &mut History,
 ) -> (GameResult, u64, u64) {
     let uses_clock =
         cfg_white.limits.wtime > 0 && cfg_white.limits.movetime == 0 && cfg_white.limits.depth == 0 && cfg_white.limits.nodes == 0;
@@ -247,8 +271,11 @@ fn play_game<'a>(
 
         let move_start = Instant::now();
 
-        let (searcher, cfg) =
-            if board.stm == Color::White { (&mut *searcher_white, cfg_white) } else { (&mut *searcher_black, cfg_black) };
+        let (searcher, cfg, hist_table) = if board.stm == Color::White {
+            (&mut *searcher_white, cfg_white, &mut *hist_white)
+        } else {
+            (&mut *searcher_black, cfg_black, &mut *hist_black)
+        };
 
         searcher.reset(cfg, &board, &history);
 
@@ -270,7 +297,7 @@ fn play_game<'a>(
         }
 
         cfg.stop.store(false, Ordering::Release);
-        searcher.iterative_deepening();
+        searcher.iterative_deepening(hist_table);
 
         let score = searcher.best_score().unwrap_or(0);
         let ply = (board.fullmove_number as usize - 1) * 2 + (board.stm as usize);

--- a/tuner/src/searchtune/selfplay.rs
+++ b/tuner/src/searchtune/selfplay.rs
@@ -16,7 +16,6 @@ use soul::{
     engine::{
         adjudication::check_adjudication,
         history::History,
-        movegen::gen_legal_moves,
         search::{Limits, Protocol, SearchConfig, SearchDisplay, Searcher},
         search_params::SearchParams,
         tm::TimeManager,
@@ -239,14 +238,6 @@ fn play_game<'a>(
     let black_inc = cfg_black.limits.binc;
 
     for _ply in 0..MAX_GAME_PLIES {
-        let moves = gen_legal_moves(&board);
-        if moves.is_empty() {
-            let in_check = board.checkers().is_not_empty();
-            if in_check {
-                return (if board.stm == Color::White { GameResult::Loss } else { GameResult::Win }, white_nodes, black_nodes);
-            }
-            return (GameResult::Draw, white_nodes, black_nodes);
-        }
         if is_draw(&board, &history) {
             return (GameResult::Draw, white_nodes, black_nodes);
         }
@@ -257,6 +248,15 @@ fn play_game<'a>(
             if board.stm == Color::White { (&mut *searcher_white, cfg_white) } else { (&mut *searcher_black, cfg_black) };
 
         searcher.reset(cfg, &board, &history);
+
+        // reset already generated root_moves; empty => mate or stalemate.
+        if searcher.best_move().is_none() {
+            let in_check = board.checkers().is_not_empty();
+            if in_check {
+                return (if board.stm == Color::White { GameResult::Loss } else { GameResult::Win }, white_nodes, black_nodes);
+            }
+            return (GameResult::Draw, white_nodes, black_nodes);
+        }
 
         if uses_clock {
             let mut limits = cfg.limits.clone();
@@ -305,7 +305,8 @@ fn play_game<'a>(
             }
         }
 
-        let best_move = searcher.best_move().unwrap_or_else(|| *moves.iter().next().unwrap());
+        // safe: terminal positions returned above, so root_moves is non-empty.
+        let best_move = searcher.best_move().expect("non-terminal position must have a move");
 
         board.make_move(best_move, &mut accumulator);
         history.push(board.hash);

--- a/tuner/src/searchtune/selfplay.rs
+++ b/tuner/src/searchtune/selfplay.rs
@@ -263,7 +263,7 @@ fn play_game<'a>(
             // Just pass the current actual clocks — no branching needed.
             limits.wtime = white_time_ms;
             limits.btime = black_time_ms;
-            let phase = i32::from(board.get_initial_accumulator().to_array()[2]);
+            let phase = i32::from(accumulator.to_array()[2]);
             searcher.tm =
                 TimeManager::new(&limits, move_start, board.stm, cfg.overhead, phase, history.len() as u64, &cfg.search_params);
         }

--- a/tuner/src/searchtune/selfplay.rs
+++ b/tuner/src/searchtune/selfplay.rs
@@ -182,6 +182,10 @@ fn play_match_pair<F: Fn()>(
     // Round 1: A (White) vs B (Black)
     let (result_as_white, nodes_a_1, nodes_b_1) = play_game(fen, &cfg_a, &cfg_b, &mut searcher_a, &mut searcher_b);
 
+    // ucinewgame-equivalent between the two games of the pair.
+    searcher_a.clear_history();
+    searcher_b.clear_history();
+
     // Round 2: B (White) vs A (Black)
     let (result_for_b, nodes_b_2, nodes_a_2) = play_game(fen, &cfg_b, &cfg_a, &mut searcher_b, &mut searcher_a);
 
@@ -252,7 +256,7 @@ fn play_game<'a>(
         let (searcher, cfg) =
             if board.stm == Color::White { (&mut *searcher_white, cfg_white) } else { (&mut *searcher_black, cfg_black) };
 
-        searcher.reset(cfg, &board, &history, History::new());
+        searcher.reset(cfg, &board, &history);
 
         if uses_clock {
             let mut limits = cfg.limits.clone();

--- a/tuner/src/searchtune/selfplay.rs
+++ b/tuner/src/searchtune/selfplay.rs
@@ -237,6 +237,9 @@ fn play_game<'a>(
     let white_inc = cfg_white.limits.winc;
     let black_inc = cfg_black.limits.binc;
 
+    // Hoisted once per game; only wtime/btime change per move.
+    let mut tm_limits = cfg_white.limits.clone();
+
     for _ply in 0..MAX_GAME_PLIES {
         if is_draw(&board, &history) {
             return (GameResult::Draw, white_nodes, black_nodes);
@@ -259,13 +262,11 @@ fn play_game<'a>(
         }
 
         if uses_clock {
-            let mut limits = cfg.limits.clone();
-            // Just pass the current actual clocks — no branching needed.
-            limits.wtime = white_time_ms;
-            limits.btime = black_time_ms;
+            tm_limits.wtime = white_time_ms;
+            tm_limits.btime = black_time_ms;
             let phase = i32::from(accumulator.to_array()[2]);
             searcher.tm =
-                TimeManager::new(&limits, move_start, board.stm, cfg.overhead, phase, history.len() as u64, &cfg.search_params);
+                TimeManager::new(&tm_limits, move_start, board.stm, cfg.overhead, phase, history.len() as u64, &cfg.search_params);
         }
 
         cfg.stop.store(false, Ordering::Release);

--- a/tuner/tuner_config.toml
+++ b/tuner/tuner_config.toml
@@ -62,13 +62,13 @@ min_sigma = 0.02
 max_restarts = 3
 stagnation_threshold = 15
 h2h_pairs = 300
-validation_pairs = 1000
+validation_pairs = 500
 
-reeval_interval = 8
+reeval_interval = 10
 confidence_factor = 2.0 # Elo - k · stderr
 
-epochs = 200
-pairs = 128
+epochs = 100
+pairs = 16
 tc = "4+0.04"
 h2h_tc = "1.0+0.01"
 val_tc = "1.0+0.01"


### PR DESCRIPTION
Search params:
- macro rewritten as a terse `T()`/`NT()` DSL with tiered auto-derivation,
   `T(name,def)` → auto bounds+step, up to fully explicit,
   `T(name,def,min,max,step)`; replaces the old verbose,
   `field: type = default, min, max, step` form.
- dropped the linkme `distributed_slice` dep; params collect into a plain
    declaration-ordered `PARAM_DEFS`.
- `NT()` marks frozen params: registered + accessible, tuner skips them
- denormalize anchors the snap grid at min and clamps to `[min,max]`,
    so declared bounds round-trip exactly
- `min`/`max` audited against real usage; degenerate floors fixed.

CMA-ES:
- `var_noise` uses mean(SE²) not mean(SE)² (Jensen).
- reliability coefficient EMA-smoothed across gens; Spearman 1904 cited (My damned bad).

Bounds reporter:
- per-param tracker writes `bounds_report.txt` every 5 epochs + on `SIGINT` and at finish.
- flags widen/tighten/converged/low-signal vs expected clamp rate.

Self-play perf:
- TTs and histories pooled per worker, cleared not realloc'd.
- History ownership inverted to caller; drops the per-iteration clone.
- phase read from incremental accumulator; redundant per-ply
  `gen_legal_moves` dropped; Limits clone hoisted out of move loop.
  
Progress display; per-pair updates with ETA
Flipped const-trait impl syntax for nightly 1.98.0
 
Engine behavior unchanged.
Though got some speedup; `./soul bench ran 1.05 ± 0.03 times faster than ./soul-base bench`.

Bench: 6136983