### PR TITLE
Ramp Correction History weight quadratically with depth

### DIFF
--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -26,7 +26,7 @@ pub struct History {
     /// `[side][pawn_hash & 0x3FFF]`
     correction: CorrectionHistory, // ~53 Elo
     /// `[side][minor_hash & 0x3FFF]` — knights + bishops, both colors
-    minor_correction: CorrectionHistory,
+    minor_correction: CorrectionHistory, // minor + major split from lumped non-pawn (~18 Elo): net ~5 Elo
     /// `[side][major_hash & 0x3FFF]` — rooks + queens, both colors
     major_correction: CorrectionHistory,
     /// `[side][attacker][to][victim]`
@@ -181,14 +181,16 @@ impl CorrectionHistory {
 
     /// Weighted moving average update.
     ///
-    /// `weight = min(1 + depth, 16)`, so shallow searches nudge gently
-    /// and deep searches carry more authority — but never so much that
-    /// a single outlier dominates.
+    /// Weight ramps quadratically with depth, capped at 32/256;
+    /// a deep search's verdict is far more trustworthy than a shallow one,
+    /// so it overwrites a larger share of the entry, while the cap still
+    /// keeps any single outlier from dominating.
     #[inline(always)]
     pub fn update(&mut self, stm: Color, pawn_hash: u64, raw_diff: i32, depth: i32) {
         let entry = &mut self.data[Self::idx(stm, pawn_hash)];
-        let weight = (1 + depth).min(16);
+        let weight = ((1 + depth) * (1 + depth) / 4).min(32);
         let scaled = raw_diff * CORRECTION_SCALE;
+
         *entry = ((*entry * (256 - weight) + scaled * weight) / 256).clamp(-CORRECTION_LIMIT, CORRECTION_LIMIT);
     }
 }


### PR DESCRIPTION
```
Elo   | 6.51 +- 4.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.47, 2.91) [0.00, 5.00]
Games | N: 10836 W: 3329 L: 3126 D: 4381
Penta | [338, 1255, 2082, 1352, 391]
```
https://asylum.red/test/4881/

Bench: 5478909