### PR TITLE
Trim eval/tuner boilerplate via macro-generated layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ EXE := $(EXE_NAME)$(EXE_EXT)
 DEBUG_EXE := debug$(EXE_EXT)
 
 .PHONY: all help debug release native bench v3 v4 pgo openbench clean \
-        evaltune searchtune test seeformat format clippy profile \
+        evaltune searchtune test oracle seeformat format clippy profile \
         releases avx2 avx2-bmi2 avx512 corrstats
 
 all: openbench
@@ -153,6 +153,9 @@ searchtune:
 
 test: ## Run test suite
 	@RUSTDOCFLAGS="-C target-cpu=native" RUSTFLAGS="-C target-cpu=native" cargo test --workspace -- --nocapture
+
+oracle: ## Run the eval-tuner gradient oracle tests
+	@RUSTFLAGS="-C target-cpu=native" cargo test -p tuner --release oracle
 
 seeformat: ## Check formatting (no changes)
 	@cargo fmt --check

--- a/src/engine/eval.rs
+++ b/src/engine/eval.rs
@@ -173,7 +173,7 @@ pub fn lazy_eval_margin(board: &Position, phase: i32, params: &SearchParams) -> 
 /// Generic evaluation — monomorphized to `i32` for search, `AutogradNode` for tuning.
 ///
 /// WARNING: Autograd Linearity Booby Trap
-/// If you introduce any non-linear math (e.g. `feature * feature * weight` or `max(feature, 0)`)
+/// If you introduce any non-linear math (e.g. `feature · feature · weight` or `max(feature, 0)`)
 /// to the evaluation parameters, the affected [`crate::engine::term::LinearTerm::scatter`]
 /// impl will silently compute mathematically invalid gradients because
 /// [`LinearTerm`] assumes perfect parameter linearity (`y = w · x`).
@@ -307,116 +307,6 @@ impl SharedFeatures {
     }
 }
 
-impl term::LinearTerm for XrayTerm {
-    /// Scalar upstream — x-ray is tapered MG-only inside the combiner's
-    /// king-safety block, same cadence as king safety.
-    type Upstream = f64;
-
-    #[inline(always)]
-    fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, _phase: T, acc: &mut Accumulators<T>) {
-        acc.xray = params.w_xray_ortho * T::from_i32(features.xray_ortho);
-    }
-
-    #[inline]
-    fn scatter(features: &SharedFeatures, upstream: f64, grads: &mut [f64]) {
-        grads[psqt::LAYOUT.xray_offset] += upstream * features.xray_ortho as f64;
-    }
-}
-
-impl term::LinearTerm for BishopPairTerm {
-    type Upstream = term::TaperPair;
-
-    #[inline(always)]
-    fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, phase: T, acc: &mut Accumulators<T>) {
-        let feature = T::from_i32(features.bishop_pair_diff);
-        let eg_phase = T::from_i32(TOTAL_PHASE) - phase;
-        let tapered = params.w_bp_mg * phase + params.w_bp_eg * eg_phase;
-        acc.bonus += (tapered * feature / T::from_i32(TOTAL_PHASE)).trunc();
-    }
-
-    #[inline]
-    fn scatter(features: &SharedFeatures, upstream: term::TaperPair, grads: &mut [f64]) {
-        let feature = features.bishop_pair_diff as f64;
-        grads[eval_params::LAYOUT.bishop_pair_offset] += upstream.d_mg * feature;
-        grads[eval_params::LAYOUT.bishop_pair_offset + 1] += upstream.d_eg * feature;
-    }
-}
-
-impl term::LinearTerm for RookOpenTerm {
-    type Upstream = term::TaperPair;
-
-    #[inline(always)]
-    fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, phase: T, acc: &mut Accumulators<T>) {
-        let feature = T::from_i32(features.rook_open_diff);
-        let eg_phase = T::from_i32(TOTAL_PHASE) - phase;
-        let tapered = params.w_rook_open_mg * phase + params.w_rook_open_eg * eg_phase;
-        acc.bonus += (tapered * feature / T::from_i32(TOTAL_PHASE)).trunc();
-    }
-
-    #[inline]
-    fn scatter(features: &SharedFeatures, upstream: term::TaperPair, grads: &mut [f64]) {
-        let feature = features.rook_open_diff as f64;
-        grads[eval_params::LAYOUT.rook_open_offset] += upstream.d_mg * feature;
-        grads[eval_params::LAYOUT.rook_open_offset + 1] += upstream.d_eg * feature;
-    }
-}
-
-impl term::LinearTerm for PassedPawnTerm {
-    type Upstream = term::TaperPair;
-
-    #[inline(always)]
-    fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, phase: T, acc: &mut Accumulators<T>) {
-        let total = T::from_i32(TOTAL_PHASE);
-        let eg_phase = total - phase;
-
-        for r in 0..6 {
-            let feature = T::from_i32(features.passed_pawn[r]);
-            let tapered = params.passed_mg[r] * phase + params.passed_eg[r] * eg_phase;
-            acc.bonus += (tapered * feature / total).trunc();
-        }
-    }
-
-    #[inline]
-    fn scatter(features: &SharedFeatures, upstream: term::TaperPair, grads: &mut [f64]) {
-        let mg = eval_params::LAYOUT.passed_mg_offset;
-        let eg = eval_params::LAYOUT.passed_eg_offset;
-
-        for r in 0..6 {
-            let feature = features.passed_pawn[r] as f64;
-            grads[mg + r] += upstream.d_mg * feature;
-            grads[eg + r] += upstream.d_eg * feature;
-        }
-    }
-}
-
-impl term::LinearTerm for EnemyKingDistTerm {
-    type Upstream = term::TaperPair;
-
-    #[inline(always)]
-    fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, phase: T, acc: &mut Accumulators<T>) {
-        let total = T::from_i32(TOTAL_PHASE);
-        let eg_phase = total - phase;
-
-        for d in 0..6 {
-            let feature = T::from_i32(features.enemy_king_dist[d]);
-            let tapered = params.enemy_king_dist_mg[d] * phase + params.enemy_king_dist_eg[d] * eg_phase;
-            acc.bonus += (tapered * feature / total).trunc();
-        }
-    }
-
-    #[inline]
-    fn scatter(features: &SharedFeatures, upstream: term::TaperPair, grads: &mut [f64]) {
-        let mg = eval_params::LAYOUT.enemy_king_dist_mg_offset;
-        let eg = eval_params::LAYOUT.enemy_king_dist_eg_offset;
-
-        for d in 0..6 {
-            let feature = features.enemy_king_dist[d] as f64;
-            grads[mg + d] += upstream.d_mg * feature;
-            grads[eg + d] += upstream.d_eg * feature;
-        }
-    }
-}
-
 /// Build the per-bucket accumulator by initializing the PSQT-level `mg_eg` bucket
 /// from the SIMD accumulator, zeroing the rest, and applying every registered term.
 /// Isolated so both `compute_macro_eval` and `detailed_eval` produce identical
@@ -438,4 +328,89 @@ fn fill_accumulators<T: EvalMath<Scalar = T>>(
     };
     apply_all_terms::<T>(features, params, phase, &mut buckets);
     buckets
