### PR TITLE
Shrink TT key to 16 bits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.19"
+version = "0.5.20"
 dependencies = [
  "ctrlc",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.19"
+version = "0.5.20"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]

--- a/src/core/board/mod.rs
+++ b/src/core/board/mod.rs
@@ -385,6 +385,29 @@ impl Position {
         minors <= 1
     }
 
+    /// Full legality of a castling move encoded king→rook (`ksq`→`rsq`) for `color`;
+    /// the right must be held, the corridor clear, and the king must neither stand
+    /// in nor cross an attacked square.
+    ///
+    /// The single source of truth shared by move generation and TT-move validation;
+    /// a TT collision can hand back a `CASTLE`-flagged move from an unrelated position,
+    /// and only the full check (not bare geometry) keeps it from castling through
+    /// pieces and corrupting the board. The side is read off the rook's file relative
+    /// to the king (FRC-safe); callers first establish that the king sits on `ksq` and
+    /// the castling rook on `rsq`.
+    #[inline]
+    pub fn is_castle_move_legal(&self, color: Color, ksq: Square, rsq: Square) -> bool {
+        let queenside = rsq.file() < ksq.file();
+        let (mask, data, check_sqs, empty): (u8, &[u8; 4], &[u8], Bitboard) = match (color, queenside) {
+            (Color::White, false) => (WHITE_OO, &CASTLE_W_KS, &CASTLE_W_KS_CHECK, W_OO_EMPTY),
+            (Color::White, true) => (WHITE_OOO, &CASTLE_W_QS, &CASTLE_W_QS_CHECK, W_OOO_EMPTY),
+            (Color::Black, false) => (BLACK_OO, &CASTLE_B_KS, &CASTLE_B_KS_CHECK, B_OO_EMPTY),
+            (Color::Black, true) => (BLACK_OOO, &CASTLE_B_QS, &CASTLE_B_QS_CHECK, B_OOO_EMPTY),
+        };
+
+        self.castling_rights & mask != 0 && self.is_castle_legal(self.occ, ksq, rsq, data, check_sqs, empty, color.opposite())
+    }
+
     /// Evaluates if a castling maneuver is strictly legal.
     ///
     /// It handles both fast-path standard chess, and the more rigorous

