### PR TITLE
Reuse static eval from the TT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.20"
+version = "0.5.21"
 dependencies = [
  "ctrlc",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.20"
+version = "0.5.21"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -845,26 +845,27 @@ impl Worker<'_> {
         // If a previous search already explored it to sufficient depth,
         // we can reuse its result and skip the entire subtree.
         // This is what makes iterative deepening fast — earlier iterations populate the table for later ones.
-        let (tt_move, tt_pv) = if let Some((mv, score, depth_stored, bound, pv)) = searcher.tt.probe(self.pos.hash, ply) {
-            // Hash collisions can inject moves from unrelated positions.
-            // Full pseudo-legality check rejects garbage before it reaches
-            // the move picker or triggers a cutoff with a bogus score.
-            let valid = mv.is_null() || is_pseudo_legal(&self.pos, mv);
+        let (tt_move, tt_pv, tt_eval) =
+            if let Some((mv, score, depth_stored, bound, pv, eval)) = searcher.tt.probe(self.pos.hash, ply) {
+                // Hash collisions can inject moves from unrelated positions.
+                // Full pseudo-legality check rejects garbage before it reaches
+                // the move picker or triggers a cutoff with a bogus score.
+                let valid = mv.is_null() || is_pseudo_legal(&self.pos, mv);
 
-            #[rustfmt::skip]
-            if valid
-                && !N::PV
-                && depth_stored >= depth
-                && tt::can_cutoff(bound, score, alpha, beta)
-            {
-                return Ok(score);
-            }
+                #[rustfmt::skip]
+                if valid
+                    && !N::PV
+                    && depth_stored >= depth
+                    && tt::can_cutoff(bound, score, alpha, beta)
+                {
+                    return Ok(score);
+                }
 
-            let tt_move = if valid && !mv.is_null() { Some(mv) } else { None };
-            (tt_move, pv)
-        } else {
-            (None, false)
-        };
+                let tt_move = if valid && !mv.is_null() { Some(mv) } else { None };
+                (tt_move, pv, Some(eval))
+            } else {
+                (None, false, None)
+            };
 
         // ── TT Move Ordering (~56 Elo) ──
         // Even when the TT score didn't produce a cutoff, the move it stored
@@ -886,7 +887,15 @@ impl Worker<'_> {
         // Used as a baseline for pruning decisions — if the position looks
         // overwhelmingly good or hopeless, we can take shortcuts.
         // Meaningless when in check (we're forced to respond, not evaluate).
-        let raw_static_eval = if in_check { tt::SCORE_NONE } else { evaluate(&self.pos, &self.accumulator) };
+        // A TT hit already carries this position's raw eval, so reuse it and skip
+        // the full evaluation; the stored sentinel (an in-check store) falls through.
+        let raw_static_eval = if in_check {
+            tt::SCORE_NONE
+        } else if let Some(eval) = tt_eval.filter(|&e| e != tt::SCORE_NONE) {
+            eval
+        } else {
+            evaluate(&self.pos, &self.accumulator)
+        };
 
         // ── Correction History ──
         // The evaluator has systematic biases tied to structural features
@@ -1316,7 +1325,7 @@ impl Worker<'_> {
         // ── TT store ──
         searcher
             .tt
-            .store(self.pos.hash, ply, depth, res.best_eval, res.best_move, bound, N::PV || tt_pv);
+            .store(self.pos.hash, ply, depth, res.best_eval, res.best_move, bound, N::PV || tt_pv, raw_static_eval);
 
         // ── Correction History Update ──
         // Only learn from positions resolved by quiet moves — tactical
@@ -1548,15 +1557,17 @@ impl Worker<'_> {
         // sequence for accurate PV reporting.
         //
         // Quiescence TT Move (~9 Elo)
-        let (qs_tt_move, qs_tt_pv) = if let Some((mv, score, _depth, bound, pv)) = searcher.tt.probe(self.pos.hash, ply) {
-            if !N::PV && tt::can_cutoff(bound, score, alpha, beta) {
-                return Ok(score);
-            }
-            let mv = if !mv.is_null() && is_pseudo_legal(&self.pos, mv) { Some(mv) } else { None };
-            (mv, pv)
-        } else {
-            (None, false)
-        };
+        let (qs_tt_move, qs_tt_pv, qs_tt_eval) =
+            if let Some((mv, score, _depth, bound, pv, eval)) = searcher.tt.probe(self.pos.hash, ply) {
+                if !N::PV && tt::can_cutoff(bound, score, alpha, beta) {
+                    return Ok(score);
+                }
+
+                let mv = if !mv.is_null() && is_pseudo_legal(&self.pos, mv) { Some(mv) } else { None };
+                (mv, pv, Some(eval))
+            } else {
+                (None, false, None)
+            };
 
         let checkers = self.pos.checkers();
         let in_check = checkers.is_not_empty();
@@ -1567,10 +1578,19 @@ impl Worker<'_> {
         // If we are in check, the position is forced and static evaluation is meaningless.
         // We drop the stand-pat evaluation (-INF) and the MovePicker will generate
         // all legal evasions instead of just captures/queen promotions.
+        // A TT hit already carries this position's raw eval; reuse it over a fresh
+        // evaluation. SCORE_NONE in check, and is also the store value below.
+        let raw_eval = if in_check {
+            tt::SCORE_NONE
+        } else if let Some(eval) = qs_tt_eval.filter(|&e| e != tt::SCORE_NONE) {
+            eval
+        } else {
+            evaluate(&self.pos, &self.accumulator)
+        };
+
         let mut best_eval = if in_check {
             -INF
         } else {
-            let raw_eval = evaluate(&self.pos, &self.accumulator);
             let pawn_hash = self.pos.pawn_key;
             let minor_hash = self.pos.minor_key;
             let major_hash = self.pos.major_key;
@@ -1689,7 +1709,10 @@ impl Worker<'_> {
         } else {
             tt::BOUND_UPPER
         };
-        searcher.tt.store_qs(self.pos.hash, ply, best_eval, best_move, bound, N::PV || qs_tt_pv);
+
+        searcher
+            .tt
+            .store_qs(self.pos.hash, ply, best_eval, best_move, bound, N::PV || qs_tt_pv, raw_eval);
 
         Ok(best_eval)
     }

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -10,7 +10,7 @@
 //! use. Replacement is depth-preferred with exact-position upgrades; qsearch
 //! stores are conservative to avoid evicting deeper negamax entries.
 //!
