### PR TITLE
Tighten the score jitter

### DIFF
--- a/src/core/defs.rs
+++ b/src/core/defs.rs
@@ -356,7 +356,7 @@ impl GameOutcome {
 /// opponent has a chance to stray.
 #[inline]
 pub fn draw_score(nodes: u64) -> i32 {
-    (nodes & 0xF) as i32 - 8
+    (nodes & 0x7) as i32 - 3
 }
 
 /// Let chess types serve as array indices directly:


### PR DESCRIPTION
```
Elo   | -0.30 +- 2.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.30 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 35610 W: 10386 L: 10417 D: 14807
Penta | [1014, 4332, 7170, 4249, 1040]
```
https://asylum.red/test/4832/

```
Elo   | 1.16 +- 3.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.26 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 14362 W: 3842 L: 3794 D: 6726
Penta | [317, 1720, 3049, 1788, 307]
```
https://asylum.red/test/4837/

Bench: 6347950