### PR TITLE
Taper the bonus bucket once in the combiner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.21"
+version = "0.5.23"
 dependencies = [
  "ctrlc",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.21"
+version = "0.5.23"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]

--- a/src/engine/combiner.rs
+++ b/src/engine/combiner.rs
@@ -27,22 +27,34 @@ use crate::{
 
 /// Per-bucket score accumulators filled by the term layer before combination.
 ///
-/// Fields are either **pre-tapered** (`mg_eg`, `mobility`, `bonus`) — the mg/eg blend
-/// happened inside the term — or **raw** (`safety_us`, `safety_them`, `xray`), tapered
-/// together by the combiner as a single `(us - them + xray) * phase / TOTAL_PHASE` block.
+/// Fields are either **pre-tapered** (`mg_eg`, `mobility`) — the mg/eg blend happened
+/// inside the SIMD lanes to keep them vectorized — or **raw** (`bonus_mg`/`bonus_eg`,
+/// `safety_us`, `safety_them`, `xray`), which the combiner tapers. Tapering raw keeps
+/// the divide-and-truncate at one site, so per-term rounding never accumulates.
 pub struct Accumulators<T: EvalMath> {
     /// Material + PSQT, read from the SIMD accumulator.
     pub mg_eg: T,
     /// Mobility differential, blended inside the SIMD lanes to preserve vectorization.
     pub mobility: T,
-    /// Simple linear bonuses; each term adds its own `mg * phase + eg * eg_phase` share.
-    pub bonus: T,
+    /// Raw bonus coefficients; each term adds its pure `mg · feature` and
+    /// `eg · feature`, and the combiner tapers the summed pair once.
+    pub bonus_mg: T,
+    pub bonus_eg: T,
     /// Raw king-safety score for the side to move.
     pub safety_us: T,
     /// Raw king-safety score for the opponent.
     pub safety_them: T,
     /// Raw x-ray king-ring differential; separate bucket so it can be rerouted independently.
     pub xray: T,
+}
+
+/// The tapered mg/eg blend: weight by phase, divide back to centipawns, truncate.
+/// The one rounding site in the combiner — `eg = zero` degenerates to the
+/// mg-only taper the king-safety block wants.
+#[inline(always)]
+pub fn taper<T: EvalMath<Scalar = T>>(mg: T, eg: T, phase: T) -> T {
+    let total = T::from_i32(TOTAL_PHASE);
+    ((mg * phase + eg * (total - phase)) / total).trunc()
 }
 
 /// Strategy for collapsing [`Accumulators`] into a final evaluation scalar.
@@ -64,8 +76,10 @@ impl Combiner for LinearCombiner {
     #[inline(always)]
     fn forward<T: EvalMath<Scalar = T>>(buckets: &Accumulators<T>, phase: T) -> T {
         let safety_diff = buckets.safety_us - buckets.safety_them + buckets.xray;
-        let safety_tapered = (safety_diff * phase / T::from_i32(TOTAL_PHASE)).trunc();
-        buckets.mg_eg + buckets.mobility + buckets.bonus + safety_tapered
+        let bonus = taper(buckets.bonus_mg, buckets.bonus_eg, phase);
+        let safety = taper(safety_diff, T::zero(), phase);
+
+        buckets.mg_eg + buckets.mobility + bonus + safety
     }
 
     #[inline]
@@ -74,6 +88,7 @@ impl Combiner for LinearCombiner {
         let t_eg = 1.0 - t_mg;
         let taper = TaperPair { d_mg: d_loss * t_mg, d_eg: d_loss * t_eg };
         let safety_block = d_loss * t_mg;
+
         BucketUpstreams { mg_eg: taper, mobility: taper, bonus: taper, king_safety: safety_block, xray: safety_block }
     }
 }

--- a/src/engine/eval.rs
+++ b/src/engine/eval.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     engine::{
         autograd::EvalMath,
-        combiner::{Accumulators, Combiner, LinearCombiner},
+        combiner::{Accumulators, Combiner, LinearCombiner, taper},
         eval_params::{
             self, ATTACKER_WEIGHTS, BACKWARD_PAWN_WEIGHTS, BISHOP_PAIR_WEIGHTS, DEFENDED_PAWN_EG, DEFENDED_PAWN_MG,
             DOUBLED_PAWN_WEIGHTS, EG_MOBILITY_CLOSED, EG_MOBILITY_OPEN, ENEMY_KING_DIST_EG, ENEMY_KING_DIST_MG,
@@ -172,7 +172,7 @@ pub fn detailed_eval(board: &Position, acc: &Vi16x8) -> DetailedEval {
     let buckets = fill_accumulators::<i32>(acc, phase, &features, &params);
     let psqt = buckets.mg_eg;
     let mobility = buckets.mobility;
-    let bonus = buckets.bonus;
+    let bonus = taper(buckets.bonus_mg, buckets.bonus_eg, phase);
     let total = LinearCombiner::forward(&buckets, phase);
     let safety = total - psqt - mobility - bonus;
 
@@ -576,7 +576,8 @@ fn fill_accumulators<T: EvalMath<Scalar = T>>(
     let mut buckets = Accumulators::<T> {
         mg_eg: T::tapered(acc, phase),
         mobility: T::zero(),
-        bonus: T::zero(),
+        bonus_mg: T::zero(),
+        bonus_eg: T::zero(),
         safety_us: T::zero(),
         safety_them: T::zero(),
         xray: T::zero(),
@@ -615,11 +616,10 @@ macro_rules! tapered_bonus_term {
             type Upstream = term::TaperPair;
 
             #[inline(always)]
-            fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, phase: T, acc: &mut Accumulators<T>) {
-                let total = T::from_i32(TOTAL_PHASE);
+            fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, _phase: T, acc: &mut Accumulators<T>) {
                 let feature = T::from_i32(features.$feat);
-                let tapered = params.$mg * phase + params.$eg * (total - phase);
-                acc.bonus += (tapered * feature / total).trunc();
+                acc.bonus_mg += params.$mg * feature;
+                acc.bonus_eg += params.$eg * feature;
             }
 
             #[inline]
@@ -637,14 +637,11 @@ macro_rules! tapered_bonus_term {
             type Upstream = term::TaperPair;
 
             #[inline(always)]
-            fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, phase: T, acc: &mut Accumulators<T>) {
-                let total = T::from_i32(TOTAL_PHASE);
-                let eg_phase = total - phase;
-
+            fn apply<T: EvalMath<Scalar = T>>(features: &SharedFeatures, params: &EvalParams<T>, _phase: T, acc: &mut Accumulators<T>) {
                 for i in 0..$n {
                     let feature = T::from_i32(features.$feat[i]);
-                    let tapered = params.$mg[i] * phase + params.$eg[i] * eg_phase;
-                    acc.bonus += (tapered * feature / total).trunc();
+                    acc.bonus_mg += params.$mg[i] * feature;
+                    acc.bonus_eg += params.$eg[i] * feature;
                 }
             }
 


### PR DESCRIPTION
Every bonus term did its own `(mg·phase + eg·eg_phase)·feature / 24`
and truncated — ~30 strength-reduced divides per eval, the hottest lines in
`fill_accumulators`. Terms now emit raw mg·feature and `eg·feature`
coefficients into an (`mg`, `eg`) bonus pair, and the combiner tapers the sum once.

This is honoring the contracts already written down:
`term.rs` says a term's output is a pure feature coefficient,
`combiner.rs` says the taper shape lives in the combiner. The bonus terms violated
both by baking the taper in — and the combiner's backward already handed
bonus a single linear `TaperPair`, so the forward was differentiating a function it
didn't compute. Now forward matches backward; the taper is one named
primitive shared by the bonus and safety blocks.

More precise as a side effect, honestly the nicer half;
one truncation instead of ~13 accumulating toward zero,
so the bonus lands within <1cp of the valued blend instead of drifting low.

Non-Regression `[-4.50, 0.50]`: LLR 4.14
```
Elo   | 1.96 +- 3.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.30 (-2.47, 2.91) [0.00, 5.00]
Games | N: 20596 W: 5908 L: 5792 D: 8896
Penta | [582, 2429, 4176, 2513, 598]
```
https://asylum.red/test/5208/

This test was unfortunately and unironically mugged by one worker.
`1.15 ± 0.03 times faster than ./soul-base bench`

Bench: 5797963