### PR TITLE
Contiguous feature record, tuner cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tuner"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap",
  "ctrlc",

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 EXE_NAME := soul
 DEPTH    ?= 12
 
+# Evaltune profiling dataset + epoch count.
+ET_DATA   ?= data/big3.txt
+ET_EPOCHS ?= 100
+
 HAS_PGO := $(shell command -v cargo-pgo 2> /dev/null)
 RUST_HOST := $(shell rustc -vV | sed -n 's/host: //p')
 
@@ -26,7 +30,7 @@ EXE := $(EXE_NAME)$(EXE_EXT)
 DEBUG_EXE := debug$(EXE_EXT)
 
 .PHONY: all help debug release native bench v3 v4 pgo openbench clean \
-        evaltune searchtune test oracle seeformat format clippy profile \
+        evaltune searchtune test oracle seeformat format clippy profile etprofile \
         releases avx2 avx2-bmi2 avx512 corrstats
 
 all: openbench
@@ -125,6 +129,19 @@ profile: ## Generate CPU performance profile
 	@perf report --stdio --header --inline --children --max-stack 15 --percent-limit 1.0 > profile_data.txt
 	@echo "\nThe profiling report has been generated in profile_data.txt"
 	@echo "Done: profile_data.txt"
+
+etprofile: ## Generate CPU performance profile for evaltune (set ET_DATA / ET_EPOCHS)
+	@echo "Building evaltune with debug symbols..."
+	@RUSTFLAGS="-C target-cpu=native -C force-frame-pointers=yes" \
+		cargo build --profile profiling -p tuner --bin evaltune --quiet
+	@cp target/profiling/evaltune eval$(EXE_EXT)
+	@echo "Recording profile ($(ET_DATA), $(ET_EPOCHS) epochs)..."
+	@rm -f perf.data
+	@perf record -g --call-graph fp -F 999 ./eval$(EXE_EXT) -d $(ET_DATA) -e $(ET_EPOCHS) --seed 1
+	@echo "Generating profiling report..."
+	@perf report --stdio --header --inline --children --max-stack 15 --percent-limit 1.0 > evaltune_profile_data.txt
+	@echo "\nThe profiling report has been generated in evaltune_profile_data.txt"
+	@echo "Done: evaltune_profile_data.txt"
 
 openbench:
 ifdef HAS_PGO

--- a/src/tools/dataset/gradient.rs
+++ b/src/tools/dataset/gradient.rs
@@ -1,5 +1,7 @@
 //! Gradient computation against dataset entries for evaluation tuning.
 
