### PR TITLE
Incremental pawn/minor/major correction keys

### DIFF
--- a/src/core/board/fen.rs
+++ b/src/core/board/fen.rs
@@ -143,6 +143,7 @@ impl Display for Fen<'_> {
 
         // En passant target
         f.write_char(' ')?;
+
         match pos.en_passant {
             Some(sq) => f.write_str(&sq.to_algebraic())?,
             None => f.write_char('-')?,
@@ -217,15 +218,18 @@ pub fn pretty_print(pos: &Position) {
 fn finish_position(mut pos: Position) -> Result<Position, FenError> {
     // 1. King Existence Invariant
     let kings = pos.role_bb[PieceType::King];
+
     if (kings & pos.side_bb[Color::White]).popcount() != 1 {
         return Err(FenError::MissingKing { color: "white" });
     }
+
     if (kings & pos.side_bb[Color::Black]).popcount() != 1 {
         return Err(FenError::MissingKing { color: "black" });
     }
 
     // 2. Pawn Rank Invariant (Pawns cannot exist on 1st/8th ranks)
     let illegal_pawns = pos.role_bb[PieceType::Pawn] & (RANK_1 | RANK_8);
+
     if illegal_pawns.is_not_empty() {
         let sq = illegal_pawns.lsb();
         let color = if pos.side_bb[Color::White].check_bit(sq) { Color::White } else { Color::Black };
@@ -245,8 +249,10 @@ fn finish_position(mut pos: Position) -> Result<Position, FenError> {
     // 4. Castling/Rook Consistency (Crucial for DFRC/Shredder-FEN)
     for slot in 0..4 {
         let bit = 1 << slot;
+
         if pos.castling_rights & bit != 0 {
             let rsq = pos.castling_rooks[slot];
+
             if pos.piece_at(rsq) != PieceType::Rook {
                 return Err(FenError::InvalidCastlingRights { sq: rsq.to_algebraic() });
             }
@@ -254,6 +260,9 @@ fn finish_position(mut pos: Position) -> Result<Position, FenError> {
     }
 
     pos.hash = pos.calc_zobrist();
+    pos.pawn_key = pos.calc_pawn_hash();
+    pos.minor_key = pos.calc_minor_hash();
+    pos.major_key = pos.calc_major_hash();
     Ok(pos)
 }
 
@@ -290,21 +299,25 @@ fn parse_placement(pos: &mut Position, field: &str) -> Result<(), FenError> {
                 rank -= 1;
                 file = 0;
                 rank_count += 1;
+
                 if rank < 0 {
                     return Err(FenError::TooManyRanks { rank: 0, count: rank_count });
                 }
             },
             '1'..='8' => {
                 file += (ch as u8 - b'0') as i32;
+
                 if file > 8 {
                     return Err(FenError::FileOverflow { rank: rank as u8, file: file as u8 });
                 }
             },
             _ => {
                 let pt = PieceType::from_char(ch);
+
                 if pt == PieceType::None {
                     return Err(FenError::InvalidPiece { ch, rank: rank as u8, file: file as u8 });
                 }
+
                 if rank < 0 || file >= 8 {
                     return Err(FenError::SquareOutOfBounds { square: rank * 8 + file });
                 }
@@ -332,11 +345,13 @@ fn parse_placement(pos: &mut Position, field: &str) -> Result<(), FenError> {
 fn parse_en_passant(pos: &mut Position, token: &str) -> Result<(), FenError> {
     let b = token.as_bytes();
     let rank = b.get(1).copied().unwrap_or(0);
+
     if b.len() != 2 || !(b'a'..=b'h').contains(&b[0]) || (rank != b'3' && rank != b'6') {
         return Err(FenError::InvalidEnPassant { square: token.to_string() });
     }
 
     let sq = Square((b[1] - b'1') * 8 + (b[0] - b'a'));
+
     if pos.can_capture_ep(sq, pos.stm) {
         pos.en_passant = Some(sq);
     }
@@ -409,6 +424,7 @@ fn find_rook(pos: &Position, color: Color, start_file: u8, step: i8) -> Option<S
 
     while (0..8).contains(&file) {
         let sq = Square(rank * 8 + file as u8);
+
         if pos.piece_at(sq) == PieceType::Rook && pos.side_bb[color].check_bit(sq) {
             return Some(sq);
         }

--- a/src/core/board/make.rs
+++ b/src/core/board/make.rs
@@ -27,6 +27,9 @@ pub fn make_move(pos: &mut Position, mv: Move, acc: &mut Vi16x8) -> StateInfo {
     let state = StateInfo {
         castling_rights: pos.castling_rights,
         hash: pos.hash,
+        pawn_key: pos.pawn_key,
+        minor_key: pos.minor_key,
+        major_key: pos.major_key,
         captured,
         halfmove_clock: pos.halfmove_clock,
         en_passant: pos.en_passant,
@@ -41,10 +44,12 @@ pub fn make_move(pos: &mut Position, mv: Move, acc: &mut Vi16x8) -> StateInfo {
 
     if captured != PieceType::None {
         pos.hash ^= zobrist::key_piece(captured, opp, to);
+        toggle_corr_key(pos, captured, opp, to);
         pos.remove_piece(to, captured, opp);
     } else if mv.is_en_passant() {
         let victim_sq = to ^ 8;
         pos.hash ^= zobrist::key_piece(PieceType::Pawn, opp, victim_sq);
+        toggle_corr_key(pos, PieceType::Pawn, opp, victim_sq);
         pos.remove_piece(victim_sq, PieceType::Pawn, opp);
     }
 
@@ -53,34 +58,40 @@ pub fn make_move(pos: &mut Position, mv: Move, acc: &mut Vi16x8) -> StateInfo {
     } else {
         pos.remove_piece(from, pt, stm);
         pos.hash ^= zobrist::key_piece(pt, stm, from);
+        toggle_corr_key(pos, pt, stm, from);
 
         pos.add_piece(to, placed, stm);
         pos.hash ^= zobrist::key_piece(placed, stm, to);
+        toggle_corr_key(pos, placed, stm, to);
     }
 
     pos.stm = opp;
+
     if stm == Color::Black {
         pos.fullmove_number += 1;
     }
+
     pos.hash ^= zobrist::key_side();
 
     refresh_castling_rights(pos, pt, stm, from, to, state.castling_rights);
     refresh_en_passant(pos, mv, from, to, state.en_passant);
-
     state
 }
 
 /// Reverses a move, perfectly restoring the prior position.
 ///
-/// The accumulator must be bulk-restored from the snapshot by the caller
-/// — no incremental undo needed. This keeps unmake fast and avoids tricky sign-flip bugs.
+/// The accumulator must be bulk-restored from the snapshot
+/// by the caller — no incremental undo needed.
+/// This keeps unmake fast and avoids tricky sign-flip bugs.
 #[inline(always)]
 pub fn unmake_move(pos: &mut Position, mv: Move, info: &StateInfo) {
     pos.stm = pos.stm.opposite();
     let stm = pos.stm;
+
     if stm == Color::Black {
         pos.fullmove_number -= 1;
     }
+
     let opp = stm.opposite();
     let from = mv.from();
     let to = mv.to();
@@ -89,6 +100,9 @@ pub fn unmake_move(pos: &mut Position, mv: Move, info: &StateInfo) {
     pos.en_passant = info.en_passant;
     pos.halfmove_clock = info.halfmove_clock;
     pos.hash = info.hash;
+    pos.pawn_key = info.pawn_key;
+    pos.minor_key = info.minor_key;
+    pos.major_key = info.major_key;
 
     if mv.is_castling() {
         revert_castling(pos, from, to);
@@ -164,6 +178,23 @@ pub fn update_piece<const ADD: bool>(pos: &mut Position, sq: Square, pt: PieceTy
     }
 }
 
+/// Routes one piece's Zobrist key into the correction key its type owns;
+/// pawns to `pawn_key`, knight/bishop to `minor_key`, rook/queen to `major_key`,
+/// king to neither. Mirrors the inline `hash` toggles in `make_move`; XOR is
+/// self-inverse, so the same call serves a piece leaving its origin and arriving
+/// on its destination.
+#[inline(always)]
+fn toggle_corr_key(pos: &mut Position, pt: PieceType, color: Color, sq: Square) {
+    let key = zobrist::key_piece(pt, color, sq);
+
+    match pt {
+        PieceType::Pawn => pos.pawn_key ^= key,
+        PieceType::Knight | PieceType::Bishop => pos.minor_key ^= key,
+        PieceType::Rook | PieceType::Queen => pos.major_key ^= key,
+        PieceType::King | PieceType::None => {},
+    }
+}
+
 /// Undoes a castling move on the board.
 /// Hash and accumulator are bulk-restored from the snapshot — only bitboards
 /// and the mailbox need rewinding.
@@ -209,12 +240,14 @@ fn apply_castling(pos: &mut Position, king_from: Square, rook_from: Square, stm:
     pos.hash ^= zobrist::key_piece(PieceType::King, stm, king_from);
     pos.remove_piece(rook_from, PieceType::Rook, stm);
     pos.hash ^= zobrist::key_piece(PieceType::Rook, stm, rook_from);
+    toggle_corr_key(pos, PieceType::Rook, stm, rook_from);
 
     // Land at final squares.
     pos.add_piece(king_to, PieceType::King, stm);
     pos.hash ^= zobrist::key_piece(PieceType::King, stm, king_to);
     pos.add_piece(rook_to, PieceType::Rook, stm);
     pos.hash ^= zobrist::key_piece(PieceType::Rook, stm, rook_to);
+    toggle_corr_key(pos, PieceType::Rook, stm, rook_to);
 }
 
 /// Revokes castling rights touched by the move's origin and destination.
@@ -240,6 +273,7 @@ fn refresh_castling_rights(pos: &mut Position, pt: PieceType, stm: Color, from: 
     if from == pos.castling_rooks[ROOK_W_QS] || to == pos.castling_rooks[ROOK_W_QS] {
         rights &= !WHITE_OOO;
     }
+
     if from == pos.castling_rooks[ROOK_B_KS] || to == pos.castling_rooks[ROOK_B_KS] {
         rights &= !BLACK_OO;
     }

--- a/src/core/board/mod.rs
+++ b/src/core/board/mod.rs
@@ -11,7 +11,7 @@
 //! Zobrist hash and SIMD accumulator are maintained incrementally — updated
 //! diff-style in `make_move`, restored from snapshots in `unmake_move`.
 
-use std::fmt;
+use std::{fmt, iter};
 
 use crate::{
     core::{
@@ -84,7 +84,7 @@ pub const CASTLE_B_QS_CHECK: [u8; 3] = [60, 59, 58];
 const _: () = {
     use std::mem::{align_of, offset_of, size_of};
 
-    assert!(size_of::<Position>() == 160, "Position must be exactly 160 bytes");
+    assert!(size_of::<Position>() == 192, "Position must be exactly 192 bytes");
     assert!(align_of::<Position>() == 32, "Position must be 32-byte aligned");
 
     // Hot fields packed at the front for cache locality during move gen.
@@ -92,14 +92,17 @@ const _: () = {
     assert!(offset_of!(Position, role_bb) == 16);
     assert!(offset_of!(Position, occ) == 64);
     assert!(offset_of!(Position, hash) == 72);
+    assert!(offset_of!(Position, pawn_key) == 80);
+    assert!(offset_of!(Position, minor_key) == 88);
+    assert!(offset_of!(Position, major_key) == 96);
 
-    assert!(size_of::<StateInfo>() == 16, "StateInfo must be exactly 16 bytes");
+    assert!(size_of::<StateInfo>() == 40, "StateInfo must be exactly 40 bytes");
     assert!(align_of::<StateInfo>() == 8);
 };
 
 pub use fen::Fen;
 
-//  160 bytes — spans up to three cache lines.
+//  192 bytes — spans three cache lines.
 //
 //  ┌──────────────────┬────────┬───────┐
 //  │ Field            │ Offset │ Bytes │
@@ -108,15 +111,18 @@ pub use fen::Fen;
 //  │ role_bb          │     16 │    48 │
 //  │ occ              │     64 │     8 │
 //  │ hash             │     72 │     8 │
-//  │ pieces           │     80 │    64 │
-//  │ castling_rooks   │    144 │     4 │
-//  │ castling_rights  │    148 │     1 │
-//  │ stm              │    149 │     1 │
-//  │ halfmove_clock   │    150 │     1 │
-//  │ en_passant       │    151 │     2 │
-//  │ is_frc           │    153 │     1 │
-//  │ fullmove_number  │    154 │     2 │
-//  │ (tail padding)   │    156 │     4 │
+//  │ pawn_key         │     80 │     8 │
+//  │ minor_key        │     88 │     8 │
+//  │ major_key        │     96 │     8 │
+//  │ pieces           │    104 │    64 │
+//  │ castling_rooks   │    168 │     4 │
+//  │ castling_rights  │    172 │     1 │
+//  │ stm              │    173 │     1 │
+//  │ halfmove_clock   │    174 │     1 │
+//  │ en_passant       │    175 │     2 │
+//  │ is_frc           │    177 │     1 │
+//  │ fullmove_number  │    178 │     2 │
+//  │ (tail padding)   │    180 │    12 │
 //  └──────────────────┴────────┴───────┘
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(32))]
@@ -129,6 +135,12 @@ pub struct Position {
     pub occ: Bitboard,
     /// Incrementally maintained Zobrist hash.
     pub hash: u64,
+    /// Incremental pawn-only Zobrist key; keys pawn correction history.
+    pub pawn_key: u64,
+    /// Incremental minor-piece (knight + bishop) Zobrist key; keys minor correction history.
+    pub minor_key: u64,
+    /// Incremental major-piece (rook + queen) Zobrist key; keys major correction history.
+    pub major_key: u64,
     /// Mailbox: `pos.piece_at(sq)` gives the piece type (or `None` if empty).
     pub pieces: [PieceType; 64],
     /// Rook home squares for castling, indexed by rights bit position.
@@ -158,11 +170,14 @@ impl fmt::Display for Position {
 // We snapshot these irreversible fields before each move so unmake_move
 // can restore them perfectly — no costly recalculation, just a memcpy.
 
-/// The irreversible state needed to undo a move. 16 bytes, stack-allocated.
+/// The irreversible state needed to undo a move — stack-allocated, snapshotted per move.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct StateInfo {
     pub hash: u64,
+    pub pawn_key: u64,
+    pub minor_key: u64,
+    pub major_key: u64,
     pub en_passant: Option<Square>,
     pub castling_rights: u8,
     pub captured: PieceType,
@@ -171,7 +186,16 @@ pub struct StateInfo {
 
 impl Default for StateInfo {
     fn default() -> Self {
-        Self { hash: 0, en_passant: None, castling_rights: 0, captured: PieceType::None, halfmove_clock: 0 }
+        Self {
+            hash: 0,
+            pawn_key: 0,
+            minor_key: 0,
+            major_key: 0,
+            en_passant: None,
+            castling_rights: 0,
+            captured: PieceType::None,
+            halfmove_clock: 0,
+        }
     }
 }
 
@@ -183,6 +207,9 @@ impl Position {
             role_bb: [Bitboard(0); 6],
             occ: Bitboard(0),
             hash: 0,
+            pawn_key: 0,
+            minor_key: 0,
+            major_key: 0,
             pieces: [PieceType::None; 64],
             castling_rooks: [Square(0); 4],
             castling_rights: 0,
@@ -209,7 +236,7 @@ impl Position {
 
     /// Parse from pre-split FEN tokens
     /// (useful for UCI `position` commands where the token stream is already available).
-    pub fn try_from_tokens<'a, I>(parts: &mut std::iter::Peekable<I>) -> Result<Self, FenError>
+    pub fn try_from_tokens<'a, I>(parts: &mut iter::Peekable<I>) -> Result<Self, FenError>
     where I: Iterator<Item = &'a str> {
         fen::try_from_tokens(parts)
     }
@@ -227,12 +254,16 @@ impl Position {
         make::unmake_move(self, mv, info);
     }
 
-    /// Pass the turn without moving. Returns the undo packet.
+    /// Pass the turn without moving.
+    /// Returns the undo packet.
     /// Used by null move pruning — the opponent gets a free move.
     #[inline]
     pub fn make_null_move(&mut self) -> StateInfo {
         let info = StateInfo {
             hash: self.hash,
+            pawn_key: self.pawn_key,
+            minor_key: self.minor_key,
+            major_key: self.major_key,
             en_passant: self.en_passant,
             castling_rights: self.castling_rights,
             captured: PieceType::None,
@@ -257,6 +288,9 @@ impl Position {
     pub fn unmake_null_move(&mut self, info: &StateInfo) {
         self.stm = self.stm.opposite();
         self.hash = info.hash;
+        self.pawn_key = info.pawn_key;
+        self.minor_key = info.minor_key;
+        self.major_key = info.major_key;
         self.en_passant = info.en_passant;
         self.halfmove_clock = info.halfmove_clock;
     }
@@ -318,6 +352,7 @@ impl Position {
         for &h in history[limit..].iter().rev().skip(2).step_by(2) {
             if h == self.hash {
                 count += 1;
+
                 if count >= 3 {
                     return true;
                 }
@@ -390,6 +425,7 @@ impl Position {
             if sq == ksq.0 || sq == rsq.0 {
                 continue;
             }
+
             if occ.check_bit(Square(sq)) {
                 return false;
             }
@@ -399,6 +435,7 @@ impl Position {
         let k_lo = ksq.0.min(king_dst);
         let k_hi = ksq.0.max(king_dst);
         let king_bb = Bitboard(1u64 << ksq.0);
+
         for sq in k_lo..=k_hi {
             // We use VIRTUAL = true, passing the king's current square as mask_out.
             // Otherwise, an enemy slider attacking the traversal path might be
@@ -508,6 +545,7 @@ impl Position {
     #[inline]
     pub fn pawn_attacks(&self, color: Color) -> Bitboard {
         let pawns = self.pieces(PieceType::Pawn, color);
+
         match color {
             Color::White => ((pawns << 9) & !FILE_A) | ((pawns << 7) & !FILE_H),
             Color::Black => ((pawns >> 9) & !FILE_H) | ((pawns >> 7) & !FILE_A),
@@ -561,9 +599,11 @@ impl Position {
         if self.stm == Color::Black {
             key ^= zobrist::key_side();
         }
+
         if self.castling_rights != 0 {
             key ^= zobrist::key_castling(self.castling_rights);
         }
+
         if let Some(ep) = self.en_passant {
             key ^= zobrist::key_ep(ep);
         }
@@ -571,9 +611,12 @@ impl Position {
         key
     }
 
+    /// Zobrist hash of all pawns (both colors). Recomputed from scratch — for
+    /// initialization and debug verification against the incremental [`Self::pawn_key`].
     pub fn calc_pawn_hash(&self) -> u64 {
         let mut key = 0u64;
         let pawns = self.role_bb[PieceType::Pawn];
+
         for sq in pawns {
             key ^= zobrist::key_piece(PieceType::Pawn, self.color_at(sq), sq);
         }
@@ -586,6 +629,7 @@ impl Position {
     pub fn calc_minor_hash(&self) -> u64 {
         let mut key = 0u64;
         let minors = self.role_bb[PieceType::Knight] | self.role_bb[PieceType::Bishop];
+
         for sq in minors {
             key ^= zobrist::key_piece(self.piece_at(sq), self.color_at(sq), sq);
         }
@@ -597,6 +641,7 @@ impl Position {
     pub fn calc_major_hash(&self) -> u64 {
         let mut key = 0u64;
         let majors = self.role_bb[PieceType::Rook] | self.role_bb[PieceType::Queen];
+
         for sq in majors {
             key ^= zobrist::key_piece(self.piece_at(sq), self.color_at(sq), sq);
         }

--- a/src/core/board/tests.rs
+++ b/src/core/board/tests.rs
@@ -55,6 +55,7 @@ fn zobrist_make_unmake_identity() {
         let original_fen = pos.as_fen();
 
         let moves = gen_legal_moves(&pos);
+
         for mv in &moves {
             let saved_acc = acc;
             let undo = pos.make_move(*mv, &mut acc);
@@ -73,6 +74,7 @@ fn zobrist_incremental_matches_full() {
     let mut acc = pos.get_initial_accumulator();
 
     let moves = ["e2e4", "e7e5", "g1f3", "b8c6", "f1b5"];
+
     for uci in moves {
         let mv = find_uci_move(&pos, uci);
         pos.make_move(mv, &mut acc);
@@ -98,8 +100,37 @@ fn zobrist_long_sequence() {
         pos.make_move(mv, &mut acc);
         assert_eq!(pos.hash, pos.calc_zobrist(), "Hash diverged after move {uci}. Position: {}", pos.as_fen());
 
+        assert_eq!(pos.pawn_key, pos.calc_pawn_hash(), "Pawn key diverged after move {uci}. Position: {}", pos.as_fen());
+        assert_eq!(pos.minor_key, pos.calc_minor_hash(), "Minor key diverged after move {uci}. Position: {}", pos.as_fen());
+        assert_eq!(pos.major_key, pos.calc_major_hash(), "Major key diverged after move {uci}. Position: {}", pos.as_fen());
+
         let fresh_acc = pos.get_initial_accumulator();
         assert_eq!(acc.to_array(), fresh_acc.to_array(), "Accumulator diverged after move {uci}");
+    }
+}
+
+#[test]
+fn correction_keys_promotion_and_en_passant() {
+    let cases = [
+        ("8/P7/8/8/8/8/k7/7K w - - 0 1", "a7a8q"),     // queen promotion → major_key
+        ("8/P7/8/8/8/8/k7/7K w - - 0 1", "a7a8n"),     // knight underpromotion → minor_key
+        ("4k3/8/8/3pP3/8/8/8/4K3 w - d6 0 1", "e5d6"), // en passant → pawn_key
+    ];
+
+    for (fen, uci) in cases {
+        let mut pos = Position::from_fen(fen);
+        let mut acc = pos.get_initial_accumulator();
+        let before = (pos.pawn_key, pos.minor_key, pos.major_key);
+
+        let mv = find_uci_move(&pos, uci);
+        let undo = pos.make_move(mv, &mut acc);
+
+        assert_eq!(pos.pawn_key, pos.calc_pawn_hash(), "Pawn key diverged after {uci} from {fen}");
+        assert_eq!(pos.minor_key, pos.calc_minor_hash(), "Minor key diverged after {uci} from {fen}");
+        assert_eq!(pos.major_key, pos.calc_major_hash(), "Major key diverged after {uci} from {fen}");
+
+        pos.unmake_move(mv, &undo);
+        assert_eq!((pos.pawn_key, pos.minor_key, pos.major_key), before, "Keys not restored after unmaking {uci} from {fen}");
     }
 }
 
@@ -112,6 +143,7 @@ fn accumulator_incremental_matches_full() {
         let mut acc = pos.get_initial_accumulator();
 
         let moves = gen_legal_moves(&pos);
+
         for mv in &moves {
             let saved_acc = acc;
             let undo = pos.make_move(*mv, &mut acc);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -897,9 +897,9 @@ impl Worker<'_> {
         // raw_static_eval stays untouched so the update at the end of this
         // frame learns from the unshifted baseline, not the already-corrected
         // value we use for pruning.
-        let pawn_hash = if in_check { 0 } else { self.pos.calc_pawn_hash() };
-        let minor_hash = if in_check { 0 } else { self.pos.calc_minor_hash() };
-        let major_hash = if in_check { 0 } else { self.pos.calc_major_hash() };
+        let pawn_hash = if in_check { 0 } else { self.pos.pawn_key };
+        let minor_hash = if in_check { 0 } else { self.pos.minor_key };
+        let major_hash = if in_check { 0 } else { self.pos.major_key };
         let static_eval = if in_check {
             tt::SCORE_NONE
         } else {
@@ -1571,9 +1571,9 @@ impl Worker<'_> {
             -INF
         } else {
             let raw_eval = evaluate(&self.pos, &self.accumulator);
-            let pawn_hash = self.pos.calc_pawn_hash();
-            let minor_hash = self.pos.calc_minor_hash();
-            let major_hash = self.pos.calc_major_hash();
+            let pawn_hash = self.pos.pawn_key;
+            let minor_hash = self.pos.minor_key;
+            let major_hash = self.pos.major_key;
             let correction =
                 self.history
                     .correction(self.pos.stm, pawn_hash, minor_hash, major_hash, minor_corr_weight(), major_corr_weight())

--- a/src/tools/dataset/viri_format.rs
+++ b/src/tools/dataset/viri_format.rs
@@ -9,7 +9,10 @@
 //! STM-relative on the way into SoulEntry. The header's score field is a
 //! stale placeholder — real evals live in the move pairs.
 
-use std::io::{self, Read};
+use std::{
+    fs,
+    io::{self, Read},
+};
 
 use super::SoulEntry;
 use crate::{
@@ -25,7 +28,7 @@ const PACKED_BOARD_SIZE: usize = 32;
 const SENTINEL: [u8; 4] = [0, 0, 0, 0];
 
 pub fn parse_viri_file(path: &str) -> io::Result<Vec<SoulEntry>> {
-    let mut file = std::fs::File::open(path)?;
+    let mut file = fs::File::open(path)?;
     let mut data = Vec::new();
     file.read_to_end(&mut data)?;
 
@@ -108,6 +111,7 @@ fn parse_packed_board(data: &[u8]) -> Option<(Position, u8)> {
     let en_passant = if ep < 64 { Some(Square(ep)) } else { None };
 
     let mut pos = Position::new();
+
     pos.stm = stm;
     pos.en_passant = en_passant;
 
@@ -131,6 +135,7 @@ fn parse_packed_board(data: &[u8]) -> Option<(Position, u8)> {
         if piece_idx >= 32 {
             break;
         }
+
         let nibble = if piece_idx.is_multiple_of(2) { pieces[piece_idx / 2] & 0x0F } else { pieces[piece_idx / 2] >> 4 };
         piece_idx += 1;
 
@@ -169,6 +174,7 @@ fn parse_packed_board(data: &[u8]) -> Option<(Position, u8)> {
     if let Some(king_sq) = white_king {
         for &rook_idx in &unmoved_rooks[Color::White as usize] {
             let rook = Square(rook_idx);
+
             if rook.file() > king_sq.file() {
                 set_castling_rights |= WHITE_OO;
                 pos.castling_rooks[ROOK_W_KS] = rook;
@@ -181,6 +187,7 @@ fn parse_packed_board(data: &[u8]) -> Option<(Position, u8)> {
     if let Some(king_sq) = black_king {
         for &rook_idx in &unmoved_rooks[Color::Black as usize] {
             let rook = Square(rook_idx);
+
             if rook.file() > king_sq.file() {
                 set_castling_rights |= BLACK_OO;
                 pos.castling_rooks[ROOK_B_KS] = rook;
@@ -199,6 +206,9 @@ fn parse_packed_board(data: &[u8]) -> Option<(Position, u8)> {
         || pos.castling_rooks[ROOK_B_QS] != Square(56);
 
     pos.hash = pos.calc_zobrist();
+    pos.pawn_key = pos.calc_pawn_hash();
+    pos.minor_key = pos.calc_minor_hash();
+    pos.major_key = pos.calc_major_hash();
 
     Some((pos, result))
 }
@@ -223,9 +233,11 @@ fn viri_to_soul_move(viri_move: u16, pos: &Position) -> Option<Move> {
     }
 
     let moving_piece = pos.piece_at(from);
+
     if moving_piece == PieceType::None {
         return None;
     }
+
     let capture = pos.piece_at(to) != PieceType::None;
 
     let flag: u16 = match move_type {


### PR DESCRIPTION
```
Elo   | 4.38 +- 3.44 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.98 (-2.47, 2.91) [0.00, 5.00]
Games | N: 18958 W: 5858 L: 5619 D: 7481
Penta | [567, 2131, 3914, 2230, 637]
```
https://asylum.red/test/5168/

`1.04 ± 0.01 times faster than ./soul-base bench`

Bench: 6124777