### PR TITLE
Post-LMR Continuation History

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "ctrlc",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.8"
+version = "0.5.9"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]
@@ -44,7 +44,6 @@ zerocopy = { version = "0.8.48", default-features = false, features = ["derive",
 
 [features]
 searchtune = []
-# Instrument correction-history reads/updates for diagnosis. Off in release.
 corrstats = []
 
 [profile.release]

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -294,6 +294,28 @@ impl History {
         }
     }
 
+    #[inline(always)]
+    pub fn update_conthist(
+        &mut self,
+        stm: Color,
+        pt: PieceType,
+        to: Square,
+        cont1: ContContext,
+        cont2: ContContext,
+        cont4: ContContext,
+        bonus: i32,
+    ) {
+        if cont1.pt != PieceType::None {
+            Self::update_entry(self.cont[0].get_mut(stm, cont1.pt, cont1.to, pt, to), bonus);
+        }
+        if cont2.pt != PieceType::None {
+            Self::update_entry(self.cont[1].get_mut(stm, cont2.pt, cont2.to, pt, to), bonus);
+        }
+        if cont4.pt != PieceType::None {
+            Self::update_entry(self.cont[1].get_mut(stm, cont4.pt, cont4.to, pt, to), bonus);
+        }
+    }
+
     /// Single soft-gravity update step. Extracted to keep updates DRY.
     #[inline(always)]
     fn update_entry(entry: &mut i16, bonus: i32) {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1378,7 +1378,7 @@ impl Worker<'_> {
             searcher.print_currmove(depth, mv, res.move_count);
         }
 
-        let eval = match self.pvs::<N>(searcher, depth, res.alpha, beta, ply, res.move_count == 1, is_pv_move, reduction) {
+        let eval = match self.pvs::<N>(searcher, depth, res.alpha, beta, ply, res.move_count == 1, is_pv_move, reduction, mv) {
             Ok(v) => v,
             Err(e) => {
                 searcher.zobrist_trail.pop();
@@ -1445,6 +1445,7 @@ impl Worker<'_> {
         is_first: bool,
         is_pv_move: bool,
         reduction: i32,
+        mv: Move,
     ) -> Result<i32, SearchAborted> {
         // Retrieve the expected PV move for the NEXT ply (ply + 1 is the child node's level).
         // If we are on the PV line AND we just played the PV move, we expect the child to also have a PV move.
@@ -1464,6 +1465,39 @@ impl Worker<'_> {
         // Re-search at full depth if the reduced scout found something.
         if score > alpha && reduction > 0 {
             score = -self.negamax::<NonPvNode>(searcher, depth - 1, -alpha - 1, -alpha, ply + 1, None)?;
+
+            // ── Post-LMR Continuation History ──
+            // The reduced scout beat alpha; the full-depth re-search settles it.
+            // A fail-low means the reduction over-promised, a fail-high means a cutoff
+            // punish or reward continuation history accordingly, ordering only.
+            if mv.is_history_quiet() && (score <= alpha || score >= beta) {
+                let stm = self.pos.stm.opposite();
+                let pt = self.stack[ply].moved_pt;
+                let to = self.stack[ply].moved_to;
+
+                let cont1 = if ply > 0 {
+                    ContContext { pt: self.stack[ply - 1].moved_pt, to: self.stack[ply - 1].moved_to }
+                } else {
+                    ContContext::default()
+                };
+
+                let cont2 = if ply > 1 {
+                    ContContext { pt: self.stack[ply - 2].moved_pt, to: self.stack[ply - 2].moved_to }
+                } else {
+                    ContContext::default()
+                };
+
+                let cont4 = if ply > 3 {
+                    ContContext { pt: self.stack[ply - 4].moved_pt, to: self.stack[ply - 4].moved_to }
+                } else {
+                    ContContext::default()
+                };
+
+                let bonus = (depth.pow(2) * hist_bonus_mult()).min(hist_bonus_cap());
+                let signed = if score <= alpha { -bonus } else { bonus };
+
+                self.history.update_conthist(stm, pt, to, cont1, cont2, cont4, signed);
+            }
         }
 
         if score > alpha && score < beta {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1466,7 +1466,7 @@ impl Worker<'_> {
         if score > alpha && reduction > 0 {
             score = -self.negamax::<NonPvNode>(searcher, depth - 1, -alpha - 1, -alpha, ply + 1, None)?;
 
-            // ── Post-LMR Continuation History ──
+            // ── Post-LMR Continuation History (~8 Elo) ──
             // The reduced scout beat alpha; the full-depth re-search settles it.
             // A fail-low means the reduction over-promised, a fail-high means a cutoff
             // punish or reward continuation history accordingly, ordering only.


### PR DESCRIPTION
```
Elo   | 3.91 +- 3.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.47, 2.91) [0.00, 5.00]
Games | N: 22950 W: 6925 L: 6667 D: 9358
Penta | [700, 2670, 4530, 2822, 753]
```
https://asylum.red/test/4929/

```
Elo   | 7.52 +- 4.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.47, 2.91) [0.00, 5.00]
Games | N: 7718 W: 2157 L: 1990 D: 3571
Penta | [140, 910, 1603, 1055, 151]
```
https://asylum.red/test/4930/

Bench: 5670422