+use std::array;
+
 use super::SoulEntry;
 use crate::{
     core::{
@@ -14,61 +16,66 @@ use crate::{
     },
 };
 
-/// Pre-computed instance-level features, populated at tuner startup.
+/// All tuner-side features for one position, packed into a single contiguous
+/// 132-byte record — about two cache lines — so the hot training loop reads one
+/// record instead of streaming a dozen independent arrays.
 ///
-/// Features are packed into raw byte arrays for SoA (Structure of Arrays) layout:
-/// the i-th entry in each vec corresponds to the i-th SoulEntry in the training set.
-/// This avoids pointer-chasing through AoS structs during the hot gradient loop.
-pub struct FeatureSlots {
-    pub mobility: Vec<[i8; 8]>,
-    pub safety_us: Vec<[u8; 4]>,
-    pub safety_them: Vec<[u8; 4]>,
-    pub xray_ortho: Vec<i8>,
-    pub bishop_pair: Vec<i8>,
-    pub rook_open: Vec<i8>,
-    pub passed_pawn: Vec<[i8; 6]>,
-    pub enemy_king_dist: Vec<[i8; 6]>,
-    pub doubled_pawn: Vec<i8>,
-    pub isolated_pawn: Vec<i8>,
-    pub phalanx: Vec<[i8; 6]>,
-    pub defended_pawn: Vec<[i8; 6]>,
-    pub backward_pawn: Vec<i8>,
-    pub tempo: Vec<i8>,
-    /// Raw static eval for volatility filtering at training time.
-    pub static_eval: Vec<i16>,
+/// Everything here is *static* across epochs — only `values` changes during
+/// training — so it is computed once at startup ([`FeatureRecord::from_entry`])
+/// and read straight through on every epoch. The PSQT gather index is
+/// pre-resolved and the board decode is folded in, so the loop never re-walks
+/// the nibble array nor reconstructs a `Position`.
+///
+/// Fields are STM-relative (us − them) to match the training target; the
+/// perspective flip happens once, at pack time.
+#[repr(C)]
+pub struct FeatureRecord {
+    /// Sign-encoded PSQT gather index per piece, one slot per occupied square.
+    /// Bits 0..14 = the MG PSQT index (≤ 351); the EG index is that `+ 32` (≤ 383).
+    /// Bit 15 = piece sign (set = "them", subtracted from the score).
+    pub piece_idx: [u16; 32],
+    pub passed_pawn: [i8; 6],
+    pub enemy_king_dist: [i8; 6],
+    pub phalanx: [i8; 6],
+    pub defended_pawn: [i8; 6],
+    /// `[us×4, them×4]`: mobility, shadow_mobility, threats, shadow_threats.
+    pub mobility: [i8; 8],
+    /// `[attackers, weak, shield, ortho<<4 | diag]`, king-safety metrics.
+    pub safety_us: [u8; 4],
+    pub safety_them: [u8; 4],
+    /// Material count differential per piece type (us − them).
+    pub mat_diffs: [i8; 6],
+    /// Piece counts per type, for the tapered phase weight.
+    pub phase_counts: [u8; 6],
+    /// Raw `compute_openness_raw` result; openness = `open_raw / OPEN_UNITY`.
+    /// Stored raw (not as a float) to keep the openness math bit-exact.
+    pub open_raw: i32,
+    /// Raw static eval, for volatility filtering at training time.
+    pub static_eval: i16,
+    pub xray_ortho: i8,
+    pub bishop_pair: i8,
+    pub rook_open: i8,
+    pub doubled_pawn: i8,
+    pub isolated_pawn: i8,
+    pub backward_pawn: i8,
+    pub tempo: i8,
+    pub piece_count: u8,
 }
 
-impl FeatureSlots {
-    pub fn with_capacity(cap: usize) -> Self {
-        Self {
-            mobility: Vec::with_capacity(cap),
-            safety_us: Vec::with_capacity(cap),
-            safety_them: Vec::with_capacity(cap),
-            xray_ortho: Vec::with_capacity(cap),
-            bishop_pair: Vec::with_capacity(cap),
-            rook_open: Vec::with_capacity(cap),
-            passed_pawn: Vec::with_capacity(cap),
-            enemy_king_dist: Vec::with_capacity(cap),
-            doubled_pawn: Vec::with_capacity(cap),
-            isolated_pawn: Vec::with_capacity(cap),
-            phalanx: Vec::with_capacity(cap),
-            defended_pawn: Vec::with_capacity(cap),
-            backward_pawn: Vec::with_capacity(cap),
-            tempo: Vec::with_capacity(cap),
-            static_eval: Vec::with_capacity(cap),
-        }
-    }
+const _: () = assert!(size_of::<FeatureRecord>() == 132);
 
-    /// Reconstruct a Position from the entry, and append the packed results to the slot arrays.
+impl FeatureRecord {
+    /// Decode a nibble-encoded entry into the packed training record.
     ///
-    /// The FEN round-trip (`to_fen` → `Position::from_fen`) is one-time startup
-    /// cost per entry — it never executes inside the training loop.
-    /// A direct nibble→Position decoder would eliminate the intermediate string allocation,
-    /// but the current cost is negligible next to the feature computation itself
-    pub fn push_entry(&mut self, entry: &SoulEntry) {
+    /// The FEN round-trip (`to_fen` → `from_fen`) plus `SharedFeatures::compute`
+    /// is a one-time startup cost per entry — none of it runs inside the
+    /// training loop. A direct nibble→`Position` decoder would drop the
+    /// intermediate string, but the cost is negligible next to the feature
+    /// computation itself.
+    pub fn from_entry(entry: &SoulEntry) -> Self {
         let pos = Position::from_fen(&entry.to_fen());
 
-        // SharedFeatures is White-relative; the cache is STM-relative, so flip
+        // SharedFeatures is White-relative; the record is STM-relative, so flip
         // perspective here. Side-symmetric metrics (mobility, safety) swap halves
         // for Black; white-minus-black differentials (xray, pairs, passers) negate.
         let sf = SharedFeatures::compute(&pos);
@@ -89,343 +96,269 @@ impl FeatureSlots {
             ]
         };
 
-        let mut mob_arr = [0i8; 8];
-        mob_arr[..4].copy_from_slice(&pack_side(mob_us));
-        mob_arr[4..].copy_from_slice(&pack_side(mob_them));
-        self.mobility.push(mob_arr);
-
-        self.safety_us.push(pack_safety(saf_us));
-        self.safety_them.push(pack_safety(saf_them));
+        let mut mobility = [0i8; 8];
+        mobility[..4].copy_from_slice(&pack_side(mob_us));
+        mobility[4..].copy_from_slice(&pack_side(mob_them));
 
         let sign = if black { -1 } else { 1 };
-        self.xray_ortho.push((sf.xray_ortho * sign) as i8);
-        self.bishop_pair.push((sf.bishop_pair_diff * sign) as i8);
-        self.rook_open.push((sf.rook_open_diff * sign) as i8);
 
-        self.passed_pawn.push(std::array::from_fn(|i| (sf.passed_pawn[i] * sign) as i8));
-        self.enemy_king_dist.push(std::array::from_fn(|i| (sf.enemy_king_dist[i] * sign) as i8));
-        self.doubled_pawn.push((sf.doubled_pawn_diff * sign) as i8);
-        self.isolated_pawn.push((sf.isolated_pawn_diff * sign) as i8);
-        self.phalanx.push(std::array::from_fn(|i| (sf.phalanx[i] * sign) as i8));
-        self.defended_pawn.push(std::array::from_fn(|i| (sf.defended_pawn[i] * sign) as i8));
-        self.backward_pawn.push((sf.backward_pawn_diff * sign) as i8);
-        self.tempo.push((sf.tempo * sign) as i8);
+        let (piece_idx, piece_count, mat_diffs, phase_counts, open_raw) = pack_board(entry);
 
         let acc = pos.get_initial_accumulator();
         let phase = extract_phase(&acc);
-        self.static_eval.push(evaluate_fast(&pos, &acc, phase) as i16);
+
+        Self {
+            piece_idx,
+            passed_pawn: array::from_fn(|i| (sf.passed_pawn[i] * sign) as i8),
+            enemy_king_dist: array::from_fn(|i| (sf.enemy_king_dist[i] * sign) as i8),
+            phalanx: array::from_fn(|i| (sf.phalanx[i] * sign) as i8),
+            defended_pawn: array::from_fn(|i| (sf.defended_pawn[i] * sign) as i8),
+            mobility,
+            safety_us: pack_safety(saf_us),
+            safety_them: pack_safety(saf_them),
+            mat_diffs,
+            phase_counts,
+            open_raw,
+            static_eval: evaluate_fast(&pos, &acc, phase) as i16,
+            xray_ortho: (sf.xray_ortho * sign) as i8,
+            bishop_pair: (sf.bishop_pair_diff * sign) as i8,
+            rook_open: (sf.rook_open_diff * sign) as i8,
+            doubled_pawn: (sf.doubled_pawn_diff * sign) as i8,
+            isolated_pawn: (sf.isolated_pawn_diff * sign) as i8,
+            backward_pawn: (sf.backward_pawn_diff * sign) as i8,
+            tempo: (sf.tempo * sign) as i8,
+            piece_count,
+        }
     }
 }
 
-/// Byte layout: [attackers, weak (i8→u8), shield (i8→u8), ortho<<4|diag (4‑bit each)].
+/// Compute the STM-relative eval for `record` under the parameter vector `values`.
+///
+/// Terms accumulate in the engine's order: each tapered term truncates to whole
+/// centipawns, so the sequence is load-bearing for bit-exact reproduction.
 #[inline]
-fn pack_safety(m: &SafetyMetrics) -> [u8; 4] {
-    [
-        m.attackers as u8,
-        m.weak.clamp(-128, 127) as i8 as u8,
-        m.shield.clamp(-128, 127) as i8 as u8,
-        ((m.ortho_exposure.clamp(0, 15) as u8) << 4) | (m.diag_exposure.clamp(0, 15) as u8),
-    ]
+pub fn eval_record(record: &FeatureRecord, values: &[f64]) -> f64 {
+    let l = &psqt::LAYOUT;
+    let phase_counts: [f64; 6] = array::from_fn(|i| f64::from(record.phase_counts[i]));
+    let (mg_w, eg_w) = compute_phase_weights_f64(&phase_counts, values);
+    let mut score = 0.0;
+
+    // PSQT — a data-dependent gather over the 384-entry table, the one loop whose
+    // index can't be proven in bounds and whose body runs up to 32× per position.
+    for i in 0..record.piece_count as usize {
+        let (mg_idx, eg_idx, sign) = decode_piece(record.piece_idx[i]);
+
+        // SAFETY: mg_idx ≤ 351 (5·64+31), eg_idx = mg_idx+32 ≤ 383 < 384. See `decode_piece`.
+        unsafe {
+            score += sign * (*values.get_unchecked(mg_idx) * mg_w + *values.get_unchecked(eg_idx) * eg_w);
+        }
+    }
+
+    // Zero diff adds nothing, so eval omits the zero-diff guard the gradient scatter keeps.
+    let mat = l.material_offset;
+    for pt in 0..6 {
+        score += f64::from(record.mat_diffs[pt]) * (values[mat + pt] * mg_w + values[mat + 6 + pt] * eg_w);
+    }
+
+    let us = unpack_safety(record.safety_us);
+    let them = unpack_safety(record.safety_them);
+    let shield_w = values[l.king_safety_offset];
+    let ortho_w = values[l.king_safety_offset + 1];
+    let diag_w = values[l.king_safety_offset + 2];
+    let us_attacker_w = values[l.attacker_offset + us.attackers.min(5)];
+    let them_attacker_w = values[l.attacker_offset + them.attackers.min(5)];
+    let safety_diff = us.score(shield_w, ortho_w, diag_w, us_attacker_w) - them.score(shield_w, ortho_w, diag_w, them_attacker_w);
+    let xray_val = f64::from(record.xray_ortho) * values[l.xray_offset];
+
+    score += ((safety_diff + xray_val) * mg_w).trunc();
+
+    // Mobility blends open/closed weights by pawn openness before tapering.
+    let (openness, closedness) = openness_pair(record.open_raw);
+    for i in 0..4 {
+        let diff = f64::from(record.mobility[i]) - f64::from(record.mobility[i + 4]);
+        score += diff
+            * interpolate_weight(
+                values,
+                l.mobility_open_offset + i,
+                l.mobility_closed_offset + i,
+                mg_w,
+                eg_w,
+                openness,
+                closedness,
+            );
+    }
+
+    // The rest are plain tapered terms: feature × phase-blended weight.
+    score += taper(record.bishop_pair, values[l.bishop_pair_offset], values[l.bishop_pair_offset + 1], mg_w, eg_w);
+    score += taper(record.rook_open, values[l.rook_open_offset], values[l.rook_open_offset + 1], mg_w, eg_w);
+
+    for r in 0..6 {
+        score += taper(record.passed_pawn[r], values[l.passed_pawn_mg_offset + r], values[l.passed_pawn_eg_offset + r], mg_w, eg_w);
+    }
+
+    for d in 0..6 {
+        score += taper(
+            record.enemy_king_dist[d],
+            values[l.enemy_king_dist_mg_offset + d],
+            values[l.enemy_king_dist_eg_offset + d],
+            mg_w,
+            eg_w,
+        );
+    }
+
+    score += taper(record.doubled_pawn, values[l.doubled_pawn_offset], values[l.doubled_pawn_offset + 1], mg_w, eg_w);
+    score += taper(record.isolated_pawn, values[l.isolated_pawn_offset], values[l.isolated_pawn_offset + 1], mg_w, eg_w);
+
+    for r in 0..6 {
+        score += taper(record.phalanx[r], values[l.phalanx_mg_offset + r], values[l.phalanx_eg_offset + r], mg_w, eg_w);
+    }
+
+    for r in 0..6 {
+        score += taper(
+            record.defended_pawn[r],
+            values[l.defended_pawn_mg_offset + r],
+            values[l.defended_pawn_eg_offset + r],
+            mg_w,
+            eg_w,
+        );
+    }
+
+    score += taper(record.backward_pawn, values[l.backward_pawn_offset], values[l.backward_pawn_offset + 1], mg_w, eg_w);
+    score += taper(record.tempo, values[l.tempo_offset], values[l.tempo_offset + 1], mg_w, eg_w);
+
+    score
 }
 
-/// Accumulate parameter gradients for `entry` using pre-computed features
-/// from `slots[idx]`. `idx` must be the parallel index in both the training
-/// entry array and the `FeatureSlots` arrays (populated together at startup).
-pub fn accumulate_gradient_cached(
-    entry: &SoulEntry,
-    slots: &FeatureSlots,
-    idx: usize,
-    values: &[f64],
-    gradient: f64,
-    grads: &mut [f64],
-) {
-    let f = extract_board(entry);
-    let (mg_w, eg_w) = compute_phase_weights_f64(&f.phase_counts, values);
+/// Accumulate parameter gradients for `record` into `grads`, scaled by the
+/// upstream `gradient` (∂loss/∂score).
+pub fn accumulate_record_grad(record: &FeatureRecord, values: &[f64], gradient: f64, grads: &mut [f64]) {
+    let phase_counts: [f64; 6] = array::from_fn(|i| f64::from(record.phase_counts[i]));
+    let (mg_w, eg_w) = compute_phase_weights_f64(&phase_counts, values);
 
-    // PSQT gradients
-    for i in 0..f.piece_count {
-        let (pt, sq_idx, sign) = f.piece_data[i];
-        let mg_idx = (pt * 64) + psqt::mirror_sq(sq_idx);
-        let eg_idx = (pt * 64) + 32 + psqt::mirror_sq(sq_idx);
+    let l = &psqt::LAYOUT;
 
-        // SAFETY: pt (0..5), mirror_sq (0..31). Max idx = 5*64+32+31 = 383 < 384.
+    for i in 0..record.piece_count as usize {
+        let (mg_idx, eg_idx, sign) = decode_piece(record.piece_idx[i]);
+
+        // SAFETY: mg_idx ≤ 351, eg_idx = mg_idx+32 ≤ 383 < 384. See `decode_piece`.
         unsafe {
             *grads.get_unchecked_mut(mg_idx) += gradient * sign * mg_w;
             *grads.get_unchecked_mut(eg_idx) += gradient * sign * eg_w;
         }
     }
 
-    let material_offset = psqt::LAYOUT.material_offset;
+    let mat = l.material_offset;
 
     for pt in 0..6 {
-        let diff = f.mat_diffs[pt];
+        let diff = f64::from(record.mat_diffs[pt]);
 
         if diff.abs() > 0.001 {
-            let mg_idx = material_offset + pt;
-            let eg_idx = material_offset + 6 + pt;
-            grads[mg_idx] += gradient * diff * mg_w;
-            grads[eg_idx] += gradient * diff * eg_w;
+            grads[mat + pt] += gradient * diff * mg_w;
+            grads[mat + 6 + pt] += gradient * diff * eg_w;
         }
     }
 
-    let king_safety_offset = psqt::LAYOUT.king_safety_offset;
-    let attacker_offset = psqt::LAYOUT.attacker_offset;
-
-    let us = unpack_safety(slots.safety_us[idx]);
-    let them = unpack_safety(slots.safety_them[idx]);
+    // King safety: per-attacker-count weight, plus shield and exposure differentials.
+    let us = unpack_safety(record.safety_us);
+    let them = unpack_safety(record.safety_them);
 
     if us.attackers > 0 {
-        let attacker_idx = attacker_offset + us.attackers.min(5);
-        grads[attacker_idx] += gradient * (-f64::from(us.weak) / 10.0) * mg_w;
+        grads[l.attacker_offset + us.attackers.min(5)] += gradient * (-f64::from(us.weak) / 10.0) * mg_w;
     }
+
     if them.attackers > 0 {
-        let attacker_idx = attacker_offset + them.attackers.min(5);
-        grads[attacker_idx] += gradient * (f64::from(them.weak) / 10.0) * mg_w;
+        grads[l.attacker_offset + them.attackers.min(5)] += gradient * (f64::from(them.weak) / 10.0) * mg_w;
     }
 
     let shield_diff = f64::from(us.shield) - f64::from(them.shield);
     let ortho_diff = f64::from(us.ortho_exposure) - f64::from(them.ortho_exposure);
     let diag_diff = f64::from(us.diag_exposure) - f64::from(them.diag_exposure);
 
-    grads[king_safety_offset] += gradient * shield_diff * mg_w;
-    grads[king_safety_offset + 1] -= gradient * ortho_diff * mg_w;
-    grads[king_safety_offset + 2] -= gradient * diag_diff * mg_w;
+    grads[l.king_safety_offset] += gradient * shield_diff * mg_w;
+    grads[l.king_safety_offset + 1] -= gradient * ortho_diff * mg_w;
+    grads[l.king_safety_offset + 2] -= gradient * diag_diff * mg_w;
+    grads[l.xray_offset] += gradient * f64::from(record.xray_ortho) * mg_w;
 
-    let xray_offset = psqt::LAYOUT.xray_offset;
-    grads[xray_offset] += gradient * f64::from(slots.xray_ortho[idx]) * mg_w;
-
-    let bp_offset = psqt::LAYOUT.bishop_pair_offset;
-    let bp = f64::from(slots.bishop_pair[idx]);
-    grads[bp_offset] += gradient * bp * mg_w;
-    grads[bp_offset + 1] += gradient * bp * eg_w;
-
-    let ro_offset = psqt::LAYOUT.rook_open_offset;
-    let ro = f64::from(slots.rook_open[idx]);
-    grads[ro_offset] += gradient * ro * mg_w;
-    grads[ro_offset + 1] += gradient * ro * eg_w;
-
-    let pmg = psqt::LAYOUT.passed_pawn_mg_offset;
-    let peg = psqt::LAYOUT.passed_pawn_eg_offset;
-    let passed = slots.passed_pawn[idx];
-    for r in 0..6 {
-        let pf = f64::from(passed[r]);
-        grads[pmg + r] += gradient * pf * mg_w;
-        grads[peg + r] += gradient * pf * eg_w;
-    }
-
-    let ekmg = psqt::LAYOUT.enemy_king_dist_mg_offset;
-    let ekeg = psqt::LAYOUT.enemy_king_dist_eg_offset;
-    let enemy_king = slots.enemy_king_dist[idx];
-    for d in 0..6 {
-        let ef = f64::from(enemy_king[d]);
-        grads[ekmg + d] += gradient * ef * mg_w;
-        grads[ekeg + d] += gradient * ef * eg_w;
-    }
-
-    let dp_offset = psqt::LAYOUT.doubled_pawn_offset;
-    let dp = f64::from(slots.doubled_pawn[idx]);
-    grads[dp_offset] += gradient * dp * mg_w;
-    grads[dp_offset + 1] += gradient * dp * eg_w;
-
-    let ip_offset = psqt::LAYOUT.isolated_pawn_offset;
-    let ip = f64::from(slots.isolated_pawn[idx]);
-    grads[ip_offset] += gradient * ip * mg_w;
-    grads[ip_offset + 1] += gradient * ip * eg_w;
-
-    let phmg = psqt::LAYOUT.phalanx_mg_offset;
-    let pheg = psqt::LAYOUT.phalanx_eg_offset;
-    let phalanx = slots.phalanx[idx];
-    for r in 0..6 {
-        let phf = f64::from(phalanx[r]);
-        grads[phmg + r] += gradient * phf * mg_w;
-        grads[pheg + r] += gradient * phf * eg_w;
-    }
-
-    let dfmg = psqt::LAYOUT.defended_pawn_mg_offset;
-    let dfeg = psqt::LAYOUT.defended_pawn_eg_offset;
-    let defended_pawn = slots.defended_pawn[idx];
-    for r in 0..6 {
-        let dff = f64::from(defended_pawn[r]);
-        grads[dfmg + r] += gradient * dff * mg_w;
-        grads[dfeg + r] += gradient * dff * eg_w;
-    }
-
-    let bw_offset = psqt::LAYOUT.backward_pawn_offset;
-    let bw = f64::from(slots.backward_pawn[idx]);
-    grads[bw_offset] += gradient * bw * mg_w;
-    grads[bw_offset + 1] += gradient * bw * eg_w;
-
-    let tempo_offset = psqt::LAYOUT.tempo_offset;
-    let tempo = f64::from(slots.tempo[idx]);
-    grads[tempo_offset] += gradient * tempo * mg_w;
-    grads[tempo_offset + 1] += gradient * tempo * eg_w;
-
-    let (openness, closedness) = openness_factors(f.white_pawns, f.black_pawns);
-    let mobility_open_offset = psqt::LAYOUT.mobility_open_offset;
-    let mobility_closed_offset = psqt::LAYOUT.mobility_closed_offset;
-
-    let mobility = slots.mobility[idx];
-
-    for i in 0..4 {
-        let diff = f64::from(mobility[i]) - f64::from(mobility[i + 4]);
-        let g_diff = gradient * diff;
-
-        grads[mobility_open_offset + i] += g_diff * openness * mg_w;
-        grads[mobility_open_offset + 4 + i] += g_diff * openness * eg_w;
-
-        grads[mobility_closed_offset + i] += g_diff * closedness * mg_w;
-        grads[mobility_closed_offset + 4 + i] += g_diff * closedness * eg_w;
-    }
-}
-
-/// Compute the STM-relative eval for `entry` using pre-computed features
-/// from `slots[idx]`. See `accumulate_gradient_cached` for the `idx` invariant.
-#[inline]
-pub fn eval_soul_cached(entry: &SoulEntry, slots: &FeatureSlots, idx: usize, values: &[f64]) -> f64 {
-    let f = extract_board(entry);
-    let (mg_w, eg_w) = compute_phase_weights_f64(&f.phase_counts, values);
-    let mut score = 0.0;
-
-    for i in 0..f.piece_count {
-        let (pt, sq_idx, sign) = f.piece_data[i];
-        let mg_idx = (pt * 64) + psqt::mirror_sq(sq_idx);
-        let eg_idx = (pt * 64) + 32 + psqt::mirror_sq(sq_idx);
-
-        // SAFETY: pt (0..5), mirror_sq (0..31). Max idx = 5*64+32+31 = 383 < 384.
-        unsafe {
-            score += sign * (*values.get_unchecked(mg_idx) * mg_w + *values.get_unchecked(eg_idx) * eg_w);
-        }
-    }
-
-    let material_offset = psqt::LAYOUT.material_offset;
-
-    for pt in 0..6 {
-        let diff = f.mat_diffs[pt];
-
-        // SAFETY: pt bounded 0..5, indices map strictly into material parameter slots.
-        unsafe {
-            let mg_idx = material_offset + pt;
-            let eg_idx = material_offset + 6 + pt;
-            score += diff * (*values.get_unchecked(mg_idx) * mg_w + *values.get_unchecked(eg_idx) * eg_w);
-        }
-    }
-
-    let king_safety_offset = psqt::LAYOUT.king_safety_offset;
-    let attacker_offset = psqt::LAYOUT.attacker_offset;
-
-    let us = unpack_safety(slots.safety_us[idx]);
-    let them = unpack_safety(slots.safety_them[idx]);
-
-    let shield_w = values[king_safety_offset];
-    let ortho_w = values[king_safety_offset + 1];
-    let diag_w = values[king_safety_offset + 2];
-    let us_attacker_w = values[attacker_offset + us.attackers.min(5)];
-    let them_attacker_w = values[attacker_offset + them.attackers.min(5)];
-
-    let safety_diff = us.score(shield_w, ortho_w, diag_w, us_attacker_w) - them.score(shield_w, ortho_w, diag_w, them_attacker_w);
-    let xray_offset = psqt::LAYOUT.xray_offset;
-    let xray_val = f64::from(slots.xray_ortho[idx]) * values[xray_offset];
-    let safety_xray = (safety_diff + xray_val) * mg_w;
-    score += safety_xray.trunc();
-
-    let (openness_f, closedness_f) = openness_factors(f.white_pawns, f.black_pawns);
-    let mobility_open_offset = psqt::LAYOUT.mobility_open_offset;
-    let mobility_closed_offset = psqt::LAYOUT.mobility_closed_offset;
-
-    let mobility = slots.mobility[idx];
-
-    for i in 0..4 {
-        let diff = f64::from(mobility[i]) - f64::from(mobility[i + 4]);
-        let mobility_w =
-            interpolate_weight(values, mobility_open_offset + i, mobility_closed_offset + i, mg_w, eg_w, openness_f, closedness_f);
-        score += diff * mobility_w;
-    }
-
-    let bp_offset = psqt::LAYOUT.bishop_pair_offset;
-    let bp = f64::from(slots.bishop_pair[idx]);
-    score += (bp * (values[bp_offset] * mg_w + values[bp_offset + 1] * eg_w)).trunc();
-
-    let ro_offset = psqt::LAYOUT.rook_open_offset;
-    let ro = f64::from(slots.rook_open[idx]);
-    score += (ro * (values[ro_offset] * mg_w + values[ro_offset + 1] * eg_w)).trunc();
-
-    let pmg = psqt::LAYOUT.passed_pawn_mg_offset;
-    let peg = psqt::LAYOUT.passed_pawn_eg_offset;
-    let passed = slots.passed_pawn[idx];
+    // Tapered terms — the scatter mirror of the eval side.
+    taper_grad(record.bishop_pair, gradient, mg_w, eg_w, grads, l.bishop_pair_offset, l.bishop_pair_offset + 1);
+    taper_grad(record.rook_open, gradient, mg_w, eg_w, grads, l.rook_open_offset, l.rook_open_offset + 1);
 
     for r in 0..6 {
-        let pf = f64::from(passed[r]);
-        score += (pf * (values[pmg + r] * mg_w + values[peg + r] * eg_w)).trunc();
+        taper_grad(record.passed_pawn[r], gradient, mg_w, eg_w, grads, l.passed_pawn_mg_offset + r, l.passed_pawn_eg_offset + r);
     }
-
-    let ekmg = psqt::LAYOUT.enemy_king_dist_mg_offset;
-    let ekeg = psqt::LAYOUT.enemy_king_dist_eg_offset;
-    let enemy_king = slots.enemy_king_dist[idx];
 
     for d in 0..6 {
-        let ef = f64::from(enemy_king[d]);
-        score += (ef * (values[ekmg + d] * mg_w + values[ekeg + d] * eg_w)).trunc();
+        taper_grad(
+            record.enemy_king_dist[d],
+            gradient,
+            mg_w,
+            eg_w,
+            grads,
+            l.enemy_king_dist_mg_offset + d,
+            l.enemy_king_dist_eg_offset + d,
+        );
     }
 
-    let dp_offset = psqt::LAYOUT.doubled_pawn_offset;
-    let dp = f64::from(slots.doubled_pawn[idx]);
-    score += (dp * (values[dp_offset] * mg_w + values[dp_offset + 1] * eg_w)).trunc();
+    taper_grad(record.doubled_pawn, gradient, mg_w, eg_w, grads, l.doubled_pawn_offset, l.doubled_pawn_offset + 1);
+    taper_grad(record.isolated_pawn, gradient, mg_w, eg_w, grads, l.isolated_pawn_offset, l.isolated_pawn_offset + 1);
 
-    let ip_offset = psqt::LAYOUT.isolated_pawn_offset;
-    let ip = f64::from(slots.isolated_pawn[idx]);
-    score += (ip * (values[ip_offset] * mg_w + values[ip_offset + 1] * eg_w)).trunc();
-
-    let phmg = psqt::LAYOUT.phalanx_mg_offset;
-    let pheg = psqt::LAYOUT.phalanx_eg_offset;
-    let phalanx = slots.phalanx[idx];
     for r in 0..6 {
-        let phf = f64::from(phalanx[r]);
-        score += (phf * (values[phmg + r] * mg_w + values[pheg + r] * eg_w)).trunc();
+        taper_grad(record.phalanx[r], gradient, mg_w, eg_w, grads, l.phalanx_mg_offset + r, l.phalanx_eg_offset + r);
     }
 
-    let dfmg = psqt::LAYOUT.defended_pawn_mg_offset;
-    let dfeg = psqt::LAYOUT.defended_pawn_eg_offset;
-    let defended_pawn = slots.defended_pawn[idx];
     for r in 0..6 {
-        let dff = f64::from(defended_pawn[r]);
-        score += (dff * (values[dfmg + r] * mg_w + values[dfeg + r] * eg_w)).trunc();
+        taper_grad(
+            record.defended_pawn[r],
+            gradient,
+            mg_w,
+            eg_w,
+            grads,
+            l.defended_pawn_mg_offset + r,
+            l.defended_pawn_eg_offset + r,
+        );
     }
 
-    let bw_offset = psqt::LAYOUT.backward_pawn_offset;
-    let bw = f64::from(slots.backward_pawn[idx]);
-    score += (bw * (values[bw_offset] * mg_w + values[bw_offset + 1] * eg_w)).trunc();
+    taper_grad(record.backward_pawn, gradient, mg_w, eg_w, grads, l.backward_pawn_offset, l.backward_pawn_offset + 1);
+    taper_grad(record.tempo, gradient, mg_w, eg_w, grads, l.tempo_offset, l.tempo_offset + 1);
 
-    let tempo_offset = psqt::LAYOUT.tempo_offset;
-    let tempo = f64::from(slots.tempo[idx]);
-    score += (tempo * (values[tempo_offset] * mg_w + values[tempo_offset + 1] * eg_w)).trunc();
-
-    score
+    // Mobility: open/closed weights scaled by openness, both phases.
+    let (openness, closedness) = openness_pair(record.open_raw);
+    for i in 0..4 {
+        let g_diff = gradient * (f64::from(record.mobility[i]) - f64::from(record.mobility[i + 4]));
+        grads[l.mobility_open_offset + i] += g_diff * openness * mg_w;
+        grads[l.mobility_open_offset + 4 + i] += g_diff * openness * eg_w;
+        grads[l.mobility_closed_offset + i] += g_diff * closedness * mg_w;
+        grads[l.mobility_closed_offset + 4 + i] += g_diff * closedness * eg_w;
+    }
 }
 
-struct BoardFeatures {
-    white_pawns: u64,
-    black_pawns: u64,
-    mat_diffs: [f64; 6],
-    phase_counts: [f64; 6],
-    piece_data: [(usize, usize, f64); 32],
-    piece_count: usize,
-}
+/// Sign bit of a packed [`FeatureRecord::piece_idx`] slot.
+const PIECE_SIGN: u16 = 0x8000;
 
-/// Extract perspective-normalized board features from a nibble-encoded entry.
+/// Decode a packed piece slot into `(mg_idx, eg_idx, sign)` for the PSQT gather.
 ///
-/// The entry stores raw colors (bit 3 = 0=White, 1=Black).
-/// We normalize to the side-to-move's perspective:
-/// STM pieces map to "Us",
-/// STM's opponent maps to "Them".
-fn extract_board(entry: &SoulEntry) -> BoardFeatures {
-    let mut f = BoardFeatures {
-        white_pawns: 0,
-        black_pawns: 0,
-        mat_diffs: [0.0; 6],
-        phase_counts: [0.0; 6],
-        piece_data: [(0, 0, 0.0); 32],
-        piece_count: 0,
-    };
+/// `mg_idx` is the MG PSQT index (≤ 351); `eg_idx = mg_idx + 32` (≤ 383); `sign`
+/// is +1.0 for our pieces, −1.0 for theirs.
+#[inline(always)]
+fn decode_piece(packed: u16) -> (usize, usize, f64) {
+    let mg_idx = (packed & !PIECE_SIGN) as usize;
+    let sign = if packed & PIECE_SIGN != 0 { -1.0 } else { 1.0 };
+
+    (mg_idx, mg_idx + 32, sign)
+}
+
+/// Walk the entry's pieces once, producing the PSQT gather indices, material
+/// differentials, phase counts, and raw openness — STM-normalized.
+///
+/// Mirrors the encoder's nibble layout: bits 0-2 = type, bit 3 = color. An
+/// unmoved-rook code (6) folds back to a rook (3).
+fn pack_board(entry: &SoulEntry) -> ([u16; 32], u8, [i8; 6], [u8; 6], i32) {
+    let mut piece_idx = [0u16; 32];
+    let mut count = 0usize;
+    let mut mat_diffs = [0i32; 6];
+    let mut phase_counts = [0u8; 6];
+    let mut white_pawns = 0u64;
+    let mut black_pawns = 0u64;
 
     let stm_black = (entry.stm_and_ep & 0x80) != 0;
     let mut occ = entry.occupancy;
@@ -447,25 +380,38 @@ fn extract_board(entry: &SoulEntry) -> BoardFeatures {
 
         let us_piece = is_black == stm_black;
         let sq_idx = if is_black { usize::from(sq.0) } else { usize::from(sq.0 ^ 0x38) };
-        let sign = if us_piece { 1.0 } else { -1.0 };
 
-        f.piece_data[f.piece_count] = (pt, sq_idx, sign);
-        f.piece_count += 1;
+        let mg_idx = (pt * 64 + psqt::mirror_sq(sq_idx)) as u16;
+        piece_idx[count] = if us_piece { mg_idx } else { mg_idx | PIECE_SIGN };
+        count += 1;
 
-        f.mat_diffs[pt] += sign;
-        f.phase_counts[pt] += 1.0;
+        mat_diffs[pt] += if us_piece { 1 } else { -1 };
+        phase_counts[pt] += 1;
 
         if pt == 0 {
             let bit = 1u64 << sq.0;
 
             if is_black {
-                f.black_pawns |= bit;
+                black_pawns |= bit;
             } else {
-                f.white_pawns |= bit;
+                white_pawns |= bit;
             }
         }
     }
-    f
+
+    let mat_diffs = array::from_fn(|i| mat_diffs[i] as i8);
+    (piece_idx, count as u8, mat_diffs, phase_counts, compute_openness_raw(white_pawns, black_pawns))
+}
+
+/// Byte layout: [attackers, weak (i8→u8), shield (i8→u8), ortho<<4|diag (4‑bit each)].
+#[inline]
+fn pack_safety(m: &SafetyMetrics) -> [u8; 4] {
+    [
+        m.attackers as u8,
+        m.weak.clamp(-128, 127) as i8 as u8,
+        m.shield.clamp(-128, 127) as i8 as u8,
+        ((m.ortho_exposure.clamp(0, 15) as u8) << 4) | (m.diag_exposure.clamp(0, 15) as u8),
+    ]
 }
 
 #[inline]
@@ -480,10 +426,25 @@ fn unpack_safety(raw: [u8; 4]) -> SafetyMetrics {
 }
 
 #[inline(always)]
-fn openness_factors(white_pawns: u64, black_pawns: u64) -> (f64, f64) {
-    let open_i32 = compute_openness_raw(white_pawns, black_pawns);
-    let openness = f64::from(open_i32) / f64::from(OPEN_UNITY);
+fn openness_pair(open_raw: i32) -> (f64, f64) {
+    let openness = f64::from(open_raw) / f64::from(OPEN_UNITY);
     (openness, 1.0 - openness)
+}
+
+/// One tapered HCE term: `feature × phase-blended weight`, truncated to whole
+/// centipawns to mirror the engine's integer eval.
+#[inline]
+fn taper(feat: i8, mg: f64, eg: f64, mg_w: f64, eg_w: f64) -> f64 {
+    (f64::from(feat) * (mg * mg_w + eg * eg_w)).trunc()
+}
+
+/// Scatter one tapered term's gradient into its MG/EG parameter slots.
+/// The `.trunc()` in [`taper`] is the identity on the backward pass (straight-through).
+#[inline]
+fn taper_grad(feat: i8, gradient: f64, mg_w: f64, eg_w: f64, grads: &mut [f64], mg_idx: usize, eg_idx: usize) {
+    let g = gradient * f64::from(feat);
+    grads[mg_idx] += g * mg_w;
+    grads[eg_idx] += g * eg_w;
 }
 
 /// Openness-weighted blend of open/closed mobility weights.

--- a/src/tools/dataset/mod.rs
+++ b/src/tools/dataset/mod.rs
@@ -13,7 +13,7 @@ mod io;
 mod quant;
 pub mod viri_format;
 
-pub use gradient::{FeatureSlots, accumulate_gradient_cached, eval_soul_cached};
+pub use gradient::{FeatureRecord, accumulate_record_grad, eval_record};
 pub use io::{MAGIC_V5, MAGIC_V6, append_encoded, load_encoded, parse_epd_entry, parse_epd_str, save_encoded};
 pub use viri_format::parse_viri_file;
 

--- a/tuner/Cargo.toml
+++ b/tuner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuner"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 rust-version = "1.95.0"
 

--- a/tuner/src/core/config.rs
+++ b/tuner/src/core/config.rs
@@ -17,6 +17,37 @@ pub enum LossFn {
     CrossEntropy,
 }
 
+impl LossFn {
+    /// Per-sample loss for tracking, from the model win probability `sig` and the
+    /// blended `target`. Cross-entropy clamps `S` so `ln` stays finite at the ends.
+    pub fn loss(self, sig: f64, target: f64) -> f64 {
+        match self {
+            // L = (S − target)²
+            Self::Mse => {
+                let err = sig - target;
+                err * err
+            },
+            // L = −target·ln(S) − (1−target)·ln(1−S)
+            Self::CrossEntropy => {
+                let s = sig.clamp(1e-7, 1.0 - 1e-7);
+                -(target * s.ln() + (1.0 - target) * (1.0 - s).ln())
+            },
+        }
+    }
+
+    /// Outer derivative ∂L/∂score — the upstream gradient handed to the parameter
+    /// scatter. `k` is the sigmoid scaling constant.
+    pub fn grad_scale(self, sig: f64, target: f64, k: f64) -> f64 {
+        let err = sig - target;
+        match self {
+            // dJ/dx = 2·(S − target)·K·S·(1 − S)
+            Self::Mse => 2.0 * err * sig * (1.0 - sig) * k,
+            // dL/dx = (S − target)·K
+            Self::CrossEntropy => err * k,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum LrScheduleConfig {

--- a/tuner/src/evaltune/evaltuner.rs
+++ b/tuner/src/evaltune/evaltuner.rs
@@ -1,4 +1,5 @@
 use std::{
+    fs,
     fs::File,
     io::{self, BufWriter, Write},
     path,
@@ -10,7 +11,7 @@ use soul::{
     color,
     core::{defs::Color, psqt},
     engine::eval_params::{self, Tunable},
-    tools::dataset::FeatureSlots,
+    tools::dataset::FeatureRecord,
 };
 
 use super::{lion::Lion, loader, palette, report::*, storage::*, training::*};
@@ -141,15 +142,13 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
     let mut rng = fastrand::Rng::with_seed(rng_seed);
     rng.shuffle(&mut entries);
 
-    // Populate cached features at startup: reconstruct a Position from each
-    // nibble-encoded entry, compute mobility / king safety / x-ray, and store
-    // in SoA (Structure of Arrays) layout for cache-friendly training access.
-    // This is the one-time cost — training reads from the slot arrays directly.
+    // Decode every nibble-encoded entry into a packed FeatureRecord at startup:
+    // reconstruct the Position, compute mobility / king safety / x-ray / pawn
+    // structure, pre-resolve the PSQT gather indices, and pack it all into one
+    // contiguous record. This is the one-time cost — training reads the records
+    // straight through. Parallel because the entries are independent.
     println!("Extracting features ({} entries)...", entries.len());
-    let mut slots = FeatureSlots::with_capacity(entries.len());
-    for entry in &entries {
-        slots.push_entry(entry);
-    }
+    let records: Vec<FeatureRecord> = entries.par_iter().map(FeatureRecord::from_entry).collect();
 
     let val_count = entries.len() / 10;
     let train_count = entries.len() - val_count;
@@ -162,8 +161,8 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
     });
 
     // Shared reference for the closure captures below.
-    // `train` and `slots` are parallel arrays indexed by the same subscript.
-    let slots_ref = &slots;
+    // `train`/`val` and `records` are parallel arrays indexed by the same subscript.
+    let records_ref = &records;
     let vol_threshold = config.volatility_threshold;
     let vol_adaptive = config.volatility_adaptive;
     let loss_fn = config.loss;
@@ -172,12 +171,14 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
         if vol_threshold == 0 || entry.score == i16::MAX {
             return true;
         }
+
         let t = if vol_adaptive {
             let short = 10i16.saturating_sub(entry.occupancy.count_ones() as i16);
             vol_threshold + short.saturating_mul(2)
         } else {
             vol_threshold
         };
+
         (i32::from(static_eval) - i32::from(entry.score)).abs() <= t as i32
     };
 
@@ -189,13 +190,14 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
                 |(mut g, mut loss, mut count), chunk| {
                     for &i in chunk {
                         let entry = &train[i];
+                        let record = &records_ref[i];
 
-                        if !passes_vol_filter(entry, slots_ref.static_eval[i]) {
+                        if !passes_vol_filter(entry, record.static_eval) {
                             continue;
                         }
 
                         let target = entry.target(k, blend);
-                        let sig = sigmoid(loader::eval_soul_cached(entry, slots_ref, i, values), k);
+                        let sig = sigmoid(loader::eval_record(record, values), k);
                         let err = sig - target;
 
                         match loss_fn {
@@ -203,13 +205,13 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
                                 // L = -target·ln(S) - (1-target)·ln(1-S), dL/dx = (S - target)·K
                                 let s = sig.clamp(1e-7, 1.0 - 1e-7);
                                 loss -= target * s.ln() + (1.0 - target) * (1.0 - s).ln();
-                                loader::accumulate_gradient_cached(entry, slots_ref, i, values, err * k, &mut g);
+                                loader::accumulate_record_grad(record, values, err * k, &mut g);
                             },
                             LossFn::Mse => {
                                 // dJ/dx = 2·(S - target)·K·S·(1 - S)
                                 let d = 2.0 * err * sig * (1.0 - sig) * k;
                                 loss = err.mul_add(err, loss);
-                                loader::accumulate_gradient_cached(entry, slots_ref, i, values, d, &mut g);
+                                loader::accumulate_record_grad(record, values, d, &mut g);
                             },
                         }
                         count += 1;
@@ -235,12 +237,16 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
             .fold(
                 || (0.0_f64, 0usize),
                 |(mut sum, mut count), (idx, entry): (usize, &loader::SoulEntry)| {
-                    if !passes_vol_filter(entry, slots_ref.static_eval[train_count + idx]) {
+                    let record = &records_ref[train_count + idx];
+
+                    if !passes_vol_filter(entry, record.static_eval) {
                         return (sum, count);
                     }
-                    let score = loader::eval_soul_cached(entry, slots_ref, train_count + idx, values);
+
+                    let score = loader::eval_record(record, values);
                     let sig = sigmoid(score, k);
                     let target = entry.target(k, blend);
+
                     match loss_fn {
                         LossFn::CrossEntropy => {
                             let s = sig.clamp(1e-7, 1.0 - 1e-7);
@@ -270,6 +276,7 @@ trait PipeGrads {
 impl PipeGrads for (Vec<f64>, f64, usize) {
     fn pipe_grads(self, out: &mut [f64]) -> (f64, usize) {
         let (grads, loss, count) = self;
+
         for (o, g) in out.iter_mut().zip(grads.iter()) {
             *o += g;
         }
@@ -292,6 +299,7 @@ fn print_dataset_stats<T, F: Fn(&T) -> f64>(train: &[T], val: &[T], total: usize
 
     let (ww, bw, dr) = train.iter().fold((0, 0, 0), |(w, b, d), entry| {
         let r = result_fn(entry);
+
         if (r - 1.0).abs() < 1e-4 {
             (w + 1, b, d)
         } else if r.abs() < 1e-4 {
@@ -313,11 +321,13 @@ fn loss_sparkline(history: &[f64]) -> String {
     if history.is_empty() {
         return String::new();
     }
+
     let lo = history.iter().copied().fold(f64::MAX, f64::min);
     let hi = history.iter().copied().fold(f64::MIN, f64::max);
     let span = (hi - lo).max(1e-12);
 
     let mut out = String::with_capacity(history.len() * 20);
+
     for &v in history {
         let frac = (v - lo) / span; // 0 = best (lowest), 1 = worst (highest)
         let level = (frac * 8.0).min(7.0) as usize;
@@ -417,6 +427,7 @@ fn train_loop<G, V>(
         writeln!(w).unwrap();
         writeln!(w, "epoch   L_train     L_val       L_ref       LR").unwrap();
     }
+
     let mut json_logger = JsonLogger::new("evaltune.jsonl").ok();
 
     let mut rng = fastrand::Rng::with_seed(rng_seed);
@@ -522,6 +533,7 @@ fn train_loop<G, V>(
             let threshold = clip_thresh * n;
 
             let scale = if norm > threshold { threshold / norm } else { 1.0 };
+
             for (i, g) in grads.iter_mut().enumerate() {
                 *g = *g / n * scale;
                 total_grads[i] += *g;
@@ -568,6 +580,7 @@ fn train_loop<G, V>(
             for i in 0..values.len() {
                 if !fixed_mask[i] && grad_ema_per_param[i] < config.freeze_threshold && !all_params[i].freeze_resistant {
                     stagnant_epochs[i] += 1;
+
                     if stagnant_epochs[i] >= config.freeze_consecutive {
                         fixed_mask[i] = true;
                         frozen += 1;
@@ -576,6 +589,7 @@ fn train_loop<G, V>(
                     stagnant_epochs[i] = 0;
                 }
             }
+
             if frozen > 0 {
                 println!("  Auto-frozen {frozen} stagnant parameters.");
             }
@@ -709,7 +723,7 @@ fn train_loop<G, V>(
 
 /// Sensitivity Analysis — writes `sensitivity-report.txt`.
 fn sensitivity_report(params: &[Tunable], grad_ema: &[f64], fixed_mask: &[bool]) {
-    let Ok(mut f) = std::fs::File::create("sensitivity-report.txt") else { return };
+    let Ok(mut f) = fs::File::create("sensitivity-report.txt") else { return };
     let mut w = io::BufWriter::new(&mut f);
     writeln!(w, "Sensitivity Analysis").ok();
     writeln!(w).ok();
@@ -718,6 +732,7 @@ fn sensitivity_report(params: &[Tunable], grad_ema: &[f64], fixed_mask: &[bool])
 
     for p in params {
         let delta = grad_ema[p.idx];
+
         if p.is_fixed || fixed_mask[p.idx] {
             frozen.push((delta, p.idx, p.name.as_str()));
         } else {
@@ -733,12 +748,14 @@ fn sensitivity_report(params: &[Tunable], grad_ema: &[f64], fixed_mask: &[bool])
     let frozen_width = frozen.iter().take(10).map(|r| r.2.len()).max().unwrap_or(20) + 1;
 
     writeln!(w, "  Top Load-Bearing Parameters:").ok();
+
     for (i, (delta, _, name)) in sensitivities.iter().take(10).enumerate() {
         writeln!(w, "    {:>3}. {:<name_width$} ΔL: {:.8}", i + 1, name, delta, name_width = active_width).ok();
     }
 
     writeln!(w).ok();
     writeln!(w, "  Lowest-Impact Parameters:").ok();
+
     for (i, (delta, _, name)) in sensitivities.iter().rev().take(10).enumerate() {
         writeln!(w, "    {:>3}. {:<name_width$} ΔL: {:.8}", i + 1, name, delta, name_width = active_width).ok();
     }
@@ -746,6 +763,7 @@ fn sensitivity_report(params: &[Tunable], grad_ema: &[f64], fixed_mask: &[bool])
     if !frozen.is_empty() {
         writeln!(w).ok();
         writeln!(w, "  Highest Sensitivity Auto-Frozen/Fixed Parameters:").ok();
+
         for (i, (delta, _, name)) in frozen.iter().take(10).enumerate() {
             writeln!(w, "    {:>3}. {:<name_width$} ΔL: {:.8}", i + 1, name, delta, name_width = frozen_width).ok();
         }
@@ -755,10 +773,12 @@ fn sensitivity_report(params: &[Tunable], grad_ema: &[f64], fixed_mask: &[bool])
 fn resolve_dataset_paths(input: &str) -> Option<Vec<String>> {
     if input == "default" {
         let mut paths = Vec::new();
-        if let Ok(entries) = std::fs::read_dir("data") {
+
+        if let Ok(entries) = fs::read_dir("data") {
             for entry in entries.flatten() {
                 let path = entry.path();
                 let name = path.to_string_lossy();
+
                 if name.ends_with(".soul.zst") || name.ends_with(".soul") {
                     paths.push(name.to_string());
                 }

--- a/tuner/src/evaltune/evaltuner.rs
+++ b/tuner/src/evaltune/evaltuner.rs
@@ -102,7 +102,7 @@ unsafe fn enable_ftz_daz() {
 /// new boundary, and only one new probe is evaluated per iteration.
 ///
 /// `range` tracks the current interval width. The probe offset from each boundary is
-/// `C * range` (not `range`) because after shrinking, the reused probe already sits
+/// `C · range` (not `range`) because after shrinking, the reused probe already sits
 /// at `C²` of the *old* width from the surviving boundary — placing the fresh probe
 /// at `C` of the *new* width mirrors it correctly.
 pub fn golden_search_k<F: Fn(f64) -> f64>(lo: f64, hi: f64, tol: f64, eval: F) -> f64 {
@@ -182,8 +182,8 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
         (i32::from(static_eval) - i32::from(entry.score)).abs() <= t as i32
     };
 
-    let batch_grad = |batch_indices: &[usize], values: &[f64], k: f64, blend: f64, grads: &mut [f64]| -> (f64, usize) {
-        let reduce_res = batch_indices
+    let batch_grad = |batch_indices: &[usize], values: &[f64], k: f64, blend: f64| -> (Vec<f64>, f64, usize) {
+        batch_indices
             .par_chunks(256)
             .fold(
                 || (vec![0.0; values.len()], 0.0, 0usize),
@@ -225,9 +225,7 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
                     let (g, l) = grad_combine((g1, l1), (g2, l2));
                     (g, l, c1 + c2)
                 },
-            );
-
-        reduce_res.pipe_grads(grads)
+            )
     };
 
     let val_eval = |values: &[f64], k: f64, blend: f64| -> f64 {
@@ -266,22 +264,6 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
     };
 
     train_loop(train.len(), "SoulEntry", config, resume_path, rng_seed, batch_grad, val_eval);
-}
-
-/// Scatter rayon-reduced gradients into the caller's accumulator.
-trait PipeGrads {
-    fn pipe_grads(self, out: &mut [f64]) -> (f64, usize);
-}
-
-impl PipeGrads for (Vec<f64>, f64, usize) {
-    fn pipe_grads(self, out: &mut [f64]) -> (f64, usize) {
-        let (grads, loss, count) = self;
-
-        for (o, g) in out.iter_mut().zip(grads.iter()) {
-            *o += g;
-        }
-        (loss, count)
-    }
 }
 
 fn grad_combine((mut g1, l1): (Vec<f64>, f64), (g2, l2): (Vec<f64>, f64)) -> (Vec<f64>, f64) {
@@ -350,7 +332,7 @@ fn train_loop<G, V>(
     batch_grad: G,
     val_eval: V,
 ) where
-    G: Fn(&[usize], &[f64], f64, f64, &mut [f64]) -> (f64, usize),
+    G: Fn(&[usize], &[f64], f64, f64) -> (Vec<f64>, f64, usize),
     V: Fn(&[f64], f64, f64) -> f64,
 {
     let all_params = eval_params::collect_parameters();
@@ -516,8 +498,7 @@ fn train_loop<G, V>(
         let mut total_grads = vec![0.0; values.len()];
 
         for batch in indices.chunks(config.batch_size) {
-            let mut grads = vec![0.0; values.len()];
-            let (batch_loss, batch_count) = batch_grad(batch, &values, k, blend, &mut grads);
+            let (mut grads, batch_loss, batch_count) = batch_grad(batch, &values, k, blend);
 
             train_loss += batch_loss;
             train_count += batch_count;

--- a/tuner/src/evaltune/evaltuner.rs
+++ b/tuner/src/evaltune/evaltuner.rs
@@ -196,7 +196,7 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
                             continue;
                         }
 
-                        let target = entry.target(k, blend);
+                        let target = wdl_target(entry, k, blend);
                         let sig = sigmoid(loader::eval_record(record, values), k);
                         let err = sig - target;
 
@@ -245,7 +245,7 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
 
                     let score = loader::eval_record(record, values);
                     let sig = sigmoid(score, k);
-                    let target = entry.target(k, blend);
+                    let target = wdl_target(entry, k, blend);
 
                     match loss_fn {
                         LossFn::CrossEntropy => {

--- a/tuner/src/evaltune/evaltuner.rs
+++ b/tuner/src/evaltune/evaltuner.rs
@@ -16,7 +16,7 @@ use soul::{
 
 use super::{lion::Lion, loader, palette, report::*, storage::*, training::*};
 use crate::core::{
-    config::{EvalTuneConfig, LossFn, LrScheduleConfig},
+    config::{EvalTuneConfig, LrScheduleConfig},
     logger::JsonLogger,
 };
 
@@ -198,22 +198,9 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
 
                         let target = wdl_target(entry, k, blend);
                         let sig = sigmoid(loader::eval_record(record, values), k);
-                        let err = sig - target;
 
-                        match loss_fn {
-                            LossFn::CrossEntropy => {
-                                // L = -target·ln(S) - (1-target)·ln(1-S), dL/dx = (S - target)·K
-                                let s = sig.clamp(1e-7, 1.0 - 1e-7);
-                                loss -= target * s.ln() + (1.0 - target) * (1.0 - s).ln();
-                                loader::accumulate_record_grad(record, values, err * k, &mut g);
-                            },
-                            LossFn::Mse => {
-                                // dJ/dx = 2·(S - target)·K·S·(1 - S)
-                                let d = 2.0 * err * sig * (1.0 - sig) * k;
-                                loss = err.mul_add(err, loss);
-                                loader::accumulate_record_grad(record, values, d, &mut g);
-                            },
-                        }
+                        loss += loss_fn.loss(sig, target);
+                        loader::accumulate_record_grad(record, values, loss_fn.grad_scale(sig, target, k), &mut g);
                         count += 1;
                     }
                     (g, loss, count)
@@ -245,16 +232,7 @@ fn train_entries(mut entries: Vec<loader::SoulEntry>, config: &EvalTuneConfig, r
                     let sig = sigmoid(score, k);
                     let target = wdl_target(entry, k, blend);
 
-                    match loss_fn {
-                        LossFn::CrossEntropy => {
-                            let s = sig.clamp(1e-7, 1.0 - 1e-7);
-                            sum -= target * s.ln() + (1.0 - target) * (1.0 - s).ln();
-                        },
-                        LossFn::Mse => {
-                            let err = sig - target;
-                            sum = err.mul_add(err, sum);
-                        },
-                    }
+                    sum += loss_fn.loss(sig, target);
                     count += 1;
                     (sum, count)
                 },

--- a/tuner/src/evaltune/evaltuner.rs
+++ b/tuner/src/evaltune/evaltuner.rs
@@ -810,6 +810,29 @@ fn resolve_dataset_paths(input: &str) -> Option<Vec<String>> {
     }
 }
 
+/// Parameter group by position in the layout, the axis the per-group optimizer
+/// masks (decay, momentum, learning rate) all key off.
+enum ParamGroup {
+    Psqt,
+    Material,
+    Mobility,
+    Other,
+}
+
+/// Classify a parameter index into its layout group — the single source of the
+/// group boundaries the masks below share.
+fn param_group(i: usize) -> ParamGroup {
+    if i < psqt::LAYOUT.material_offset {
+        ParamGroup::Psqt
+    } else if i < psqt::LAYOUT.mobility_open_offset {
+        ParamGroup::Material
+    } else if i < psqt::LAYOUT.weight_offset {
+        ParamGroup::Mobility
+    } else {
+        ParamGroup::Other
+    }
+}
+
 /// Weight decay mask: not all parameters deserve equal punishment.
 ///
 /// - PSQT center squares decay at 0.5× (central values are more structurally
@@ -818,25 +841,16 @@ fn resolve_dataset_paths(input: &str) -> Option<Vec<String>> {
 ///   features are unbounded integer counts).
 /// - Everything else decays at 1.0×.
 fn build_decay_mask(params: &[Tunable]) -> Vec<f64> {
-    let psqt_end = psqt::LAYOUT.material_offset;
-    let mat_end = psqt::LAYOUT.mobility_open_offset;
-    let mob_end = psqt::LAYOUT.weight_offset;
-
     (0..params.len())
-        .map(|i| {
-            if i < psqt_end {
+        .map(|i| match param_group(i) {
+            ParamGroup::Psqt => {
                 let sq = i % 32;
-                let row = sq / 4;
-                let col = sq % 4;
+                let (row, col) = (sq / 4, sq % 4);
                 let is_center = (2..=5).contains(&row) && (2..=3).contains(&col);
                 if is_center { 0.5 } else { 1.0 }
-            } else if i < mat_end {
-                1.0
-            } else if i < mob_end {
-                1.5
-            } else {
-                1.0
-            }
+            },
+            ParamGroup::Mobility => 1.5,
+            ParamGroup::Material | ParamGroup::Other => 1.0,
         })
         .collect()
 }
@@ -850,41 +864,22 @@ fn build_decay_mask(params: &[Tunable]) -> Vec<f64> {
 ///   lets weights track the faster dynamics without lag.
 /// - Everything else (0.99): the existing default from the config.
 fn build_beta2_mask(params: &[Tunable], default_beta2: f64) -> Vec<f64> {
-    let psqt_end = psqt::LAYOUT.material_offset;
-    let mat_end = psqt::LAYOUT.mobility_open_offset;
-    let mob_end = psqt::LAYOUT.weight_offset;
-
     (0..params.len())
-        .map(|i| {
-            if i < psqt_end {
-                0.995
-            } else if i < mat_end {
-                default_beta2
-            } else if i < mob_end {
-                0.95
-            } else {
-                default_beta2
-            }
+        .map(|i| match param_group(i) {
+            ParamGroup::Psqt => 0.995,
+            ParamGroup::Mobility => 0.95,
+            ParamGroup::Material | ParamGroup::Other => default_beta2,
         })
         .collect()
 }
 
 fn build_lr_mask(params: &[Tunable], config: &EvalTuneConfig) -> Vec<f64> {
-    let psqt_end = psqt::LAYOUT.material_offset;
-    let mat_end = psqt::LAYOUT.mobility_open_offset;
-    let mob_end = psqt::LAYOUT.weight_offset;
-
     (0..params.len())
-        .map(|i| {
-            if i < psqt_end {
-                config.lr_psqt
-            } else if i < mat_end {
-                config.lr_material
-            } else if i < mob_end {
-                config.lr_mobility
-            } else {
-                config.lr_other
-            }
+        .map(|i| match param_group(i) {
+            ParamGroup::Psqt => config.lr_psqt,
+            ParamGroup::Material => config.lr_material,
+            ParamGroup::Mobility => config.lr_mobility,
+            ParamGroup::Other => config.lr_other,
         })
         .collect()
 }

--- a/tuner/src/evaltune/loader.rs
+++ b/tuner/src/evaltune/loader.rs
@@ -10,7 +10,7 @@ use std::{
 
 use soul::core::{board::Position as Board, defs::Color};
 pub use soul::tools::dataset::{
-    SoulEntry, accumulate_gradient_cached, eval_soul_cached, load_encoded, parse_epd_str, parse_viri_file, save_encoded,
+    FeatureRecord, SoulEntry, accumulate_record_grad, eval_record, load_encoded, parse_epd_str, parse_viri_file, save_encoded,
 };
 
 /// A raw EPD position with its game result (1.0 = white, 0.0 = black, 0.5 = draw).

--- a/tuner/src/evaltune/tape.rs
+++ b/tuner/src/evaltune/tape.rs
@@ -22,16 +22,6 @@ use soul::{
     },
 };
 
-/// Active piece entry for PSQT gradient scatter.
-#[derive(Copy, Clone, Default)]
-pub struct ActivePiece {
-    pub mg_idx: u32,
-    pub eg_idx: u32,
-    pub mat_mg_idx: u32,
-    pub mat_eg_idx: u32,
-    pub sign: f32,
-}
-
 mod scatter {
     #[inline(always)]
     pub(super) fn scatter_scalar(grad: &[f32], slot: &mut usize, outer: f64, out: &mut [f64], offset: usize) {
@@ -88,142 +78,12 @@ macro_rules! impl_scatter {
 
 soul::define_tunables!(impl_scatter);
 
-/// Result of a forward-mode dual evaluation.
-///
-/// Captures the score and raw gradient array from the dual forward pass,
-/// plus the piece locations needed to scatter PSQT gradients.
-/// Designed as a snapshot that can be consumed later once the outer loss
-/// derivative is known.
+/// Gradient snapshot from the dual forward pass — the raw partial derivatives,
+/// consumed by `scatter_dynamic` once the outer loss derivative is known.
 pub struct DualEvalResult {
-    pub score: f64,
-    /// Raw partial derivatives from the dual pass (44 active slots in 64).
+    /// Raw partial derivatives from the dual pass — one slot per dual-tracked
+    /// input (`DUAL_SLOTS`), zero-padded to `DUAL_N`.
     pub grad: [f32; DUAL_N],
-    /// Board pieces recorded during accumulation for PSQT scatter.
-    pub active: [ActivePiece; 32],
-    pub active_count: usize,
-}
-
-impl DualEvalResult {
-    /// Scatter gradients into `param_grads`, scaled by `outer_deriv`.
-    pub fn scatter_grads(&self, outer_deriv: f64, param_grads: &mut [f64]) {
-        self.scatter_dynamic(outer_deriv, param_grads);
-
-        // PSQT gradients: d(output)/d(psqt_i) = d(output)/d(lane_j) · d(lane_j)/d(psqt_i)
-        let d_mg = outer_deriv * f64::from(self.grad[0]); // Mg slot = 0
-        let d_eg = outer_deriv * f64::from(self.grad[1]); // Eg slot = 1
-
-        debug_assert!(
-            param_grads.len() >= psqt::LAYOUT.mobility_open_offset,
-            "param_grads too small: {} < {} (material+PSQT footprint)",
-            param_grads.len(),
-            psqt::LAYOUT.mobility_open_offset,
-        );
-
-        for i in 0..self.active_count {
-            let a = &self.active[i];
-            let s = f64::from(a.sign);
-
-            param_grads[a.mg_idx as usize] += d_mg * s;
-            param_grads[a.eg_idx as usize] += d_eg * s;
-            param_grads[a.mat_mg_idx as usize] += d_mg * s;
-            param_grads[a.mat_eg_idx as usize] += d_eg * s;
-        }
-    }
-}
-
-/// Run forward-mode AD on a position. Returns a `DualEvalResult` containing
-/// the score and all information needed to scatter gradients later.
-pub fn eval_dual_forward(board: &Board, values: &[f64]) -> DualEvalResult {
-    // PSQT + Material accumulator (plain f64, no tape)
-    let mut lane_vals = [0.0f64; 8];
-    let mut piece_counts = [0.0f64; 6];
-
-    let mut active = [ActivePiece::default(); 32];
-    let mut active_count = 0;
-
-    for piece in PieceType::ALL {
-        let pt = piece.as_usize();
-        piece_counts[pt] = f64::from(board.role_bb[pt].popcount());
-
-        let mat_mg_idx = psqt::LAYOUT.material_offset + pt;
-        let mat_eg_idx = psqt::LAYOUT.material_offset + 6 + pt;
-        let mat_mg_val = values.get(mat_mg_idx).copied().unwrap_or(0.0);
-        let mat_eg_val = values.get(mat_eg_idx).copied().unwrap_or(0.0);
-
-        let mut bb_w = board.pieces(piece, Color::White);
-
-        while bb_w.is_not_empty() {
-            let sq = bb_w.pop_lsb();
-            let sq_idx = usize::from(sq.flip_rank());
-            let mirror_idx = psqt::mirror_sq(sq_idx);
-            let mg_idx = pt * 64 + mirror_idx;
-            let eg_idx = pt * 64 + 32 + mirror_idx;
-
-            lane_vals[0] += values.get(mg_idx).copied().unwrap_or(0.0) + mat_mg_val;
-            lane_vals[1] += values.get(eg_idx).copied().unwrap_or(0.0) + mat_eg_val;
-
-            active[active_count] = ActivePiece {
-                mg_idx: mg_idx as u32,
-                eg_idx: eg_idx as u32,
-                mat_mg_idx: mat_mg_idx as u32,
-                mat_eg_idx: mat_eg_idx as u32,
-                sign: 1.0,
-            };
-            active_count += 1;
-        }
-
-        let mut bb_b = board.pieces(piece, Color::Black);
-
-        while bb_b.is_not_empty() {
-            let sq = bb_b.pop_lsb();
-            let sq_idx = usize::from(sq);
-            let mirror_idx = psqt::mirror_sq(sq_idx);
-            let mg_idx = pt * 64 + mirror_idx;
-            let eg_idx = pt * 64 + 32 + mirror_idx;
-
-            lane_vals[0] -= values.get(mg_idx).copied().unwrap_or(0.0) + mat_mg_val;
-            lane_vals[1] -= values.get(eg_idx).copied().unwrap_or(0.0) + mat_eg_val;
-
-            active[active_count] = ActivePiece {
-                mg_idx: mg_idx as u32,
-                eg_idx: eg_idx as u32,
-                mat_mg_idx: mat_mg_idx as u32,
-                mat_eg_idx: mat_eg_idx as u32,
-                sign: -1.0,
-            };
-            active_count += 1;
-        }
-    }
-
-    let mut phase_dual = DualNode::zero();
-
-    for (pt, count) in piece_counts.iter().enumerate().take(6) {
-        let phase_idx = psqt::LAYOUT.weight_offset + pt;
-
-        if phase_idx < values.len() {
-            phase_dual += DualNode::constant(*count) * DualNode::constant(values[phase_idx]);
-        }
-    }
-
-    let phase = phase_dual.math_clamp(DualNode::constant(0.0), DualNode::constant(24.0)).trunc();
-
-    // Seed DualNode values
-    // Only lanes 0 (MG) and 1 (EG) need gradient tracking.
-    // Lane 2 is the Phase counter. Lanes 3-7 are unused padding.
-    let mut dual_acc = DualVec8::zero();
-
-    dual_acc.0[0] = DualNode::seed(lane_vals[0], 0);
-    dual_acc.0[1] = DualNode::seed(lane_vals[1], 1);
-
-    for (dual, &val) in dual_acc.0[2..8].iter_mut().zip(&lane_vals[2..8]) {
-        *dual = DualNode::constant(val);
-    }
-
-    let params = EvalParams::<DualNode>::load_tunable(values);
-    let features = SharedFeatures::compute(board);
-    let result = evaluate_generic::<DualNode>(board, &dual_acc, phase, &params, Some(&features));
-
-    DualEvalResult { score: result.val, grad: result.grad, active, active_count }
 }
 
 /// Fully fused eval + gradient scatter via forward-mode AD.
@@ -279,7 +139,7 @@ pub fn eval_dual_fused(board: &Board, values: &[f64], target: f64, k: f64, param
     let outer_deriv = 2.0 * err * sig * (1.0 - sig) * k;
 
     // EvalParams gradients (slots 2..29)
-    let dummy = DualEvalResult { score: 0.0, grad: result.grad, active: [ActivePiece::default(); 32], active_count: 0 };
+    let dummy = DualEvalResult { grad: result.grad };
     dummy.scatter_dynamic(outer_deriv, param_grads);
 
     // PSQT gradients — re-iterate board pieces (still hot in L1)

--- a/tuner/src/evaltune/tape.rs
+++ b/tuner/src/evaltune/tape.rs
@@ -425,10 +425,8 @@ pub fn eval_linear_grad(board: &Board, values: &[f64], target: f64, k: f64, para
             param_grads[eg_idx] -= d_eg;
         }
     }
-
     // Adding a new term = one line in `register_terms!`
     scatter_all_terms(&features, &upstreams, param_grads);
-
     err * err
 }
 
@@ -457,6 +455,7 @@ pub fn eval_f64_with_acc(board: &Board, values: &[f64]) -> (f64, [f64; 8], [f64;
     // Same generator the DualNode path uses — no per-term hand literal to drift.
     let params = EvalParams::<f64>::load_tunable(values);
     let features = SharedFeatures::compute(board);
+
     (evaluate_generic::<f64>(board, &trace_acc, phase, &params, Some(&features)), trace_acc.0, piece_counts)
 }
 
@@ -531,7 +530,7 @@ mod tests {
 
     use soul::{
         core::{board::Position, psqt::LAYOUT},
-        tools::dataset::{FeatureSlots, SoulEntry, accumulate_gradient_cached, eval_soul_cached},
+        tools::dataset::{FeatureRecord, SoulEntry, accumulate_record_grad, eval_record},
     };
 
     use super::*;
@@ -637,6 +636,7 @@ mod tests {
 
     fn full_values() -> Vec<f64> {
         let mut values = vec![0.0f64; LAYOUT.tempo_offset + LAYOUT.tempo_len];
+
         for (n, v) in values.iter_mut().enumerate() {
             *v = (n % 17) as f64 - 8.0;
         }
@@ -649,6 +649,7 @@ mod tests {
     /// being verified against the `DualNode` oracle.
     fn values_in_range(range: Range<usize>) -> Vec<f64> {
         let mut values = vec![0.0f64; LAYOUT.tempo_offset + LAYOUT.tempo_len];
+
         for i in range {
             values[i] = (i % 17) as f64 - 8.0;
         }
@@ -775,11 +776,10 @@ mod tests {
                 "Round-trip score mismatch on '{fen}': orig={orig_score} reconstructed={rt_score}",
             );
 
-            let mut slots = FeatureSlots::with_capacity(1);
-            slots.push_entry(&entry);
+            let record = FeatureRecord::from_entry(&entry);
 
             let board_score = eval_f64(&pos, &values);
-            let entry_score = eval_soul_cached(&entry, &slots, 0, &values);
+            let entry_score = eval_record(&record, &values);
             assert!(
                 (board_score - entry_score).abs() < 1e-4,
                 "Score mismatch on '{fen}': board={board_score} encoded={entry_score}",
@@ -793,7 +793,7 @@ mod tests {
             let outer = 2.0 * err * sig * (1.0 - sig) * K;
 
             let mut encoded_grads = vec![0.0f64; n_params];
-            accumulate_gradient_cached(&entry, &slots, 0, &values, outer, &mut encoded_grads);
+            accumulate_record_grad(&record, &values, outer, &mut encoded_grads);
 
             let enc_loss = err * err;
             assert!((dual_loss - enc_loss).abs() < 1e-4, "Loss mismatch on '{fen}': dual={dual_loss} encoded={enc_loss}");

--- a/tuner/src/evaltune/training.rs
+++ b/tuner/src/evaltune/training.rs
@@ -1,6 +1,6 @@
 use soul::core::{board::Position, defs::Color};
 
-use crate::evaltune::{loader, tape, tape::eval_f64};
+use crate::evaltune::{loader, tape::eval_f64};
 
 /// Adaptive gradient clipping based on exponentially weighted percentile estimation.
 ///
@@ -65,29 +65,34 @@ pub fn sigmoid(score: f64, k: f64) -> f64 {
 
 /// Read-only evaluation trait: can compute a score and knows the game result.
 ///
-/// Implemented by both `Entry` (raw EPD) and `SoulEntry` (encoded).
-/// This is the base layer — `TrainableEntry` extends it with gradient support.
+/// Implemented by both `Entry` (raw EPD) and `SoulEntry` (encoded); the ablation
+/// tool is generic over it.
 pub trait TunableData: Sync + Send {
     fn eval(&self, values: &[f64]) -> f64;
     fn result(&self) -> f64;
 }
 
-/// Gradient-capable evaluation trait.
+/// Training target for an encoded entry: the game result, blended toward the
+/// search eval by instance-confidence WDL.
 ///
-/// Adds `target()` (result with optional WDL blending), `eval_with_state()`
-/// (evaluation that may capture internal state for gradient scatter), and
-/// `accumulate_grad()` (scatter gradients into the parameter vector).
-///
-/// For raw EPD entries, this trait is **not used in the production loop** —
-/// `eval_linear_grad` bypasses it entirely. It remains active for the
-/// encoded `.soul.zst` pipeline.
-pub trait TrainableEntry: TunableData {
-    type GradState: Default + Send;
+/// Near-zero search scores (low engine confidence) fall back to the game result;
+/// high-magnitude scores trust the eval fully. `wdl_blend >= 1.0` bypasses the
+/// instance scaling — the target is pure `sigmoid(score)`, for random-restart
+/// data with no game outcome. 400 cp is the empirical confidence saturation point.
+pub fn wdl_target(entry: &loader::SoulEntry, k: f64, wdl_blend: f64) -> f64 {
+    const CONFIDENCE_THRESHOLD: f64 = 400.0;
 
-    fn target(&self, k: f64, wdl_blend: f64) -> f64;
-    fn eval_with_state(&self, values: &[f64], state: &mut Self::GradState) -> f64;
+    // i16::MAX sentinel = EPD data with no search score — pure outcome.
+    if entry.score == i16::MAX {
+        return f64::from(entry.result) / 2.0;
+    }
+    let score = f64::from(entry.score);
 
-    fn accumulate_grad(&self, values: &[f64], gradient: f64, grads: &mut [f64], state: &Self::GradState);
+    let instance_blend = if wdl_blend >= 1.0 { 1.0 } else { wdl_blend * (score.abs() / CONFIDENCE_THRESHOLD).min(1.0) };
+
+    let expected = sigmoid(score, k);
+    // result in {0,1,2} → normalize to [0.0, 1.0] for sigmoid target.
+    (1.0 - instance_blend).mul_add(f64::from(entry.result) / 2.0, instance_blend * expected)
 }
 
 impl TunableData for loader::SoulEntry {
@@ -105,46 +110,6 @@ impl TunableData for loader::SoulEntry {
     }
 }
 
-impl TrainableEntry for loader::SoulEntry {
-    type GradState = ();
-
-    #[inline]
-    fn target(&self, k: f64, wdl_blend: f64) -> f64 {
-        // i16::MAX sentinel = EPD data with no search score — pure outcome.
-        if self.score == i16::MAX {
-            return f64::from(self.result) / 2.0;
-        }
-        let score = f64::from(self.score);
-
-        // Instance-Confidence WDL blending:
-        // Scale the global `wdl_blend` based on the magnitude of the search score.
-        // Near-zero scores (low engine confidence) fall back to the game result;
-        // high-magnitude scores trust the search eval fully.
-        //
-        // wdl_blend >= 1.0 bypasses instance-confidence entirely — the target
-        // is pure sigmoid(score). Used for random-restart data with no game outcome.
-        // 400 cp is the empirical confidence saturation point.
-        let confidence_threshold = 400.0;
-        let instance_blend = if wdl_blend >= 1.0 { 1.0 } else { wdl_blend * (score.abs() / confidence_threshold).min(1.0) };
-
-        let expected = sigmoid(score, k);
-        // result in {0,1,2} → normalize to [0.0, 1.0] for sigmoid target.
-        (1.0 - instance_blend).mul_add(f64::from(self.result) / 2.0, instance_blend * expected)
-    }
-
-    #[inline]
-    fn eval_with_state(&self, values: &[f64], _: &mut Self::GradState) -> f64 {
-        self.eval(values)
-    }
-
-    #[inline]
-    fn accumulate_grad(&self, _values: &[f64], _gradient: f64, _grads: &mut [f64], _: &Self::GradState) {
-        unimplemented!(
-            "SoulEntry gradient accumulation requires a FeatureRecord; production code uses the packed path via eval_record / accumulate_record_grad"
-        );
-    }
-}
-
 impl TunableData for loader::Entry {
     #[inline]
     fn eval(&self, values: &[f64]) -> f64 {
@@ -157,29 +122,5 @@ impl TunableData for loader::Entry {
         // The eval produces a score relative to the side-to-move,
         // so we flip for Black.
         if self.board.stm == Color::Black { 1.0 - self.result } else { self.result }
-    }
-}
-
-impl TrainableEntry for loader::Entry {
-    type GradState = Option<tape::DualEvalResult>;
-
-    #[inline]
-    fn target(&self, _k: f64, _wdl_blend: f64) -> f64 {
-        self.result()
-    }
-
-    #[inline]
-    fn eval_with_state(&self, values: &[f64], state: &mut Self::GradState) -> f64 {
-        let result = tape::eval_dual_forward(&self.board, values);
-        let val = result.score;
-        *state = Some(result);
-        val
-    }
-
-    #[inline]
-    fn accumulate_grad(&self, _: &[f64], gradient: f64, grads: &mut [f64], state: &Self::GradState) {
-        if let Some(result) = state {
-            result.scatter_grads(gradient, grads);
-        }
     }
 }

--- a/tuner/src/evaltune/training.rs
+++ b/tuner/src/evaltune/training.rs
@@ -92,7 +92,7 @@ pub trait TrainableEntry: TunableData {
 
 impl TunableData for loader::SoulEntry {
     /// Evaluation via FEN round-trip — valid but slow.
-    /// Production code uses `eval_soul_cached` with `FeatureSlots`.
+    /// Production code uses `eval_record` with a packed `FeatureRecord`.
     #[inline]
     fn eval(&self, values: &[f64]) -> f64 {
         let board = Position::from_fen(&self.to_fen());
@@ -140,7 +140,7 @@ impl TrainableEntry for loader::SoulEntry {
     #[inline]
     fn accumulate_grad(&self, _values: &[f64], _gradient: f64, _grads: &mut [f64], _: &Self::GradState) {
         unimplemented!(
-            "SoulEntry gradient accumulation requires FeatureSlots; production code uses the cached path via eval_soul_cached / accumulate_gradient_cached"
+            "SoulEntry gradient accumulation requires a FeatureRecord; production code uses the packed path via eval_record / accumulate_record_grad"
         );
     }
 }


### PR DESCRIPTION
- `FeatureRecord`: one contiguous 132-byte record per position replaces the
  15 SoA arrays + the per-call board decode. Hot loop reads ~2 cache lines
  instead of ~16 and never re-decodes nibbles. ~0.77s → ~0.33s/epoch (2.3×).
- Drop dead `TrainableEntry` trait; rehome `target(`) as `wdl_target`.
- Removed the orphaned forward-AD scatter path (`eval_dual_forward`,
  `scatter_grads`,` ActivePiece`) left dead by the above.
- Unify the three optimizer mask builders behind one `ParamGroup` classifier.
- `batch_grad` returns its gradient directly; drop the one-impl `PipeGrads` trait.
- Move loss formulas onto `LossFn` (`loss + grad_scale`) — adding a loss is now
  one variant plus an arm in each.
- Added `make etprofile` for profiling the tuner.

No functional change.
Bench: 5669888