+}
+
+impl term::LinearTerm for XrayTerm {
+    /// Scalar upstream — x-ray is tapered MG-only inside the combiner's
+    /// king-safety block, same cadence as king safety.
+    type Upstream = f64;
+
+    #[inline(always)]
+    fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, _phase: T, acc: &mut Accumulators<T>) {
+        acc.xray = params.w_xray_ortho * T::from_i32(features.xray_ortho);
+    }
+
+    #[inline]
+    fn scatter(features: &SharedFeatures, upstream: f64, grads: &mut [f64]) {
+        grads[psqt::LAYOUT.xray_offset] += upstream * features.xray_ortho as f64;
+    }
+}
+
+/// Generates the `LinearTerm` impl for a taper bonus — a feature dotted with its
+/// (MG, EG) weight pair, summed into the bonus bucket. `scalar` is one feature on a
+/// contiguous `(mg, eg)` slot pair; `array` is an N-bucket vector with separate MG
+/// and EG slot blocks. Same forward/backward shape, so neither is hand-copied.
+macro_rules! tapered_bonus_term {
+    ( $( $term:ident = $kind:ident ( $($spec:tt)* ) ; )* ) => {
+        $( tapered_bonus_term!(@$kind $term, $($spec)*); )*
+    };
+
+    (@scalar $term:ident, $feat:ident, $mg:ident, $eg:ident, $off:ident) => {
+        impl term::LinearTerm for $term {
+            type Upstream = term::TaperPair;
+
+            #[inline(always)]
+            fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, phase: T, acc: &mut Accumulators<T>) {
+                let total = T::from_i32(TOTAL_PHASE);
+                let feature = T::from_i32(features.$feat);
+                let tapered = params.$mg * phase + params.$eg * (total - phase);
+                acc.bonus += (tapered * feature / total).trunc();
+            }
+
+            #[inline]
+            fn scatter(features: &SharedFeatures, upstream: term::TaperPair, grads: &mut [f64]) {
+                let off = eval_params::LAYOUT.$off;
+                let feature = features.$feat as f64;
+                grads[off] += upstream.d_mg * feature;
+                grads[off + 1] += upstream.d_eg * feature;
+            }
+        }
+    };
+
+    (@array $term:ident, $feat:ident, $mg:ident, $eg:ident, $mg_off:ident, $eg_off:ident, $n:literal) => {
+        impl term::LinearTerm for $term {
+            type Upstream = term::TaperPair;
+
+            #[inline(always)]
+            fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, phase: T, acc: &mut Accumulators<T>) {
+                let total = T::from_i32(TOTAL_PHASE);
+                let eg_phase = total - phase;
+
+                for i in 0..$n {
+                    let feature = T::from_i32(features.$feat[i]);
+                    let tapered = params.$mg[i] * phase + params.$eg[i] * eg_phase;
+                    acc.bonus += (tapered * feature / total).trunc();
+                }
+            }
+
+            #[inline]
+            fn scatter(features: &SharedFeatures, upstream: term::TaperPair, grads: &mut [f64]) {
+                let mg = eval_params::LAYOUT.$mg_off;
+                let eg = eval_params::LAYOUT.$eg_off;
+
+                for i in 0..$n {
+                    let feature = features.$feat[i] as f64;
+                    grads[mg + i] += upstream.d_mg * feature;
+                    grads[eg + i] += upstream.d_eg * feature;
+                }
+            }
+        }
+    };
+}
+
+tapered_bonus_term! {
+    BishopPairTerm    = scalar(bishop_pair_diff, w_bp_mg, w_bp_eg, bishop_pair_offset);
+    RookOpenTerm      = scalar(rook_open_diff, w_rook_open_mg, w_rook_open_eg, rook_open_offset);
+    PassedPawnTerm    = array(passed_pawn, passed_mg, passed_eg, passed_mg_offset, passed_eg_offset, 6);
+    EnemyKingDistTerm = array(enemy_king_dist, enemy_king_dist_mg, enemy_king_dist_eg, enemy_king_dist_mg_offset, enemy_king_dist_eg_offset, 6);
 }

--- a/src/engine/eval_params.rs
+++ b/src/engine/eval_params.rs
@@ -7,6 +7,27 @@
 
 use crate::weave::Vi32x4;
 
+/// Slot count each `EvalParams` field consumes in the dual-AD gradient vector.
+#[rustfmt::skip]
+macro_rules! slot_width {
+    (Scalar) => (1);
+    (Vec4)   => (4);
+    (Array4) => (4);
+    (Array6) => (6);
+}
+
+/// Sum the dual-AD footprint over the tunable list; 2 accumulator lanes (MG/EG)
+/// plus one slot per scalar weight.
+macro_rules! count_dual_slots {
+    ($( ($name:ident, $ty:ident, $off:ident, $extra:expr) ),* $(,)?) => {
+        2usize $( + slot_width!($ty) )*
+    };
+}
+
+/// Total dual-AD inputs; the 2 accumulator lanes plus every tunable weight.
+/// Drives `DUAL_N`, so the gradient array sizes itself as eval terms are added.
+pub const DUAL_SLOTS: usize = crate::define_tunables!(count_dual_slots);
+
 #[derive(Debug, Clone)]
 pub struct Tunable {
     pub name: String,
@@ -276,120 +297,49 @@ macro_rules! define_tunables {
     };
 }
 