-//! Three-entry clusters (30 bytes per cluster): each hash index maps to
+//! Three-entry clusters (36 bytes per cluster): each hash index maps to
 //! a 3-slot bucket, giving the replacement formula three candidates to
 //! select from instead of one.
 
@@ -32,7 +32,7 @@ pub const BOUND_UPPER: u8 = 3; // Alpha cutoff (fail-low)
 
 pub const SCORE_NONE: i32 = 32000;
 
-const _: () = assert!(mem::size_of::<TtEntry>() == 10);
+const _: () = assert!(mem::size_of::<TtEntry>() == 12);
 
 /// `quality = depth - gen_diff · AGE_FACTOR`.
 /// Higher values evict stale entries faster.
@@ -64,6 +64,9 @@ pub struct TtEntry {
     /// Best move found in this position
     pub mv: u16,
     pub score: i16,
+    /// Raw static eval at store time (`SCORE_NONE` when stored in check), so a
+    /// hit can reuse it instead of recomputing the full evaluation.
+    pub eval: i16,
     pub depth: u8,
     pub bound: u8,
     /// Generation at store time — prior-generation entries evict first.
@@ -141,7 +144,7 @@ impl TranspositionTable {
     }
 
     #[inline(always)]
-    pub fn probe(&self, hash: u64, ply: usize) -> Option<(Move, i32, i32, u8, bool)> {
+    pub fn probe(&self, hash: u64, ply: usize) -> Option<(Move, i32, i32, u8, bool, i32)> {
         if self.entries.is_empty() {
             return None;
         }
@@ -157,14 +160,14 @@ impl TranspositionTable {
                 let score = Self::score_from_tt(entry.score as i32, ply);
                 let mv = Move::from_u16(entry.mv);
 
-                return Some((mv, score, entry.depth as i32, entry.bound, entry.pv != 0));
+                return Some((mv, score, entry.depth as i32, entry.bound, entry.pv != 0, entry.eval as i32));
             }
         }
         None
     }
 
     #[inline(always)]
-    pub fn store(&self, hash: u64, ply: usize, depth: i32, score: i32, mv: Move, bound: u8, pv: bool) {
+    pub fn store(&self, hash: u64, ply: usize, depth: i32, score: i32, mv: Move, bound: u8, pv: bool, eval: i32) {
         if self.entries.is_empty() {
             return;
         }
@@ -211,6 +214,7 @@ impl TranspositionTable {
 
         entry.mv = store_mv;
         entry.score = Self::score_to_tt(score, ply) as i16;
+        entry.eval = eval.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
         entry.depth = depth as u8;
         entry.bound = bound;
         entry.age = cur;
@@ -223,7 +227,7 @@ impl TranspositionTable {
     /// only overwrites empty slots, existing depth-0 entries, or stale entries
     /// whose aged quality has dropped to zero — never evicts a fresh deep entry.
     #[inline(always)]
-    pub fn store_qs(&self, hash: u64, ply: usize, score: i32, mv: Move, bound: u8, pv: bool) {
+    pub fn store_qs(&self, hash: u64, ply: usize, score: i32, mv: Move, bound: u8, pv: bool, eval: i32) {
         if self.entries.is_empty() {
             return;
         }
@@ -265,6 +269,7 @@ impl TranspositionTable {
             entry.key = key16;
             entry.mv = mv.inner();
             entry.score = Self::score_to_tt(score, ply) as i16;
+            entry.eval = eval.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
             entry.depth = 0;
             entry.bound = bound;
             entry.age = cur;


### PR DESCRIPTION
Store the raw static eval in the bytes the 16-bit key freed (entry 10→12)
and reuse it on a hit instead of recomputing the full evaluation.

`SCORE_NONE` is the in-check sentinel; on a real hit the reused value
is identical to a recompute, so the search only moves from entry density.

```
Elo   | 18.54 +- 8.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.47, 2.91) [0.00, 5.00]
Games | N: 2926 W: 930 L: 774 D: 1222
Penta | [63, 307, 608, 381, 104]
```
https://asylum.red/test/5188/

```
Elo   | 19.14 +- 8.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.47, 2.91) [0.00, 5.00]
Games | N: 2526 W: 754 L: 615 D: 1157
Penta | [33, 268, 554, 343, 65]
```
https://asylum.red/test/5189/

Bench: 6090944