--- a/src/core/zobrist.rs
+++ b/src/core/zobrist.rs
@@ -91,6 +91,7 @@ const fn init_keys() -> ZobristKeys {
 
     let mut pieces = [0; PIECE_KEYS_LEN];
     let mut pt = 0;
+
     while pt < 6 {
         let mut sq = 0;
         while sq < 64 {
@@ -103,6 +104,7 @@ const fn init_keys() -> ZobristKeys {
 
     let mut en_passant = [0; EP_KEYS_LEN];
     let mut j = 0;
+
     while j < EP_KEYS_LEN {
         en_passant[j] = rng.next();
         j += 1;
@@ -110,10 +112,16 @@ const fn init_keys() -> ZobristKeys {
 
     let mut castling = [0; CASTLING_KEYS_LEN];
     let mut k = 0;
+
     while k < CASTLING_KEYS_LEN {
         castling[k] = rng.next();
         k += 1;
     }
+    // Empty rights must hash to nothing. make_move XORs key_castling on every rights
+    // change, so a non-zero key at index 0 desyncs the incremental hash from
+    // calc_zobrist (which skips zero rights) the moment castling rights run out. Drawn
+    // above, then zeroed, so the non-zero-rights keys keep their values.
+    castling[0] = 0;
 
     let side = rng.next();
 

--- a/src/engine/movegen.rs
+++ b/src/engine/movegen.rs
@@ -5,8 +5,7 @@
 
 use crate::core::{
     board::{
-        B_OO_EMPTY, B_OOO_EMPTY, BLACK_OO, BLACK_OOO, CASTLE_B_KS, CASTLE_B_KS_CHECK, CASTLE_B_QS, CASTLE_B_QS_CHECK, CASTLE_W_KS,
-        CASTLE_W_KS_CHECK, CASTLE_W_QS, CASTLE_W_QS_CHECK, Position, W_OO_EMPTY, W_OOO_EMPTY, WHITE_OO, WHITE_OOO,
+        BLACK_OO, BLACK_OOO, Position, ROOK_B_KS, ROOK_B_QS, ROOK_W_KS, ROOK_W_QS, WHITE_OO, WHITE_OOO,
         bitboard::{atk_bishop, atk_king, atk_knight, atk_pawn, atk_rook, between_bb, line_bb},
     },
     defs::{Bitboard, Color, Direction, FILE_A, FILE_H, PieceType, RANK_1, RANK_3, RANK_6, RANK_8, Square},
@@ -61,6 +60,7 @@ pub fn gen_legal_moves(board: &Position) -> MoveList {
 #[inline]
 pub fn gen_pseudo_moves(board: &Position) -> MoveList {
     let mut list = MoveList::new();
+
     match board.stm {
         Color::White => gen_all::<{ Color::White }, false>(board, &mut list),
         Color::Black => gen_all::<{ Color::Black }, false>(board, &mut list),
@@ -72,6 +72,7 @@ pub fn gen_pseudo_moves(board: &Position) -> MoveList {
 #[inline]
 pub fn gen_tactical_moves(board: &Position) -> MoveList {
     let mut list = MoveList::new();
+
     match board.stm {
         Color::White => gen_all::<{ Color::White }, true>(board, &mut list),
         Color::Black => gen_all::<{ Color::Black }, true>(board, &mut list),
@@ -105,11 +106,15 @@ pub fn is_pseudo_legal(board: &Position, mv: Move) -> bool {
     // A TT collision with the CASTLE flag but a garbage 'to' would make
     // apply_castling lift a non-rook piece and place a phantom rook,
     // permanently corrupting the board after unmake.
+    // Geometry guards reject that cheaply; the legality check then rejects
+    // a castle whose right is gone, whose corridor is blocked, or that crosses
+    // check — none of which were verified for a move that never went through generation.
     if mv.is_castling() {
         return piece == PieceType::King
             && board.piece_at(to) == PieceType::Rook
             && us.check_bit(to)
-            && board.castling_rooks.contains(&to);
+            && board.castling_rooks.contains(&to)
+            && board.is_castle_move_legal(stm, from, to);
     }
 
     // Destination must not hold a friendly piece.
@@ -253,8 +258,10 @@ fn is_ep_legal(board: &Position, mv: Move, ksq: Square, pinned: Bitboard, checke
     // the king, the move is illegal.
     if ksq.rank() == from.rank() {
         let rq = board.pieces(PieceType::Rook, opp) | board.pieces(PieceType::Queen, opp);
+
         if rq.is_not_empty() {
             let rank_occ = board.occ ^ from.bitboard() ^ cap_sq.bitboard();
+
             if (atk_rook(ksq, rank_occ) & rq).is_not_empty() {
                 return false;
             }
@@ -269,6 +276,7 @@ fn is_ep_legal(board: &Position, mv: Move, ksq: Square, pinned: Bitboard, checke
     let bq = board.pieces(PieceType::Bishop, opp) | board.pieces(PieceType::Queen, opp);
     if bq.is_not_empty() {
         let ep_occ = (board.occ ^ from.bitboard() ^ cap_sq.bitboard()) | to.bitboard();
+
         if (atk_bishop(ksq, ep_occ) & bq).is_not_empty() {
             return false;
         }
@@ -290,7 +298,7 @@ fn gen_all<const US: Color, const TACTICAL: bool>(board: &Position, acc: &mut Mo
     gen_king::<TACTICAL>(board, acc, us, them);
 
     if !TACTICAL {
-        gen_castling::<US>(board, acc, occ);
+        gen_castling::<US>(board, acc);
     }
 }
 
@@ -385,6 +393,7 @@ fn gen_pawns<const US: Color, const TACTICAL: bool>(board: &Position, acc: &mut 
     // ── En passant ──
     if let Some(ep_sq) = board.en_passant {
         let mut attackers = board.get_attackers_on(ep_sq, US) & pawns;
+
         while attackers.is_not_empty() {
             acc.push(Move::new(attackers.pop_lsb(), ep_sq, Move::EP_CAPTURE));
         }
@@ -396,6 +405,7 @@ fn gen_pawns<const US: Color, const TACTICAL: bool>(board: &Position, acc: &mut 
 fn gen_knights<const TACTICAL: bool>(board: &Position, acc: &mut MoveList, us: Bitboard, them: Bitboard) {
     for from in board.role_bb[PieceType::Knight] & us {
         let mut targets = atk_knight(from) & !us;
+
         if TACTICAL {
             targets &= them;
         }
@@ -413,6 +423,7 @@ fn gen_sliders<const TACTICAL: bool>(board: &Position, acc: &mut MoveList, occ: 
     while diags.is_not_empty() {
         let from = diags.pop_lsb();
         let mut targets = atk_bishop(from, occ) & !us;
+
         if TACTICAL {
             targets &= them;
         }
@@ -424,6 +435,7 @@ fn gen_sliders<const TACTICAL: bool>(board: &Position, acc: &mut MoveList, occ: 
     while orthos.is_not_empty() {
         let from = orthos.pop_lsb();
         let mut targets = atk_rook(from, occ) & !us;
+
         if TACTICAL {
             targets &= them;
         }
@@ -436,6 +448,7 @@ fn gen_sliders<const TACTICAL: bool>(board: &Position, acc: &mut MoveList, occ: 
 fn gen_king<const TACTICAL: bool>(board: &Position, acc: &mut MoveList, us: Bitboard, them: Bitboard) {
     for from in board.role_bb[PieceType::King] & us {
         let mut targets = atk_king(from) & !us;
+
         if TACTICAL {
             targets &= them;
         }
@@ -453,35 +466,29 @@ fn gen_king<const TACTICAL: bool>(board: &Position, acc: &mut MoveList, us: Bitb
 ///   2. King is not currently in check.
 ///   3. King does not pass through or land on an attacked square.
 #[inline]
-fn gen_castling<const US: Color>(board: &Position, acc: &mut MoveList, occ: Bitboard) {
+fn gen_castling<const US: Color>(board: &Position, acc: &mut MoveList) {
     let k_bb = board.role_bb[PieceType::King] & board.side_bb[US];
+
     if k_bb.is_empty() {
         return;
     }
 
     let ksq = k_bb.lsb();
-    let opp = US.opposite();
+    let (oo_mask, oo_idx, ooo_mask, ooo_idx) =
+        if US == Color::White { (WHITE_OO, ROOK_W_KS, WHITE_OOO, ROOK_W_QS) } else { (BLACK_OO, ROOK_B_KS, BLACK_OOO, ROOK_B_QS) };
 
-    let (oo_mask, ooo_mask, oo_idx, ooo_idx) =
-        if US == Color::White { (WHITE_OO, WHITE_OOO, 0, 1) } else { (BLACK_OO, BLACK_OOO, 2, 3) };
-
-    // Compute both castle data upfront, then check each right.
-    let (oo_data, oo_checks, oo_empty, ooo_data, ooo_checks, ooo_empty) = if US == Color::White {
-        (&CASTLE_W_KS, &CASTLE_W_KS_CHECK, W_OO_EMPTY, &CASTLE_W_QS, &CASTLE_W_QS_CHECK, W_OOO_EMPTY)
-    } else {
-        (&CASTLE_B_KS, &CASTLE_B_KS_CHECK, B_OO_EMPTY, &CASTLE_B_QS, &CASTLE_B_QS_CHECK, B_OOO_EMPTY)
-    };
-
-    if (board.castling_rights & oo_mask) != 0 {
-        let rsq = board.castling_rooks[oo_idx];
-        if board.is_castle_legal(occ, ksq, rsq, oo_data, oo_checks, oo_empty, opp) {
-            acc.push(Move::new(ksq, rsq, Move::CASTLE));
+    // The right must be held before we read its rook-home slot: an unheld slot
+    // can alias the other side's and double-generate. With the right held the
+    // slot is live, and `is_castle_move_legal` — shared verbatim with TT-move
+    // validation — owns the corridor and through-check logic.
+    for (mask, idx) in [(oo_mask, oo_idx), (ooo_mask, ooo_idx)] {
+        if board.castling_rights & mask == 0 {
+            continue;
         }
-    }
 
-    if (board.castling_rights & ooo_mask) != 0 {
-        let rsq = board.castling_rooks[ooo_idx];
-        if board.is_castle_legal(occ, ksq, rsq, ooo_data, ooo_checks, ooo_empty, opp) {
+        let rsq = board.castling_rooks[idx];
+
+        if board.is_castle_move_legal(US, ksq, rsq) {
             acc.push(Move::new(ksq, rsq, Move::CASTLE));
         }
     }
@@ -530,5 +537,22 @@ mod tests {
             !moves2.contains(&ep_move),
             "EP move should be illegal due to horizontal discovered check exposing the mover's king"
         );
+    }
+
+    #[test]
+    fn tt_castle_move_validates_corridor() {
+        // A TT hash collision can hand back a CASTLE-flagged move from an
+        // unrelated position. King-home/rook-home geometry alone is not enough:
+        // castling through an occupied corridor makes apply_castling drop a rook
+        // onto the blocker and corrupt the board. is_pseudo_legal must run the
+        // full legality check, not just the geometry.
+        let pos = Position::from_fen("r3k2r/8/8/8/8/8/8/R3K1NR w KQkq - 0 1");
+
+        let e1 = Square(4);
+        let kingside = Move::new(e1, Square(7), Move::CASTLE); // blocked by the knight on g1
+        let queenside = Move::new(e1, Square(0), Move::CASTLE); // corridor clear
+
+        assert!(!is_pseudo_legal(&pos, kingside), "kingside castle through the g1 knight must be rejected");
+        assert!(is_pseudo_legal(&pos, queenside), "queenside castle with a clear corridor must pass");
     }
 }

--- a/src/engine/movegen.rs
+++ b/src/engine/movegen.rs
@@ -131,8 +131,12 @@ pub fn is_pseudo_legal(board: &Position, mv: Move) -> bool {
         return false;
     }
 
-    // Promotions must come from a pawn.
-    if mv.is_promotion() && piece != PieceType::Pawn {
+    // Pawn-only flags must come from a pawn. A collision pairing promotion,
+    // en passant, or double push with a slider or knight move slips past the
+    // per-piece attack check below, then trips make_move's pawn-special paths;
+    // phantom en passant, a victim removed off the wrong square — corrupting the
+    // board. The castle flag is already handled (king-only) above.
+    if piece != PieceType::Pawn && (mv.is_promotion() || mv.is_en_passant() || mv.is_double_push()) {
         return false;
     }
 
@@ -489,8 +493,12 @@ fn gen_castling<const US: Color>(board: &Position, acc: &mut MoveList) {
     }
 
     let ksq = k_bb.lsb();
-    let (oo_mask, oo_idx, ooo_mask, ooo_idx) =
-        if US == Color::White { (WHITE_OO, ROOK_W_KS, WHITE_OOO, ROOK_W_QS) } else { (BLACK_OO, ROOK_B_KS, BLACK_OOO, ROOK_B_QS) };
+
+    let (oo_mask, oo_idx, ooo_mask, ooo_idx) = if US == Color::White {
+        (WHITE_OO, ROOK_W_KS, WHITE_OOO, ROOK_W_QS)
+    } else {
+        (BLACK_OO, ROOK_B_KS, BLACK_OOO, ROOK_B_QS)
+    };
 
     // The right must be held before we read its rook-home slot: an unheld slot
     // can alias the other side's and double-generate. With the right held the
@@ -533,7 +541,10 @@ fn emit_from_mask(acc: &mut MoveList, from: Square, targets: Bitboard, them: Bit
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::board::Position;
+    use crate::core::{
+        board::{Position, STARTPOS},
+        zobrist::ConstRng,
+    };
 
     #[test]
     fn ep_diagonal_discovered_check() {
@@ -541,6 +552,7 @@ mod tests {
         let moves = gen_legal_moves(&pos);
 
         let ep_move = Move::new(Square::from_coords(3, 4), Square::from_coords(4, 5), Move::EP_CAPTURE);
+
         assert!(
             !moves.contains(&ep_move),
             "EP move should be illegal due to diagonal discovered check exposing the mover's king"
@@ -548,6 +560,7 @@ mod tests {
 
         let pos2 = Position::from_fen("4k3/8/8/r2Pp2K/8/8/8/8 w - e6 0 1");
         let moves2 = gen_legal_moves(&pos2);
+
         assert!(
             !moves2.contains(&ep_move),
             "EP move should be illegal due to horizontal discovered check exposing the mover's king"
@@ -579,10 +592,227 @@ mod tests {
         // outlives the move. The origin must be the pawn's start rank.
         let pos = Position::from_fen("4k3/8/8/8/8/4P3/8/4K3 w - - 0 1"); // pawn on e3
         let phantom = Move::new(Square::from_coords(4, 2), Square::from_coords(4, 4), Move::DOUBLE_PUSH);
+
         assert!(!is_pseudo_legal(&pos, phantom), "double push from the third rank must be rejected");
 
         let start = Position::from_fen("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1"); // pawn on e2
         let real = Move::new(Square::from_coords(4, 1), Square::from_coords(4, 3), Move::DOUBLE_PUSH);
+
         assert!(is_pseudo_legal(&start, real), "double push from the second rank must pass");
+    }
+
+    /// Legality perft (after Rose): at each node, sweep every 16-bit move encoding
+    /// and recurse on whatever `is_pseudo_legal` + `is_legal` jointly accept. A 16-bit
+    /// TT key lets collisions feed the search any encoding, so this drives the
+    /// validators exactly as collisions do. Matching known-good perft proves the pair
+    /// accepts precisely the legal moves: no spurious move (which `make_move` would
+    /// turn into a corrupt board) and none missing.
+    #[test]
+    fn legality_perft_matches_reference() {
+        // (FEN, [perft(0), perft(1), …])
+        let cases: &[(&str, &[u64])] = &[
+            (STARTPOS, &[1, 20, 400, 8902]),
+            ("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1", &[1, 48, 2039]),
+            ("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1", &[1, 14, 191, 2812]),
+            ("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1", &[1, 6, 264]),
+            ("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8", &[1, 44, 1486]),
+            ("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", &[1, 46, 2079]),
+        ];
+
+        for (fen, expected) in cases {
+            let pos = Position::from_fen(fen);
+
+            for (depth, &want) in expected.iter().enumerate() {
+                assert_eq!(legality_perft(&pos, depth), want, "legality perft depth {depth} for {fen}");
+            }
+        }
+    }
+
+    /// The same legality perft, pushed deeper. The all-encoding sweep is O(65536) per
+    /// node, so this is too slow for the default suite — run it explicitly:
+    /// `cargo test --release legality_perft_deep -- --ignored`.
+    #[test]
+    #[ignore = "deep: run explicitly with --release"]
+    fn legality_perft_deep() {
+        let cases: &[(&str, &[u64])] = &[
+            (STARTPOS, &[1, 20, 400, 8902, 197281]),
+            ("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1", &[1, 48, 2039, 97862]),
+            ("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1", &[1, 14, 191, 2812, 43238]),
+            ("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8", &[1, 44, 1486, 62379]),
+            ("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", &[1, 46, 2079, 89890]),
+        ];
+
+        for (fen, expected) in cases {
+            let pos = Position::from_fen(fen);
+
+            for (depth, &want) in expected.iter().enumerate() {
+                assert_eq!(legality_perft(&pos, depth), want, "deep legality perft depth {depth} for {fen}");
+            }
+        }
+    }
+
+    /// Counts legal-move paths by validating every 16-bit encoding through
+    /// `is_pseudo_legal` + `is_legal` — the exact pair that guards TT moves.
+    fn legality_perft(pos: &Position, depth: usize) -> u64 {
+        if depth == 0 {
+            return 1;
+        }
+
+        let stm = pos.stm;
+        let opp = stm.opposite();
+        let ksq = pos.pieces(PieceType::King, stm).lsb();
+        let pinned = pos.king_blockers();
+        let checkers = pos.checkers();
+
+        let mut nodes = 0;
+
+        for raw in 0..=u16::MAX {
+            // 8, 9, 13 are unused flag nibbles the generator never emits, so a real
+            // collision never carries them; counting them would double-count the
+            // quiet/capture move they decode to.
+            if matches!(raw >> 12, 8 | 9 | 13) {
+                continue;
+            }
+
+            let mv = Move::from_u16(raw);
+
+            if !is_pseudo_legal(pos, mv) || !is_legal(pos, mv, ksq, pinned, checkers, opp) {
+                continue;
+            }
+
+            let mut child = *pos;
+            let mut acc = child.get_initial_accumulator();
+
+            child.make_move(mv, &mut acc);
+            nodes += legality_perft(&child, depth - 1);
+        }
+        nodes
+    }
+
+    /// Make/unmake integrity fuzzer — the state-level companion to the legality perft,
+    /// which only counts. For positions drawn from a random playout, every move the
+    /// validators accept must make into a self-consistent board (occupancy is the color
+    /// union, roles partition it, the mailbox mirrors the bitboards, both kings stand,
+    /// and every incremental key matches a from-scratch recompute) and must unmake back
+    /// to the original position unchanged.
+    #[test]
+    fn fuzz_make_unmake_integrity() {
+        const POSITIONS: usize = 256;
+
+        let mut rng = ConstRng::new(0x9E3779B97F4A7C15);
+        let mut pos = Position::from_fen(STARTPOS);
+        let mut acc = pos.get_initial_accumulator();
+
+        for _ in 0..POSITIONS {
+            check_every_move(&pos);
+
+            let legal = gen_legal_moves(&pos);
+
+            if legal.is_empty() {
+                pos = Position::from_fen(STARTPOS);
+                acc = pos.get_initial_accumulator();
+                continue;
+            }
+
+            let mv = legal[rng.next() as usize % legal.len()];
+            pos.make_move(mv, &mut acc);
+        }
+    }
+
+    /// Sweep every 16-bit encoding against `pos`; each move the validators accept must
+    /// survive make (consistent board, matching accumulator) and unmake (exact restore).
+    fn check_every_move(pos: &Position) {
+        let stm = pos.stm;
+        let opp = stm.opposite();
+        let ksq = pos.pieces(PieceType::King, stm).lsb();
+        let pinned = pos.king_blockers();
+        let checkers = pos.checkers();
+
+        for raw in 0..=u16::MAX {
+            let mv = Move::from_u16(raw);
+
+            if !is_pseudo_legal(pos, mv) || !is_legal(pos, mv, ksq, pinned, checkers, opp) {
+                continue;
+            }
+
+            let mut child = *pos;
+            let mut acc = child.get_initial_accumulator();
+            let undo = child.make_move(mv, &mut acc);
+
+            assert_consistent(&child, pos, mv);
+            let fresh = child.get_initial_accumulator();
+            assert_eq!(acc.to_array(), fresh.to_array(), "accumulator diverged {}", context(pos, mv));
+
+            child.unmake_move(mv, &undo);
+            assert!(board_eq(&child, pos), "unmake did not restore {}", context(pos, mv));
+        }
+    }
+
+    /// Every internal view of a position agrees with the others.
+    fn assert_consistent(pos: &Position, before: &Position, mv: Move) {
+        let w = pos.side_bb[Color::White];
+        let b = pos.side_bb[Color::Black];
+
+        assert_eq!(pos.occ, w | b, "occupancy is not the color union {}", context(before, mv));
+        assert!((w & b).is_empty(), "a square is owned by both colors {}", context(before, mv));
+
+        let mut union = Bitboard(0);
+        let mut count = 0;
+
+        for pt in [PieceType::Pawn, PieceType::Knight, PieceType::Bishop, PieceType::Rook, PieceType::Queen, PieceType::King] {
+            let role = pos.role_bb[pt];
+            assert!((role & !pos.occ).is_empty(), "role {pt:?} outside occupancy {}", context(before, mv));
+            union |= role;
+            count += role.popcount();
+        }
+
+        assert_eq!(union, pos.occ, "roles do not cover occupancy {}", context(before, mv));
+        assert_eq!(count, pos.occ.popcount(), "two roles share a square {}", context(before, mv));
+
+        for color in [Color::White, Color::Black] {
+            assert_eq!(pos.pieces(PieceType::King, color).popcount(), 1, "{color:?} king count {}", context(before, mv));
+        }
+
+        for sq in (0..64).map(Square) {
+            let pt = pos.piece_at(sq);
+
+            assert_eq!(
+                pos.occ.check_bit(sq),
+                pt != PieceType::None,
+                "mailbox/occupancy disagree at {} {}",
+                sq.0,
+                context(before, mv)
+            );
+
+            if pt != PieceType::None {
+                assert!(pos.role_bb[pt].check_bit(sq), "mailbox/role disagree at {} {}", sq.0, context(before, mv));
+            }
+        }
+
+        assert_eq!(pos.hash, pos.calc_zobrist(), "hash desynced {}", context(before, mv));
+        assert_eq!(pos.pawn_key, pos.calc_pawn_hash(), "pawn key desynced {}", context(before, mv));
+        assert_eq!(pos.minor_key, pos.calc_minor_hash(), "minor key desynced {}", context(before, mv));
+        assert_eq!(pos.major_key, pos.calc_major_hash(), "major key desynced {}", context(before, mv));
+    }
+
+    /// Field-wise board equality across everything make/unmake can touch.
+    fn board_eq(a: &Position, b: &Position) -> bool {
+        a.side_bb == b.side_bb
+            && a.role_bb == b.role_bb
+            && a.occ == b.occ
+            && a.hash == b.hash
+            && a.pawn_key == b.pawn_key
+            && a.minor_key == b.minor_key
+            && a.major_key == b.major_key
+            && a.pieces == b.pieces
+            && a.castling_rights == b.castling_rights
+            && a.stm == b.stm
+            && a.en_passant == b.en_passant
+            && a.halfmove_clock == b.halfmove_clock
+            && a.fullmove_number == b.fullmove_number
+    }
+
+    fn context(pos: &Position, mv: Move) -> String {
+        format!("after {} from {}", mv.to_uci(pos.is_frc), pos.as_fen())
     }
 }

--- a/src/engine/movegen.rs
+++ b/src/engine/movegen.rs
@@ -139,14 +139,29 @@ pub fn is_pseudo_legal(board: &Position, mv: Move) -> bool {
     match piece {
         PieceType::Pawn => {
             let fwd = stm.forward_dir().delta();
+            let (start_rank, last_rank) = if stm == Color::White { (1u8, 7u8) } else { (6u8, 0u8) };
+
+            // A promotion flag belongs exactly on the last rank, and a non-promoting
+            // pawn move must never land there — the generator always promotes.
+            // A collision that breaks either would queen mid-board or push
+            // a pawn onto the back rank.
+            if mv.is_promotion() != (to.rank() == last_rank) {
+                return false;
+            }
 
             if mv.is_en_passant() {
                 return board.en_passant == Some(to) && atk_pawn(from, stm).check_bit(to);
             }
 
             if mv.is_double_push() {
+                // From the start rank only. Otherwise the move arms a phantom en
+                // passant square that a later EP capture turns into board corruption.
                 let mid = Square((from.0 as i8 + fwd) as u8);
-                return to.0 as i8 == from.0 as i8 + fwd * 2 && !occ.check_bit(mid) && !occ.check_bit(to);
+
+                return from.rank() == start_rank
+                    && to.0 as i8 == from.0 as i8 + fwd * 2
+                    && !occ.check_bit(mid)
+                    && !occ.check_bit(to);
             }
 
             if mv.is_capture() {
@@ -554,5 +569,20 @@ mod tests {
 
         assert!(!is_pseudo_legal(&pos, kingside), "kingside castle through the g1 knight must be rejected");
         assert!(is_pseudo_legal(&pos, queenside), "queenside castle with a clear corridor must pass");
+    }
+
+    #[test]
+    fn tt_double_push_validates_start_rank() {
+        // A TT collision can hand back a DOUBLE_PUSH from the wrong rank. Played,
+        // it arms a phantom en passant square; a later EP capture removes a pawn
+        // that isn't there and unmake then conjures one — board corruption that
+        // outlives the move. The origin must be the pawn's start rank.
+        let pos = Position::from_fen("4k3/8/8/8/8/4P3/8/4K3 w - - 0 1"); // pawn on e3
+        let phantom = Move::new(Square::from_coords(4, 2), Square::from_coords(4, 4), Move::DOUBLE_PUSH);
+        assert!(!is_pseudo_legal(&pos, phantom), "double push from the third rank must be rejected");
+
+        let start = Position::from_fen("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1"); // pawn on e2
+        let real = Move::new(Square::from_coords(4, 1), Square::from_coords(4, 3), Move::DOUBLE_PUSH);
+        assert!(is_pseudo_legal(&start, real), "double push from the second rank must pass");
     }
 }

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -3,12 +3,14 @@
 //! # Notes
 //!
 //! Lockless single-threaded design: probe and store take `&self` and
-//! mutate entries through raw pointers. The 64-bit full-key match prevents
-//! hash collisions from corrupting position data. Replacement is depth-
-//! preferred with exact-position upgrades; qsearch stores are conservative
-//! to avoid evicting deeper negamax entries.
+//! mutate entries through raw pointers. A 16-bit verification key guards
+//! against hash collisions; the rare aliasing that slips through (~1 in 2¹⁶
+//! within a probed cluster) can only return a stale score, never a corrupting
+//! move, because every stored move is re-validated by `is_pseudo_legal` before
+//! use. Replacement is depth-preferred with exact-position upgrades; qsearch
+//! stores are conservative to avoid evicting deeper negamax entries.
 //!
-//! Three-entry clusters (48 bytes per cluster): each hash index maps to
+//! Three-entry clusters (30 bytes per cluster): each hash index maps to
 //! a 3-slot bucket, giving the replacement formula three candidates to
 //! select from instead of one.
 
@@ -30,9 +32,9 @@ pub const BOUND_UPPER: u8 = 3; // Alpha cutoff (fail-low)
 
 pub const SCORE_NONE: i32 = 32000;
 
-const _: () = assert!(mem::size_of::<TtEntry>() == 16);
+const _: () = assert!(mem::size_of::<TtEntry>() == 10);
 
-/// `quality = depth - gen_diff * AGE_FACTOR`.
+/// `quality = depth - gen_diff · AGE_FACTOR`.
 /// Higher values evict stale entries faster.
 /// Sirius: 2, Obsidian: 8
 const AGE_FACTOR: i32 = 4;
@@ -45,11 +47,20 @@ pub fn can_cutoff(bound: u8, score: i32, alpha: i32, beta: i32) -> bool {
     bound == BOUND_EXACT || (bound == BOUND_LOWER && score >= beta) || (bound == BOUND_UPPER && score <= alpha)
 }
 
+/// The slot's verification key: the low 16 bits of the Zobrist hash. The
+/// cluster index already consumes the high bits, so these are the discriminating
+/// bits left over within a bucket.
+#[inline(always)]
+const fn verification_key(hash: u64) -> u16 {
+    hash as u16
+}
+
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
 pub struct TtEntry {
-    /// Full 64-bit Zobrist key to mathematically prevent hash collisions
-    pub key: u64,
+    /// 16-bit verification key (low bits of the Zobrist hash). Collisions that
+    /// survive it are caught downstream by `is_pseudo_legal` on the stored move.
+    pub key: u16,
     /// Best move found in this position
     pub mv: u16,
     pub score: i16,
@@ -99,7 +110,9 @@ impl TranspositionTable {
         if self.entries.is_empty() {
             return;
         }
+
         let ptr = self.entries.as_ptr() as *mut TtEntry;
+
         unsafe {
             ptr::write_bytes(ptr, 0, self.entries.len());
         }
@@ -119,6 +132,7 @@ impl TranspositionTable {
         }
 
         let idx = self.index(hash);
+
         unsafe {
             let ptr = self.entries.as_ptr().add(idx) as *const i8;
             #[cfg(target_arch = "x86_64")]
@@ -133,11 +147,13 @@ impl TranspositionTable {
         }
 
         let idx = self.index(hash);
+        let key16 = verification_key(hash);
 
         for i in 0..CLUSTER_SIZE {
             let entry = unsafe { &*self.entries.as_ptr().add(idx + i) };
-            // 64-bit exact match completely prevents hash-collision-induced memory corruption.
-            if entry.key == hash && entry.bound != BOUND_NONE {
+            // The bound guard keeps an empty slot (key 0) from matching a real
+            // position whose low 16 bits happen to be 0.
+            if entry.key == key16 && entry.bound != BOUND_NONE {
                 let score = Self::score_from_tt(entry.score as i32, ply);
                 let mv = Move::from_u16(entry.mv);
 
@@ -154,6 +170,7 @@ impl TranspositionTable {
         }
 
         let idx = self.index(hash);
+        let key16 = verification_key(hash);
         let cur = self.generation.load(Ordering::Relaxed);
         let mut replace_idx = idx;
         let mut worst_quality = i32::MAX;
@@ -161,13 +178,14 @@ impl TranspositionTable {
         for i in 0..CLUSTER_SIZE {
             let entry = unsafe { &*self.entries.as_ptr().add(idx + i) };
 
-            if entry.bound == BOUND_NONE || entry.key == hash {
+            if entry.bound == BOUND_NONE || entry.key == key16 {
                 replace_idx = idx + i;
                 break;
             }
 
             let gen_diff = cur.wrapping_sub(entry.age) as i32;
             let quality = entry.depth as i32 - gen_diff * AGE_FACTOR;
+
             if quality < worst_quality {
                 worst_quality = quality;
                 replace_idx = idx + i;
@@ -177,8 +195,8 @@ impl TranspositionTable {
         // SAFETY: Obtaining mutable reference to a slot via an immutable &self.
         // Standard high-performance lockless TT approach.
         let entry = unsafe { &mut *(self.entries.as_ptr().add(replace_idx) as *mut TtEntry) };
-        let is_exact_match = entry.key == hash;
-        entry.key = hash;
+        let is_exact_match = entry.key == key16;
+        entry.key = key16;
 
         let mut store_mv = mv.inner();
         let mut store_pv = pv as u8;
@@ -211,6 +229,7 @@ impl TranspositionTable {
         }
 
         let idx = self.index(hash);
+        let key16 = verification_key(hash);
         let cur = self.generation.load(Ordering::Relaxed);
         let mut best_idx: Option<usize> = None;
         let mut best_quality = i32::MAX;
@@ -219,14 +238,15 @@ impl TranspositionTable {
         for i in 0..CLUSTER_SIZE {
             let entry = unsafe { &*self.entries.as_ptr().add(idx + i) };
 
-            if entry.key == hash || entry.bound == BOUND_NONE || entry.depth == 0 {
+            if entry.key == key16 || entry.bound == BOUND_NONE || entry.depth == 0 {
                 best_idx = Some(idx + i);
-                is_key_match = entry.key == hash;
+                is_key_match = entry.key == key16;
                 break;
             }
 
             let gen_diff = cur.wrapping_sub(entry.age) as i32;
             let quality = entry.depth as i32 - gen_diff * AGE_FACTOR;
+
             if quality <= 0 && quality < best_quality {
                 best_quality = quality;
                 best_idx = Some(idx + i);
@@ -241,7 +261,8 @@ impl TranspositionTable {
             // position — qs visits would otherwise erase the propagated flag
             // stamped by a previous negamax store.
             let store_pv = if is_key_match { (pv as u8) | entry.pv } else { pv as u8 };
-            entry.key = hash;
+
+            entry.key = key16;
             entry.mv = mv.inner();
             entry.score = Self::score_to_tt(score, ply) as i16;
             entry.depth = 0;


### PR DESCRIPTION
Drop the transposition table's full 64-bit key to a 16-bit verification key.
The cluster index already discriminates the high bits, so 16 bits suffice.
Entry shrinks 16→10 bytes, ~60% more positions per MB.

The catch: a 16-bit key lets a collision hand back a well-formed move from an
unrelated position, which the full key never could. `is_pseudo_legal` was the
only guard left, and it had holes. Castling checked geometry but not the
corridor, rights, or through-check. Double pushes weren't tied to the start
rank. Promotions weren't tied to the last rank. Pawn-only flags (EP, double
push, promotion) could ride on a slider or knight move into `make_move`'s
pawn-special paths. Each let a collision corrupt the board. The early 16-bit
runs surfaced all four. All closed; a collision now costs at most a stale
score, never a corrupting move.

Two permanent guards: a legality perft (sweeps every 16-bit encoding through
`is_pseudo_legal` + `is_legal`) and a `make`/`unmake` integrity fuzzer.

Also zeroes the empty-rights castling Zobrist key. Pre-existing desync between
`make_move` and `calc_zobrist` once rights reach 0, surfaced by the fuzzer.

```
Elo   | 5.16 +- 3.94 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=1MB
LLR   | 2.98 (-2.47, 2.91) [0.00, 5.00]
Games | N: 15292 W: 4703 L: 4476 D: 6113
Penta | [497, 1751, 2982, 1860, 556]
```
https://asylum.red/test/5179/

```
Elo   | 3.29 +- 2.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.47, 2.91) [0.00, 5.00]
Games | N: 30558 W: 8939 L: 8650 D: 12969
Penta | [845, 3586, 6155, 3821, 872]
```
https://asylum.red/test/5180/

At `[-4.50, 0.50]` bounds; LLR 2.69, passing the 2.25 target.
with penta calc; LLR 2.93
```
Elo   | 2.53 +- 3.96 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.73 (-2.47, 2.91) [0.00, 5.00]
Games | N: 11832 W: 3125 L: 3039 D: 5668
Penta | [213, 1447, 2539, 1475, 242]
```
https://asylum.red/test/5181/

Bench: 6112546