-/// Slot count each `EvalParams` field consumes in the dual-AD gradient vector.
-#[rustfmt::skip]
-macro_rules! slot_width {
-    (Scalar) => (1);
-    (Vec4)   => (4);
-    (Array4) => (4);
-    (Array6) => (6);
-}
+/// One ordered row per parameter block: name and slot width.
+/// Generates the `Layout` struct (`<name>_offset` / `<name>_len`) and the `LAYOUT` prefix-sum.
+/// The order *is* the slot map — it must match `collect_parameters`'s collection
+/// order, or every gradient indexes the wrong slot.
+macro_rules! define_layout {
+    ($( $name:ident = $len:expr ),* $(,)?) => {
+        paste::paste! {
+            pub struct Layout {
+                $(
+                    pub [<$name _offset>]: usize,
+                    pub [<$name _len>]: usize,
+                )*
+            }
 
-/// Sum the dual-AD footprint over the tunable list; 2 accumulator lanes (MG/EG)
-/// plus one slot per scalar weight.
-macro_rules! count_dual_slots {
-    ($( ($name:ident, $ty:ident, $off:ident, $extra:expr) ),* $(,)?) => {
-        2usize $( + slot_width!($ty) )*
+            pub const LAYOUT: Layout = {
+                $( let [<$name _len>]: usize = $len; )*
+                let mut acc = 0usize;
+                $(
+                    let [<$name _offset>] = acc;
+                    acc += [<$name _len>];
+                )*
+                let _total = acc;
+                Layout { $( [<$name _offset>], [<$name _len>], )* }
+            };
+        }
     };
 }
 
-/// Total dual-AD inputs; the 2 accumulator lanes plus every tunable weight.
-/// Drives `DUAL_N`, so the gradient array sizes itself as eval terms are added.
-pub const DUAL_SLOTS: usize = crate::define_tunables!(count_dual_slots);
-
-pub struct Layout {
-    pub psqt_offset: usize,
-    pub psqt_len: usize,
-    pub material_offset: usize,
-    pub material_len: usize,
-    pub mobility_open_offset: usize,
-    pub mobility_open_len: usize,
-    pub mobility_closed_offset: usize,
-    pub mobility_closed_len: usize,
-    pub weight_offset: usize,
-    pub weight_len: usize,
-    pub attacker_offset: usize,
-    pub attacker_len: usize,
-    pub king_safety_offset: usize,
-    pub king_safety_len: usize,
-    pub xray_offset: usize,
-    pub xray_len: usize,
-    pub bishop_pair_offset: usize,
-    pub bishop_pair_len: usize,
-    pub rook_open_offset: usize,
-    pub rook_open_len: usize,
-    pub passed_mg_offset: usize,
-    pub passed_mg_len: usize,
-    pub passed_eg_offset: usize,
-    pub passed_eg_len: usize,
-    pub enemy_king_dist_mg_offset: usize,
-    pub enemy_king_dist_mg_len: usize,
-    pub enemy_king_dist_eg_offset: usize,
-    pub enemy_king_dist_eg_len: usize,
-}
-
-pub const LAYOUT: Layout = calc_layout();
-
-const fn calc_layout() -> Layout {
-    let psqt_len = (PAWN.len() + KNIGHT.len() + BISHOP.len() + ROOK.len() + QUEEN.len() + KING.len()) * 2;
-    let material_len = MATERIAL.len() * 2;
-    let mobility_len = 4 * 2; // MG + EG
-    let phase_len = PHASE_WEIGHTS.len();
-    let attacker_len = ATTACKER_WEIGHTS.len();
-    let safety_len = KING_SAFETY_WEIGHTS.len();
-    let xray_len = XRAY_WEIGHTS.len();
-    let bishop_pair_len = BISHOP_PAIR_WEIGHTS.len();
-    let rook_open_len = ROOK_OPEN_WEIGHTS.len();
-    let passed_mg_len = PASSED_PAWN_MG.len();
-    let passed_eg_len = PASSED_PAWN_EG.len();
-    let enemy_king_dist_mg_len = ENEMY_KING_DIST_MG.len();
-    let enemy_king_dist_eg_len = ENEMY_KING_DIST_EG.len();
-
-    let psqt_offset = 0;
-    let material_offset = psqt_offset + psqt_len;
-    let mobility_open_offset = material_offset + material_len;
-    let mobility_closed_offset = mobility_open_offset + mobility_len;
-    let weight_offset = mobility_closed_offset + mobility_len;
-    let attacker_offset = weight_offset + phase_len;
-    let king_safety_offset = attacker_offset + attacker_len;
-    let xray_offset = king_safety_offset + safety_len;
-    let bishop_pair_offset = xray_offset + xray_len;
-    let rook_open_offset = bishop_pair_offset + bishop_pair_len;
-    let passed_mg_offset = rook_open_offset + rook_open_len;
-    let passed_eg_offset = passed_mg_offset + passed_mg_len;
-    let enemy_king_dist_mg_offset = passed_eg_offset + passed_eg_len;
-    let enemy_king_dist_eg_offset = enemy_king_dist_mg_offset + enemy_king_dist_mg_len;
-
-    Layout {
-        psqt_offset,
-        psqt_len,
-        material_offset,
-        material_len,
-        mobility_open_offset,
-        mobility_open_len: mobility_len,
-        mobility_closed_offset,
-        mobility_closed_len: mobility_len,
-        weight_offset,
-        weight_len: phase_len,
-        attacker_offset,
-        attacker_len,
-        king_safety_offset,
-        king_safety_len: safety_len,
-        xray_offset,
-        xray_len,
-        bishop_pair_offset,
-        bishop_pair_len,
-        rook_open_offset,
-        rook_open_len,
-        passed_mg_offset,
-        passed_mg_len,
-        passed_eg_offset,
-        passed_eg_len,
-        enemy_king_dist_mg_offset,
-        enemy_king_dist_mg_len,
-        enemy_king_dist_eg_offset,
-        enemy_king_dist_eg_len,
-    }
+define_layout! {
+    psqt               = (PAWN.len() + KNIGHT.len() + BISHOP.len() + ROOK.len() + QUEEN.len() + KING.len()) * 2,
+    material           = MATERIAL.len() * 2,
+    mobility_open      = 4 * 2, // MG + EG
+    mobility_closed    = 4 * 2,
+    weight             = PHASE_WEIGHTS.len(),
+    attacker           = ATTACKER_WEIGHTS.len(),
+    king_safety        = KING_SAFETY_WEIGHTS.len(),
+    xray               = XRAY_WEIGHTS.len(),
+    bishop_pair        = BISHOP_PAIR_WEIGHTS.len(),
+    rook_open          = ROOK_OPEN_WEIGHTS.len(),
+    passed_mg          = PASSED_PAWN_MG.len(),
+    passed_eg          = PASSED_PAWN_EG.len(),
+    enemy_king_dist_mg = ENEMY_KING_DIST_MG.len(),
+    enemy_king_dist_eg = ENEMY_KING_DIST_EG.len(),
 }
 
 pub fn collect_parameters() -> Vec<Tunable> {
@@ -506,7 +456,7 @@ define_simple_params! {
 
 define_simd_params! {
     MG_MOBILITY_OPEN = [
-        V(5), V(-6), V(6), V(2)],
+        V(5), V(-6), V(6), V(2)], // [mobility, battery, threats, xray threats]
     EG_MOBILITY_OPEN = [
         V(-5), V(-8), V(-4), V(-12)],
     MG_MOBILITY_CLOSED = [

--- a/src/tools/dataset/gradient.rs
+++ b/src/tools/dataset/gradient.rs
@@ -3,18 +3,14 @@
 use super::SoulEntry;
 use crate::{
     core::{
-        board::{
-            Position,
-            bitboard::{atk_king, passed_span},
-            spatial::SpatialTensor,
-        },
-        defs::{Color, PieceType, Square},
+        board::Position,
+        defs::{Color, Square},
         phase::compute_phase_weights_f64,
         psqt,
     },
     engine::{
-        eval::{evaluate_fast, extract_phase},
-        mobility::{Mobility, OPEN_UNITY, SafetyMetrics, compute_openness_raw},
+        eval::{SharedFeatures, evaluate_fast, extract_phase},
+        mobility::{OPEN_UNITY, SafetyMetrics, SideMetrics, compute_openness_raw},
     },
 };
 
@@ -60,81 +56,42 @@ impl FeatureSlots {
     pub fn push_entry(&mut self, entry: &SoulEntry) {
         let pos = Position::from_fen(&entry.to_fen());
 
-        let pinned_w = pos.pinned_pieces(Color::White);
-        let pinned_b = pos.pinned_pieces(Color::Black);
-        let tensor = SpatialTensor::compute(&pos, pinned_w.0, pinned_b.0);
-        let mob = Mobility::compute_all(&pos, pos.stm, &tensor, pinned_w, pinned_b);
+        // SharedFeatures is White-relative; the cache is STM-relative, so flip
+        // perspective here. Side-symmetric metrics (mobility, safety) swap halves
+        // for Black; white-minus-black differentials (xray, pairs, passers) negate.
+        let sf = SharedFeatures::compute(&pos);
+        let black = pos.stm == Color::Black;
+
+        let (mob_us, mob_them, saf_us, saf_them) = if black {
+            (&sf.data.metrics_them, &sf.data.metrics_us, &sf.data.safety_them, &sf.data.safety_us)
+        } else {
+            (&sf.data.metrics_us, &sf.data.metrics_them, &sf.data.safety_us, &sf.data.safety_them)
+        };
+
+        let pack_side = |m: &SideMetrics| {
+            [
+                m.mobility.clamp(-127, 127) as i8,
+                m.shadow_mobility.clamp(-127, 127) as i8,
+                m.threats.clamp(-127, 127) as i8,
+                m.shadow_threats.clamp(-127, 127) as i8,
+            ]
+        };
 
         let mut mob_arr = [0i8; 8];
-        mob_arr[0] = mob.metrics_us.mobility.clamp(-127, 127) as i8;
-        mob_arr[1] = mob.metrics_us.shadow_mobility.clamp(-127, 127) as i8;
-        mob_arr[2] = mob.metrics_us.threats.clamp(-127, 127) as i8;
-        mob_arr[3] = mob.metrics_us.shadow_threats.clamp(-127, 127) as i8;
-        mob_arr[4] = mob.metrics_them.mobility.clamp(-127, 127) as i8;
-        mob_arr[5] = mob.metrics_them.shadow_mobility.clamp(-127, 127) as i8;
-        mob_arr[6] = mob.metrics_them.threats.clamp(-127, 127) as i8;
-        mob_arr[7] = mob.metrics_them.shadow_threats.clamp(-127, 127) as i8;
+        mob_arr[..4].copy_from_slice(&pack_side(mob_us));
+        mob_arr[4..].copy_from_slice(&pack_side(mob_them));
         self.mobility.push(mob_arr);
 
-        self.safety_us.push(pack_safety(&mob.safety_us));
-        self.safety_them.push(pack_safety(&mob.safety_them));
+        self.safety_us.push(pack_safety(saf_us));
+        self.safety_them.push(pack_safety(saf_them));
 
-        let w_ksq = pos.pieces(PieceType::King, Color::White).lsb();
-        let b_ksq = pos.pieces(PieceType::King, Color::Black).lsb();
-        let w_ring = atk_king(w_ksq).0;
-        let b_ring = atk_king(b_ksq).0;
-        let xray_val = (tensor.w_ortho_xray() & b_ring).count_ones() as i32 - (tensor.b_ortho_xray() & w_ring).count_ones() as i32;
-        let stm_xray = if pos.stm == Color::White { xray_val } else { -xray_val };
-        self.xray_ortho.push(stm_xray as i8);
+        let sign = if black { -1 } else { 1 };
+        self.xray_ortho.push((sf.xray_ortho * sign) as i8);
+        self.bishop_pair.push((sf.bishop_pair_diff * sign) as i8);
+        self.rook_open.push((sf.rook_open_diff * sign) as i8);
 
-        let white_bp = i8::from(pos.pieces(PieceType::Bishop, Color::White).more_than_one());
-        let black_bp = i8::from(pos.pieces(PieceType::Bishop, Color::Black).more_than_one());
-        let bp_diff = white_bp - black_bp;
-        self.bishop_pair.push(if pos.stm == Color::Black { -bp_diff } else { bp_diff });
-
-        let open = !pos.role_bb[PieceType::Pawn].file_fill();
-        let rooks_open = pos.role_bb[PieceType::Rook] & open;
-        let w_open = (rooks_open & pos.side_bb[Color::White]).popcount() as i8;
-        let b_open = (rooks_open & pos.side_bb[Color::Black]).popcount() as i8;
-        let open_diff = w_open - b_open;
-        self.rook_open.push(if pos.stm == Color::Black { -open_diff } else { open_diff });
-
-        let wp = pos.pieces(PieceType::Pawn, Color::White);
-        let bp = pos.pieces(PieceType::Pawn, Color::Black);
-        let mut passed = [0i8; 6];
-        let mut enemy_king = [0i8; 6];
-        let mut w = wp;
-
-        while w.is_not_empty() {
-            let sq = w.pop_lsb();
-
-            if (passed_span(sq, Color::White) & bp).is_empty() {
-                passed[(sq.rank() - 1) as usize] += 1;
-                enemy_king[(b_ksq.chebyshev_distance(sq).clamp(1, 6) - 1) as usize] += 1;
-            }
-        }
-
-        let mut b = bp;
-
-        while b.is_not_empty() {
-            let sq = b.pop_lsb();
-
-            if (passed_span(sq, Color::Black) & wp).is_empty() {
-                passed[(6 - sq.rank()) as usize] -= 1;
-                enemy_king[(w_ksq.chebyshev_distance(sq).clamp(1, 6) - 1) as usize] -= 1;
-            }
-        }
-
-        if pos.stm == Color::Black {
-            for v in &mut passed {
-                *v = -*v;
-            }
-            for v in &mut enemy_king {
-                *v = -*v;
-            }
-        }
-        self.passed_pawn.push(passed);
-        self.enemy_king_dist.push(enemy_king);
+        self.passed_pawn.push(std::array::from_fn(|i| (sf.passed_pawn[i] * sign) as i8));
+        self.enemy_king_dist.push(std::array::from_fn(|i| (sf.enemy_king_dist[i] * sign) as i8));
 
         let acc = pos.get_initial_accumulator();
         let phase = extract_phase(&acc);

--- a/tuner/ADDING_EVAL_TERMS.md
+++ b/tuner/ADDING_EVAL_TERMS.md
@@ -1,221 +1,207 @@
-# Adding New Eval Terms
+# Adding an Eval Term
 
-Step-by-step recipe for wiring a new linear eval term.
-
-See [`EVAL_TUNER.md`](EVAL_TUNER.md) for the tuner architecture.
+Wiring a new linear eval term, end to end.
+Architecture lives in [`EVAL_TUNER.md`](EVAL_TUNER.md).
 
 ---
 
 ## What a term is
 
-A term is a zero-sized type implementing `LinearTerm`:
+A zero-sized type implementing `LinearTerm`:
 
-- `fn apply<T: EvalMath>` — forward pass. Reads features and params, writes its contribution into `Accumulators`.
-- `fn scatter` — backward pass. Consumes the combiner-derived upstream for its bucket and writes `∂loss/∂param` into the term's param slots.
-- `type Upstream` — `TaperPair` for pre-tapered buckets (`bonus`, `mobility`); `f64` for scalar buckets (`king_safety`, `xray`).
+- `apply<T: EvalMath>` — forward. Read features and params, write the contribution into `Accumulators`.
+- `scatter` — backward. Take the combiner's upstream for the bucket, write `∂loss/∂param` into the term's slots.
+- `type Upstream` — `TaperPair` for pre-tapered buckets (`bonus`, `mobility`), `f64` for the scalar ones (`king_safety`, `xray`).
 
-The `register_terms!` macro in `src/engine/eval.rs` wires terms into `apply_all_terms` and `scatter_all_terms`.
+`register_terms!` in `eval.rs` stitches every term into `apply_all_terms` / `scatter_all_terms`, which feed both the engine and the board-based tuner gradient off the same impl.
 
-Adding a term is one macro line plus the impl — no edits to the eval pipeline or to `tape.rs`.
+Most terms are a **tapered bonus** — a feature dotted with an `(mg, eg)` weight pair, summed into the `bonus` bucket.
+Those never get a hand-written impl; they're one row of `tapered_bonus_term!`.
+You hand-write a `LinearTerm` only for a **"novel shape"** — own bucket, own combiner activation, MG-only taper, multi-bucket output. Those are below.
 
----
-
-## Linearity rule
-
-`LinearTerm` assumes `∂bucket/∂param` is a pure feature coefficient: `bucket += param · feature_expr`. The feature expression can be any combination of features; the parameter must appear linearly.
-
-| Pattern | Fast tape works? |
-|---|---|
-| `param · feature_count` | Yes |
-| `param · (feature_a * feature_b)` | Yes — feature non-linearity is free |
-| `param · (feature² / threshold)` | Yes |
-| `param_a · param_b · feature` | **No** — parameter non-linearity, breaks scatter |
-| `sigmoid(param_a + const) · feature` | **No** — param inside an activation |
-
-Parameter non-linearity belongs in the `Combiner` (as a bucket-level activation) or a future `NonlinearTerm` escape hatch. The oracle test will catch drift if you cross the line.
+The macros stop at the engine and the board path.
+They do not reach the **cached SoA path** (`src/tools/dataset/gradient.rs`) — a hand-rolled mirror that packs features into `i8` so the epoch loop over `.soul.zst` data skips recomputing the spatial tensor.
+It doesn't go through `LinearTerm`, so you mirror the term there yourself (Step 5).
+Forget it and the term is right on raw EPD and silently wrong on encoded data — the exact bug the bishop-pair gap once hid.
 
 ---
 
-## Recipe: bishop pair
+## The linearity rule
 
-A tapered bonus for holding both bishops. When white has the pair and black doesn't, add `mg_bonus · phase + eg_bonus · eg_phase` (and mirror for black).
+`LinearTerm` assumes `∂bucket/∂param` is a pure feature coefficient: `bucket += param · feature_expr`. The feature expression can be anything; the *parameter* has to stay linear.
 
-### 1. Add the params to `define_tunables!`
+| Pattern                            | Fast tape holds?                               |
+|------------------------------------|------------------------------------------------|
+| `param · feature_count`            | Yes                                            |
+| `param · (feature_a * feature_b)`  | Yes — feature non-linearity is free            |
+| `param · (feature² / threshold)`   | Yes                                            |
+| `param_a · param_b · feature`      | **No** — two params multiplied, scatter breaks |
+| `sigmoid(param + const) · feature` | **No** — param inside an activation            |
 
-In `src/engine/eval_params.rs`:
+Parameter non-linearity belongs in the `Combiner` as a bucket-level activation, or a future `NonlinearTerm`. Cross the line and the oracle catches you.
 
-```rust
-#[macro_export]
-macro_rules! define_tunables {
-    ($macro:ident) => {
-        $macro! {
-            // ...
-            (w_bishop_pair_mg, Scalar, $crate::engine::eval_params::LAYOUT.bishop_pair_offset),
-            (w_bishop_pair_eg, Scalar, $crate::engine::eval_params::LAYOUT.bishop_pair_offset + 1),
-        }
-    }
-}
-```
+---
 
-One entry feeds all three sites: the engine's `EvalParams<i32>`, the autograd `EvalParams<DualNode>`, and the tuner's f64 loader.
+## Recipe: a tapered bonus (bishop pair)
 
-### 2. Extend `Layout`
+A bonus for the pair: white holds both bishops and black doesn't, add `mg · phase + eg · eg_phase`, mirrored for black. Scalar case — one feature, one weight pair.
 
-Same file:
+### 1. The feature → `SharedFeatures`
 
-```rust
-pub struct Layout {
-    // ...
-    pub xray_offset: usize,
-    pub xray_len: usize,
-    pub bishop_pair_offset: usize,
-    pub bishop_pair_len: usize,
-}
-
-const fn calc_layout() -> Layout {
-    // ...
-    let xray_offset = king_safety_offset + safety_len;
-    let xray_len = 1;
-    let bishop_pair_offset = xray_offset + xray_len;
-    let bishop_pair_len = 2;
-
-    Layout {
-        // ...
-        xray_offset,
-        xray_len,
-        bishop_pair_offset,
-        bishop_pair_len,
-    }
-}
-```
-
-Then update `EvalParams::<i32>::from_const()` in `src/engine/eval.rs` to load the compile-time defaults for the new params.
-
-### 3. Write the term
-
-Place it in a sensible file — new module `src/engine/terms/bishop_pair.rs`, or co-located if it belongs with existing logic (e.g. pawn terms beside other pawn code):
-
-```rust
-use crate::{
-    core::{defs::TOTAL_PHASE, psqt::LAYOUT},
-    engine::{
-        autograd::EvalMath,
-        combiner::Accumulators,
-        eval::{EvalParams, SharedFeatures},
-        term::{LinearTerm, TaperPair},
-    },
-};
-
-pub struct BishopPairTerm;
-
-impl LinearTerm for BishopPairTerm {
-    type Upstream = TaperPair;
-
-    #[inline(always)]
-    fn apply<T: EvalMath<Scalar = T>>(
-        features: &SharedFeatures,
-        params: &EvalParams<T>,
-        phase: T,
-        acc: &mut Accumulators<T>,
-    ) {
-        let feature = T::from_i32(features.bishop_pair_diff);
-        let eg_phase = T::from_i32(TOTAL_PHASE) - phase;
-        let tapered = params.w_bishop_pair_mg * phase + params.w_bishop_pair_eg * eg_phase;
-        acc.bonus += (tapered * feature / T::from_i32(TOTAL_PHASE)).trunc();
-    }
-
-    #[inline]
-    fn scatter(features: &SharedFeatures, upstream: TaperPair, grads: &mut [f64]) {
-        let feature = features.bishop_pair_diff as f64;
-        grads[LAYOUT.bishop_pair_offset] += upstream.d_mg * feature;
-        grads[LAYOUT.bishop_pair_offset + 1] += upstream.d_eg * feature;
-    }
-}
-```
-
-`apply` uses `+=` on `acc.bonus` because the bonus bucket is shared across every simple tapered term. `scatter` reads `upstream.d_mg` / `upstream.d_eg` directly — the combiner already folded in the phase fractions and loss derivative, so scatter is just `upstream · ∂bucket/∂param`.
-
-### 4. Extend `SharedFeatures`
-
-Both `apply` and `scatter` read `features.bishop_pair_diff`, so it lives on `SharedFeatures` (single source, computed once per position). In `src/engine/eval.rs`:
+Computed once per position, read by every consumer. In `eval.rs`:
 
 ```rust
 pub struct SharedFeatures {
-    pub openness: i32,
-    pub data: MobilityData,
-    pub xray_ortho: i32,
-    pub bishop_pair_diff: i32,
+    // ...
+    pub bishop_pair_diff: i32, // +1 white pair, −1 black pair, 0 neither
 }
 
 impl SharedFeatures {
     pub fn compute(board: &Position) -> Self {
         // ... existing extraction ...
-        let bishop_pair_diff = pair_i32(board.pieces(PieceType::Bishop, Color::White))
-                             - pair_i32(board.pieces(PieceType::Bishop, Color::Black));
+        let w_pair = i32::from(board.pieces(PieceType::Bishop, Color::White).more_than_one());
+        let b_pair = i32::from(board.pieces(PieceType::Bishop, Color::Black).more_than_one());
+        let bishop_pair_diff = w_pair - b_pair;
         Self { /* ... */ bishop_pair_diff }
     }
 }
-
-fn pair_i32(bb: Bitboard) -> i32 { i32::from(bb.more_than_one()) }
 ```
 
-### 5. Register the term
+`compute` is White-relative. The cached path flips to STM in Step 5 — don't bake the sign in here.
 
-In `src/engine/eval.rs`:
+### 2. The weights and the slot map
+
+All in `eval_params.rs`, one line each:
 
 ```rust
-crate::register_terms! {
-    crate::engine::mobility::MobilityTerm => mobility,
-    crate::engine::mobility::KingSafetyTerm => king_safety,
-    crate::engine::terms::bishop_pair::BishopPairTerm => bonus,
-    XrayTerm => xray,
+// defaults
+define_weight_params! {
+    // ...
+    BISHOP_PAIR_WEIGHTS = [V(33), V(85)], // [MG, EG]
+}
+
+// slot map — the Layout struct and prefix-sum offsets are generated; order IS the map
+define_layout! {
+    // ...
+    bishop_pair = BISHOP_PAIR_WEIGHTS.len(),
+}
+
+// typed EvalParams fields — one row feeds engine i32, tuner f64, and oracle DualNode
+macro_rules! define_tunables {
+    ($macro:ident) => { $macro! {
+        // ...
+        (w_bp_mg, Scalar, bishop_pair_offset, 0),
+        (w_bp_eg, Scalar, bishop_pair_offset, 1),
+    }};
 }
 ```
 
-The right-hand side names the `BucketUpstreams` field that feeds this term's `scatter`. A tapered bonus routes to `bonus`.
+Then the compile-time defaults in `EvalParams::<i32>::from_const()` (`eval.rs`):
 
-### 6. Verify
-
-```sh
-cargo test -p tuner --release oracle
+```rust
+w_bp_mg: BISHOP_PAIR_WEIGHTS[0],
+w_bp_eg: BISHOP_PAIR_WEIGHTS[1],
 ```
 
-The per-term oracle tests in `tuner/src/evaltune/tape.rs` run each `LinearTerm` in isolation. If your scatter disagrees with the `DualNode` AD oracle by more than `1e-3` on any fen, the matching test fails and names the term.
+### 3. The term — one macro row
 
-### 7. SPRT
+No hand-written `apply`/`scatter` for a bonus. Scalar feature on a contiguous `(mg, eg)` slot:
 
-Commit with a `Bench: XXXXX` trailer (CI and OB requires it). Then SPRT the branch against base :)
+```rust
+tapered_bonus_term! {
+    BishopPairTerm = scalar(bishop_pair_diff, w_bp_mg, w_bp_eg, bishop_pair_offset);
+    // array form — N buckets, separate MG/EG blocks:
+    // PassedPawnTerm = array(passed_pawn, passed_mg, passed_eg, passed_mg_offset, passed_eg_offset, 6);
+}
+```
+
+Declare the marker struct with its peers, not buried in the macro:
+
+```rust
+/// Tapered bonus for holding both bishops (~9 Elo).
+pub struct BishopPairTerm;
+```
+
+### 4. Register it
+
+```rust
+crate::register_terms! {
+    // ...
+    BishopPairTerm => bonus,
+}
+```
+
+The right side is the `BucketUpstreams` field that feeds this term's `scatter`. A tapered bonus routes to `bonus`.
+
+### 5. Mirror the cached path
+
+`gradient.rs` packs features into `i8` at startup and runs its own forward/backward over the bytes — it never calls your `LinearTerm`, so mirror it or `.soul.zst` training is wrong:
+
+- `FeatureSlots`: a `pub bishop_pair: Vec<i8>` field and its `with_capacity` line.
+- `push_entry`: pack from the `SharedFeatures` value with the STM flip — `self.bishop_pair.push((sf.bishop_pair_diff * sign) as i8)`.
+                A white-minus-black diff negates for Black; a side-symmetric metric swaps halves.
+- `eval_soul_cached`: the forward contribution, `bp · (mg·mg_w + eg·eg_w)`, truncated.
+- `accumulate_gradient_cached`: the scatter — `grads[bp_offset] += gradient · bp · mg_w`, `+1` for eg.
+
+### 6. Oracle test, then run it
+
+Add a per-term test in `tape.rs` — a `term_for` arm, a `test_*_term_oracle`, and a fen that imbalances the feature (without one the term is never exercised, which is how the gap stays invisible).
+Then:
+
+```sh
+make oracle
+```
+
+The per-term tests run each `LinearTerm` against the `DualNode` oracle; the encoded test checks the cached path. Drift past `1e-3` on any fen fails and names the term.
+
+### 7. Bench, then SPRT
+
+`make bench`, commit with the `Bench: XXXXX` trailer (CI and OB demand it), SPRT against base. :)
 
 ---
 
-## Choosing the right bucket
+## Novel shapes
 
-For a pre-tapered, pure linear-sum term, route to `bonus`. No new bucket needed.
+When the term isn't a plain tapered bonus — its own bucket, a combiner activation, MG-only taper, multiple output buckets — skip the macro and hand-write the `LinearTerm`.
 
-If the term has its own combiner shape — a separate activation, its own taper logic — then it earns a new bucket.<br>
-Add a field to `Accumulators`, a matching field to `BucketUpstreams`, and update `LinearCombiner::forward` + `backward`.<br>
-Bucket additions touch every combiner impl, so only add one when a term's combiner treatment is genuinely different.
+The live examples:
 
-Multi-bucket terms (one term writing several accumulator fields from shared features) already exist — `KingSafetyTerm` writes both `safety_us` and `safety_them`.
-Scatter handles the per-side sign; `Upstream` is whatever the combiner produces for the shared block.
+- **`XrayTerm`** (`eval.rs`) — scalar, MG-only, `f64` upstream, writes the `xray` bucket. The smallest hand-written term, and the one to copy.
+- **`KingSafetyTerm`** (`mobility.rs`) — one feature pass, two buckets (`safety_us`, `safety_them`); attacker weights indexed by attacker count.
+- **`MobilityTerm`** (`mobility.rs`) — interpolates the open and closed weight vectors by openness, then tapers.
+
+Steps 1, 2, 4, 5, 6, 7 are unchanged. Only Step 3 becomes the hand-written impl instead of a macro row.
+
+---
+
+## Choosing the bucket
+
+Pre-tapered, pure linear sum → `bonus`. No new bucket.
+
+A term earns its own bucket only when its combiner treatment is genuinely different — a separate activation, its own taper.
+That costs a field on `Accumulators`, a matching field on `BucketUpstreams`, and an edit to `LinearCombiner::forward` + `backward`.
+Bucket additions touch every combiner impl, so add one deliberately.
+
+Multi-bucket terms already exist: `KingSafetyTerm` writes `safety_us` and `safety_them` from shared features, and scatter carries the per-side sign.
+`Upstream` is whatever the combiner hands the shared block.
 
 ---
 
 ## Gradient cheat sheet
 
-For a term routed to bucket `B` with upstream `U`, where `bucket += param · feature_expr(p)`:
+A term on bucket `B` with upstream `U`, where `bucket += param · feature_expr(p)`:
 
 ```
 grads[p] += U · feature_expr(p)
 ```
 
-| Bucket routing | `Upstream` type | Scatter formula |
-|---|---|---|
-| `bonus` (shared tapered bonus) | `TaperPair { d_mg, d_eg }` | `grads[mg] += d_mg · feature`, `grads[eg] += d_eg · feature` |
-| `mobility` (internal openness+phase blend) | `TaperPair` | Same shape, multiply by openness fraction — see `MobilityTerm::scatter` |
-| `king_safety` (raw bucket, combiner tapers) | `f64` | `grads[p] += upstream · feature_diff` |
-| `xray` (raw bucket, combiner tapers) | `f64` | `grads[xray] += upstream · feature` |
+|               Bucket              |         `Upstream`         |                                Scatter                                |
+|-----------------------------------|----------------------------|-----------------------------------------------------------------------|
+| `bonus` (tapered bonus)           | `TaperPair { d_mg, d_eg }` | `grads[mg] += d_mg · feature`, `grads[eg] += d_eg · feature`          |
+| `mobility` (openness+phase blend) | `TaperPair`                | same shape, times the openness fraction — see `MobilityTerm::scatter` |
+| `king_safety` (combiner tapers)   | `f64`                      | `grads[p] += upstream · feature_diff`                                 |
+| `xray` (combiner tapers)          | `f64`                      | `grads[xray] += upstream · feature`                                   |
 
-The combiner's `backward` has already folded in the loss derivative, STM sign, and taper. Scatter's only job is `upstream · ∂bucket/∂param`.
-
-If the shape isn't on the table, derive `∂bucket/∂param` by hand from your `apply` formula. The oracle test catches mistakes — run it.
+The combiner's `backward` already folded in the loss derivative, the STM sign, and the taper, so scatter is only `upstream · ∂bucket/∂param`.
+A `tapered_bonus_term!` row generates all of it — the table matters when you hand-write a novel shape.
+If your shape isn't here, derive `∂bucket/∂param` from your `apply` by hand; the oracle catches the slips.

--- a/tuner/EVAL_TUNER.md
+++ b/tuner/EVAL_TUNER.md
@@ -1,64 +1,40 @@
 # The Eval Tuner
 
-*How it works and why it's structured the way it is.*
+How it works, and why it's shaped this way.
 
 ---
 
-## The Core Idea
+## The core idea
 
-Think of evaluation parameters like the knobs on a mixing board.
-Each knob controls how much weight a specific positional feature gets — how important is a pawn shield?
-How much do we reward mobility?
-The tuner's job is to find the knob positions that minimize the gap between what the engine
-thinks about a position and what actually happened in real games.
+Evaluation parameters are the knobs on a mixing board.
+Each one sets how much a positional feature counts — what a pawn shield is worth, how much mobility earns.
+Tuning is finding the knob positions that close the gap between what the engine thinks of a position and what actually happened in the games.
 
-The engine computes `score = Σ(feature_i · weight_i)`. The tuner adjusts the weights
-to minimize `(sigmoid(score) - game_result)²` across millions of positions.
+The engine computes `score = Σ(featureᵢ · weightᵢ)`.
+The tuner moves the weights to minimize `(sigmoid(score) − result)²` over millions of positions.
+To move a weight you need its gradient — which way to turn the knob, and how far.
 
-To do that, we need gradients — for each weight, which direction should we turn
-the knob, and how far?
+## Two ways to get the gradient
 
-## Two Gradient Engines
+The eval is linear in its parameters: every weight shows up as `weight · feature`.
+So a weight's gradient is just its feature coefficient — no calculus at runtime, only bookkeeping.
+If `score = 3·w_shield + 7·w_mobility + …`, then `∂score/∂w_shield = 3`, and that `3` is a fact about the board, not about the weight's value.
 
-The tuner has two independent systems for computing gradients.
-They produce the same answers but work in fundamentally different ways:
+**Direct (`eval_linear_grad`) — production.** Evaluate the position, read each feature coefficient straight off the board, phase, and openness, scatter `outer_deriv · coefficient` into the gradient vector. ~90 f64 ops on top of the eval itself. This is what runs every epoch.
 
-### The Direct Path — production (`eval_linear_grad`)
+For encoded `.soul.zst` datasets the direct path has a cached twin in `src/tools/dataset/gradient.rs`: the features are packed into `i8` once at startup, so the epoch loop never recomputes the spatial tensor. Same math, packed storage — and it's a hand-rolled mirror, so a new term has to be wired there by hand or it's silently wrong on encoded data.
 
-Since our eval is a linear function of its parameters — every weight appears as
-`weight · board_feature` — the gradient for each weight is simply its feature
-coefficient. No calculus required at runtime, just bookkeeping.
-
-If you know `score = 3 · w_shield + 7 · w_mobility + ...`, then `d(score)/d(w_shield) = 3`.
-That number `3` depends on the board, not on the weight values.
-
-This is what `eval_linear_grad` computes: it evaluates the position, then extracts
-each feature coefficient directly from the board state, phase, and openness.
-Cost: ~90 f64 operations for feature coefficients, plus the eval itself.
-This is what runs in the training loop.
-
-### The Dual Number Path — oracle (`eval_dual_fused`)
-
-This is a general-purpose automatic differentiation engine.
-It works by replacing every number in the computation with a "dual number",
-value paired with a gradient vector. When you multiply two dual numbers,
-the product rule happens automatically. When you add them, the gradients add.
-
-It handles any function, not just linear ones.
-If you ever added `sigmoid(w₁ · w₂)` to the eval, the dual path would still give correct gradients.
-The direct path would not — you'd need to update it.
-
-The dual path lives as a correctness oracle. When you add a new eval term and write
-its gradient formula, you can run both paths and compare.
-If they disagree, your hand-derived formula has a bug.
+**Dual (`eval_dual_fused`) — oracle.** Forward-mode autodiff: every number carries its gradient vector, the product rule fires on each multiply, the chain rule falls out for free.
+It handles any function, linear or not — drop a `sigmoid(w₁·w₂)` into the eval and it still returns the right gradient where the direct path would quietly hand you a wrong one.
+It earns its keep as a check; run both, diff the gradients, and disagreement means the hand-derived formula has a bug. The per-term tests in `tape.rs` are exactly that diff.
 
 ## Architecture
 
-### Training Loop
+### Training loop
 
 ```mermaid
 flowchart LR
-    EPD["Positions (EPD)"] --> EF64
+    EPD["Positions (EPD / .soul.zst)"] --> EF64
 
     subgraph Forward ["Forward Pass"]
         EF64["eval_f64 → score"] --> SIG["sigmoid σ(score)"] --> LOSS["(σ − target)²"]
@@ -77,80 +53,60 @@ flowchart LR
     W -. "next epoch" .-> EF64
 ```
 
-### Eval Internals
+### The eval, by bucket
+
+`evaluate_generic<T>` fills per-bucket accumulators, the combiner sums them, then the score flips for side to move.
+Each term writes one bucket; the buckets are the stable shape, not the term list.
+Anything non-linear lives in the combiner, never in a term — that's the line that keeps the direct gradient honest.
 
 ```mermaid
 flowchart TD
-    PSQT["PSQT (384 + 12 material)"] --> TAP
-    PH["Phase (6 weights)"] --> TAP
-    PH --> SDIFF
-    OPEN["Openness (pawn structure)"] --> SDIFF
+    ACC["SIMD accumulator — PSQT + material"] --> MGEG["mg_eg"]
+    MOB["mobility / threats / battery / xray reach"] --> MOBB["mobility"]
+    BON["bishop pair · rook-open · passers · king-distance · …"] --> BONB["bonus"]
+    SAF["shield / exposure / weak squares · xray ring"] --> SAFB["safety − safety + xray"]
+    PHASE["phase"] --> MGEG
+    PHASE --> SAFB
+    OPEN["openness"] --> MOBB
 
-    subgraph EvalParams ["EvalParams — 26 weights"]
-        MW["Mobility (8 open + 8 closed)"]
-        KS["King safety (3)"]
-        ATK["Attackers (6)"]
-        XR["X-Ray (1)"]
-    end
-
-    subgraph Board ["Board-derived features"]
-        MOB["Mobility / threats / shadow"]
-        SAFE_F["Shield, exposure, weak squares"]
-        XR_F["X-Ray ortho diff"]
-    end
-
-    MOB --> SDIFF
-    SAFE_F --> SAFE
-    XR_F --> SAFE
-
-    KS --> SAFE
-    ATK --> SAFE
-    XR --> SAFE
-    MW --> SDIFF
-
-    subgraph eval ["evaluate_generic‹T›"]
-        TAP["tapered(mg, eg, phase)"]
-        SAFE["safety.score()"]
-        SDIFF["evaluate_score_diff()"]
-        TAP & SAFE & SDIFF --> SUM(("Σ"))
+    subgraph Combiner ["LinearCombiner"]
+        MGEG & MOBB & BONB & SAFB --> SUM(("Σ"))
         SUM --> FLIP["· stm_sign"]
     end
-
-    FLIP --> OUT(["Score"])
+    FLIP --> OUT(["score"])
 ```
 
-**Three instantiations of `T`:**
+The `bonus` bucket is the cheap home for any pre-tapered linear term; a term earns its own bucket only when it needs a combiner shape of its own — an activation, a different taper.
+See [ADDING_EVAL_TERMS.md](ADDING_EVAL_TERMS.md).
 
-| Context | `T` type | What it does |
-|---------|----------|-------------|
-| Engine search | `i32` | Fast integer eval, const-inlined weights |
-| Tuner score | `f64` | Floating-point eval for sigmoid/loss |
-| Tuner oracle | `DualNode` | Forward-mode AD, carries `[f32; 32]` gradient array |
+**`T` resolves three ways, one code path:**
+
+|    Context    |     `T`    |                                      What it does                                     |
+|---------------|------------|---------------------------------------------------------------------------------------|
+| Engine search | `i32`      | Fast integer eval, weights const-inlined                                              |
+| Tuner score   | `f64`      | Float eval for sigmoid and loss                                                       |
+| Tuner oracle  | `DualNode` | Forward-mode AD, carries `[f32; DUAL_N]` — `DUAL_N` self-sizes from the tunable count |
 
 ## Files
 
-| File | What it does |
-|------|-------------|
-| `src/engine/eval.rs` | `evaluate_generic<T>` — the eval, generic over math type |
-| `src/engine/eval_params.rs` | Const arrays for weights, `Tunable` descriptors |
-| `src/engine/autograd/dual.rs` | `DualNode` — forward-mode AD engine |
-| `src/core/psqt.rs` | PSQT layout, parameter offsets, index mapping |
-| `tuner/src/evaltune/tape.rs` | `eval_linear_grad` (production), `eval_dual_fused` (oracle), `eval_f64` (score-only) |
-| `tuner/src/evaltune/evaltuner.rs` | Training loop, optimizer, scheduling |
-| `tuner/src/evaltune/training.rs` | `TrainableEntry` trait (used by encoded `.soul.zst` path) |
+|                File               |                                               What it does                                             |
+|-----------------------------------|--------------------------------------------------------------------------------------------------------|
+| `src/engine/eval.rs`              | `evaluate_generic<T>` — the eval, generic over the math type; terms and `register_terms!`              |
+| `src/engine/eval_params.rs`       | Weight arrays, the `define_layout!` slot map, `Tunable` descriptors                                    |
+| `src/engine/combiner.rs`          | `LinearCombiner` — collapses buckets to a scalar, owns every non-linearity                             |
+| `src/engine/autograd/dual.rs`     | `DualNode` — forward-mode AD engine                                                                    |
+| `src/core/psqt.rs`                | PSQT layout, parameter offsets, index mapping                                                          |
+| `tuner/src/evaltune/tape.rs`      | `eval_linear_grad` (production), `eval_dual_fused` (oracle), `eval_f64` (score-only)                   |
+| `src/tools/dataset/gradient.rs`   | Cached SoA gradient for `.soul.zst` — `FeatureSlots`, `eval_soul_cached`, `accumulate_gradient_cached` |
+| `tuner/src/evaltune/evaltuner.rs` | Training loop, optimizer, scheduling                                                                   |
 
-## Performance Notes
+## Performance notes
 
-The direct path adds zero overhead to the eval itself — it calls `eval_f64`
-for the score and computes feature coefficients separately.
-The cost is dominated by the eval, not the gradients.
+The direct path adds nothing to the eval — it calls `eval_f64` for the score and derives the feature coefficients alongside. The cost is the eval, not the gradient.
 
-The FTZ/DAZ flags (Flush-To-Zero, Denormals-Are-Zero) are set on every Rayon worker
-thread via a `start_handler` in `evaltune.rs`.
-Without these, subnormal floats *might* cause 4-10× slowdowns on specific gradient values as training converges.
+FTZ/DAZ (flush-to-zero, denormals-are-zero) are set on every Rayon worker via a `start_handler` in `evaltune.rs`.
+Without them, subnormal floats can drag specific gradient values into a 4–10× slowdown as training converges on small numbers.
 
 ---
 
-
-**→ See [ADDING_EVAL_TERMS.md](ADDING_EVAL_TERMS.md) for the step-by-step recipe
-for wiring new evaluation parameters.**
+**→ [ADDING_EVAL_TERMS.md](ADDING_EVAL_TERMS.md) — the step-by-step recipe for wiring a new term.**

--- a/tuner/src/evaltune/report.rs
+++ b/tuner/src/evaltune/report.rs
@@ -163,62 +163,28 @@ pub fn write_params<W: Write>(w: &mut W, params: &[Tunable], values: &[f64], ini
     if params.len() > psqt::LAYOUT.weight_offset {
         writeln!(w, "\ndefine_weight_params! {{").ok();
 
-        write!(w, "    PHASE_WEIGHTS       = [").ok();
-        write_weight_array(w, psqt::LAYOUT.weight_offset, 6, values, params, initial);
-        writeln!(w, "], // [P, N, B, R, Q, K]").ok();
+        let l = psqt::LAYOUT;
 
-        if params.len() > psqt::LAYOUT.attacker_offset {
-            write!(w, "    ATTACKER_WEIGHTS    = [").ok();
-            write_weight_array(w, psqt::LAYOUT.attacker_offset, 6, values, params, initial);
-            writeln!(w, "], // [0, 1, 2, 3, 4, 5] attackers × weak").ok();
-        }
+        #[rustfmt::skip]
+        let bands: &[(&str, usize, usize, &str)] = &[
+            ("PHASE_WEIGHTS",       l.weight_offset,             6, " // [P, N, B, R, Q, K]"),
+            ("ATTACKER_WEIGHTS",    l.attacker_offset,           6, " // [0, 1, 2, 3, 4, 5] attackers × weak"),
+            ("KING_SAFETY_WEIGHTS", l.king_safety_offset,        3, " // [Pawn Shield, Ortho Exp, Diag Exp]"),
+            ("XRAY_WEIGHTS",        l.xray_offset,               1, " // [Ortho King]"),
+            ("BISHOP_PAIR_WEIGHTS", l.bishop_pair_offset,        2, " // [MG, EG]"),
+            ("ROOK_OPEN_WEIGHTS",   l.rook_open_offset,          2, " // [MG, EG]"),
+            ("PASSED_PAWN_MG",      l.passed_mg_offset,          6, " // by relative rank 1-6"),
+            ("PASSED_PAWN_EG",      l.passed_eg_offset,          6, " // by relative rank 1-6"),
+            ("ENEMY_KING_DIST_MG",  l.enemy_king_dist_mg_offset, 6, " // enemy king→passer dist, 7 clamps to 6"),
+            ("ENEMY_KING_DIST_EG",  l.enemy_king_dist_eg_offset, 6, " // enemy king→passer dist, 7 clamps to 6"),
+        ];
 
-        if params.len() > psqt::LAYOUT.king_safety_offset {
-            write!(w, "    KING_SAFETY_WEIGHTS = [").ok();
-            write_weight_array(w, psqt::LAYOUT.king_safety_offset, 3, values, params, initial);
-            writeln!(w, "], // [Pawn Shield, Ortho Exp, Diag Exp]").ok();
-        }
-
-        if params.len() > psqt::LAYOUT.xray_offset {
-            write!(w, "    XRAY_WEIGHTS        = [").ok();
-            write_weight_array(w, psqt::LAYOUT.xray_offset, 1, values, params, initial);
-            writeln!(w, "], // [Ortho King]").ok();
-        }
-
-        if params.len() > psqt::LAYOUT.bishop_pair_offset {
-            write!(w, "    BISHOP_PAIR_WEIGHTS = [").ok();
-            write_weight_array(w, psqt::LAYOUT.bishop_pair_offset, 2, values, params, initial);
-            writeln!(w, "], // [MG, EG]").ok();
-        }
-
-        if params.len() > psqt::LAYOUT.rook_open_offset {
-            write!(w, "    ROOK_OPEN_WEIGHTS   = [").ok();
-            write_weight_array(w, psqt::LAYOUT.rook_open_offset, 2, values, params, initial);
-            writeln!(w, "], // [MG, EG]").ok();
-        }
-
-        if params.len() > psqt::LAYOUT.passed_mg_offset {
-            write!(w, "    PASSED_PAWN_MG      = [").ok();
-            write_weight_array(w, psqt::LAYOUT.passed_mg_offset, 6, values, params, initial);
-            writeln!(w, "], // by relative rank 1-6").ok();
-        }
-
-        if params.len() > psqt::LAYOUT.passed_eg_offset {
-            write!(w, "    PASSED_PAWN_EG      = [").ok();
-            write_weight_array(w, psqt::LAYOUT.passed_eg_offset, 6, values, params, initial);
-            writeln!(w, "], // by relative rank 1-6").ok();
-        }
-
-        if params.len() > psqt::LAYOUT.enemy_king_dist_mg_offset {
-            write!(w, "    ENEMY_KING_DIST_MG  = [").ok();
-            write_weight_array(w, psqt::LAYOUT.enemy_king_dist_mg_offset, 6, values, params, initial);
-            writeln!(w, "], // enemy king→passer dist, 7 clamps to 6").ok();
-        }
-
-        if params.len() > psqt::LAYOUT.enemy_king_dist_eg_offset {
-            write!(w, "    ENEMY_KING_DIST_EG  = [").ok();
-            write_weight_array(w, psqt::LAYOUT.enemy_king_dist_eg_offset, 6, values, params, initial);
-            writeln!(w, "], // enemy king→passer dist, 7 clamps to 6").ok();
+        for &(name, offset, count, comment) in bands {
+            if params.len() > offset {
+                write!(w, "    {name:<20}= [").ok();
+                write_weight_array(w, offset, count, values, params, initial);
+                writeln!(w, "],{comment}").ok();
+            }
         }
 
         writeln!(w, "}}").ok();

--- a/tuner/src/evaltune/report.rs
+++ b/tuner/src/evaltune/report.rs
@@ -143,18 +143,19 @@ pub fn write_params<W: Write>(w: &mut W, params: &[Tunable], values: &[f64], ini
     if params.len() > psqt::LAYOUT.mobility_open_offset {
         writeln!(w, "\ndefine_simd_params! {{").ok();
 
+        #[rustfmt::skip]
         let mobility_bands = [
-            ("MG_MOBILITY_OPEN", psqt::LAYOUT.mobility_open_offset),
-            ("EG_MOBILITY_OPEN", psqt::LAYOUT.mobility_open_offset + 4),
-            ("MG_MOBILITY_CLOSED", psqt::LAYOUT.mobility_closed_offset),
-            ("EG_MOBILITY_CLOSED", psqt::LAYOUT.mobility_closed_offset + 4),
+            ("MG_MOBILITY_OPEN",   psqt::LAYOUT.mobility_open_offset,       " // [mobility, battery, threats, xray threats]"),
+            ("EG_MOBILITY_OPEN",   psqt::LAYOUT.mobility_open_offset + 4,   ""),
+            ("MG_MOBILITY_CLOSED", psqt::LAYOUT.mobility_closed_offset,     ""),
+            ("EG_MOBILITY_CLOSED", psqt::LAYOUT.mobility_closed_offset + 4, ""),
         ];
 
-        for (name, offset) in &mobility_bands {
+        for (name, offset, comment) in &mobility_bands {
             writeln!(w, "    {name} = [").ok();
             write!(w, "        ").ok();
             write_weight_array(w, *offset, 4, values, params, initial);
-            writeln!(w, "],").ok();
+            writeln!(w, "],{comment}").ok();
         }
 
         writeln!(w, "}}").ok();

--- a/tuner/src/evaltune/tape.rs
+++ b/tuner/src/evaltune/tape.rs
@@ -537,14 +537,24 @@ mod tests {
     use super::*;
     use crate::evaltune::training::sigmoid;
 
+    // Each must round-trip cleanly through `SoulEntry`.
     const FENS: &[&str] = &[
+        // White-to-move
         "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
         "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
         "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
         "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+        // Black-to-move
+        "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1",
+        "r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 4 4",
+        // Bishop pair imbalance
+        "r1bqkbnr/1pp2ppp/p1p5/4p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 5",
+        // Rook open-file imbalance
         "2r3k1/pp3ppp/4p3/8/8/8/PPP2PPP/3R2K1 w - - 0 1",
+        // Passed pawns: mid-board and near-promotion
         "8/2k5/8/3K4/2P5/8/8/8 w - - 0 1",
         "8/4P3/6k1/4K3/8/8/8/8 w - - 0 1",
+        // Passer far from the enemy king
         "8/8/P7/8/2K5/8/8/7k w - - 0 1",
     ];
 
@@ -677,25 +687,6 @@ mod tests {
         );
     }
 
-    const ENCODED_FENS: &[&str] = &[
-        // White-to-move
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
-        "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
-        // Black-to-move
-        "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1",
-        "r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 4 4",
-        // Bishop pair imbalance
-        "r1bqkbnr/1pp2ppp/p1p5/4p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 5",
-        // Rook open-file imbalance
-        "2r3k1/pp3ppp/4p3/8/8/8/PPP2PPP/3R2K1 w - - 0 1",
-        // Passed pawns: mid-board and near-promotion
-        "8/2k5/8/3K4/2P5/8/8/8 w - - 0 1",
-        "8/4P3/6k1/4K3/8/8/8/8 w - - 0 1",
-        // Passer far from the enemy king
-        "8/8/P7/8/2K5/8/8/7k w - - 0 1",
-    ];
-
     /// `accumulate_gradient` shares math with the board-based gradient paths.
     /// A drift here corrupts every `run_encoded` session.
     #[test]
@@ -703,7 +694,7 @@ mod tests {
         let values = full_values();
         let n_params = values.len();
 
-        for fen in ENCODED_FENS {
+        for fen in FENS {
             let pos = Position::from_fen(fen);
             let entry = SoulEntry::from_board(&pos, TARGET, None, Some(20));
 

--- a/tuner/src/evaltune/tape.rs
+++ b/tuner/src/evaltune/tape.rs
@@ -15,7 +15,6 @@ use soul::{
         autograd::{
             EnvVec8, EvalMath,
             dual::{DUAL_N, DualNode, DualVec8},
-            traits::F64Vec4,
         },
         combiner::{Combiner, LinearCombiner},
         eval::{EvalParams, SharedFeatures, evaluate_generic, scatter_all_terms},
@@ -446,7 +445,6 @@ pub fn eval_f64(board: &Board, values: &[f64]) -> f64 {
 /// Score-only evaluation that also returns the trace accumulator and piece counts.
 ///
 /// Used by `eval_linear_grad` to avoid redundant board iterations.
-#[allow(clippy::too_many_lines)]
 pub fn eval_f64_with_acc(board: &Board, values: &[f64]) -> (f64, [f64; 8], [f64; 6]) {
     let mut trace_acc = <f64 as EvalMath>::Vec8::zero();
     let mut piece_counts = [0.0f64; 6];
@@ -456,52 +454,8 @@ pub fn eval_f64_with_acc(board: &Board, values: &[f64]) -> (f64, [f64; 8], [f64;
     let phase_raw = compute_phase(&piece_counts, values);
     let phase = phase_raw.math_clamp(0.0, 24.0).trunc();
 
-    let lo = psqt::LAYOUT.mobility_open_offset;
-    let lc = psqt::LAYOUT.mobility_closed_offset;
-    let ks = psqt::LAYOUT.king_safety_offset;
-    let ao = psqt::LAYOUT.attacker_offset;
-    let xr = psqt::LAYOUT.xray_offset;
-    let bp = psqt::LAYOUT.bishop_pair_offset;
-    let ro = psqt::LAYOUT.rook_open_offset;
-    let pmg = psqt::LAYOUT.passed_mg_offset;
-    let peg = psqt::LAYOUT.passed_eg_offset;
-    let ekmg = psqt::LAYOUT.enemy_king_dist_mg_offset;
-    let ekeg = psqt::LAYOUT.enemy_king_dist_eg_offset;
-
-    let params = EvalParams {
-        mg_mob_open: F64Vec4([values[lo], values[lo + 1], values[lo + 2], values[lo + 3]]),
-        eg_mob_open: F64Vec4([values[lo + 4], values[lo + 5], values[lo + 6], values[lo + 7]]),
-        mg_mob_closed: F64Vec4([values[lc], values[lc + 1], values[lc + 2], values[lc + 3]]),
-        eg_mob_closed: F64Vec4([values[lc + 4], values[lc + 5], values[lc + 6], values[lc + 7]]),
-        w_shield: values[ks],
-        w_ortho: values[ks + 1],
-        w_diag: values[ks + 2],
-        atk_weights: [values[ao], values[ao + 1], values[ao + 2], values[ao + 3], values[ao + 4], values[ao + 5]],
-        w_xray_ortho: values[xr],
-        w_bp_mg: values[bp],
-        w_bp_eg: values[bp + 1],
-        w_rook_open_mg: values[ro],
-        w_rook_open_eg: values[ro + 1],
-        passed_mg: [values[pmg], values[pmg + 1], values[pmg + 2], values[pmg + 3], values[pmg + 4], values[pmg + 5]],
-        passed_eg: [values[peg], values[peg + 1], values[peg + 2], values[peg + 3], values[peg + 4], values[peg + 5]],
-        enemy_king_dist_mg: [
-            values[ekmg],
-            values[ekmg + 1],
-            values[ekmg + 2],
-            values[ekmg + 3],
-            values[ekmg + 4],
-            values[ekmg + 5],
-        ],
-        enemy_king_dist_eg: [
-            values[ekeg],
-            values[ekeg + 1],
-            values[ekeg + 2],
-            values[ekeg + 3],
-            values[ekeg + 4],
-            values[ekeg + 5],
-        ],
-    };
-
+    // Same generator the DualNode path uses — no per-term hand literal to drift.
+    let params = EvalParams::<f64>::load_tunable(values);
     let features = SharedFeatures::compute(board);
     (evaluate_generic::<f64>(board, &trace_acc, phase, &params, Some(&features)), trace_acc.0, piece_counts)
 }


### PR DESCRIPTION
Replaces hand-maintained lockstep tables with single sources of truth:

- `define_layout!` generates the param slot map — adding a tunable is a line in the macro,
  not a slot index to hand-thread through `eval_params.rs`.
- `tapered_bonus_term!` generates the `MG`/`EG` bonus terms instead of spelling each out.
- The tuner feature cache packs straight from `SharedFeatures`,
  so the SoA gradient path mirrors the registered terms by construction instead of by vigilance.
- f64 `EvalParams` deduped; the report writer is now table-driven.
- Docs (`ADDING_EVAL_TERMS.md`, `EVAL_TUNER.md`) updated to the new flow.

Bench: 5829154