### PR TITLE
Add MovePicker instrumentation (mvpstats)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.23"
+version = "0.5.24"
 dependencies = [
  "ctrlc",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.23"
+version = "0.5.24"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]
@@ -45,6 +45,7 @@ zerocopy = { version = "0.8.48", default-features = false, features = ["derive",
 [features]
 searchtune = []
 corrstats = []
+mvpstats = []
 
 [profile.release]
 lto = "fat"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ DEBUG_EXE := debug$(EXE_EXT)
 
 .PHONY: all help debug release native bench v3 v4 pgo openbench clean \
         evaltune searchtune test oracle seeformat format clippy profile etprofile \
-        releases avx2 avx2-bmi2 avx512 corrstats
+        releases avx2 avx2-bmi2 avx512 corrstats movepicker
 
 all: openbench
 
@@ -102,6 +102,14 @@ corrstats: ## Native build with correction-history stats
 	@cp target/release/$(EXE_NAME) $(EXE)-corrstats
 	@echo "Done: ./$(EXE)-corrstats"
 	@./$(EXE)-corrstats bench $(DEPTH)
+
+movepicker: ## Native build with move-picker quiet stats
+	@echo "Building $(EXE_NAME)-movepicker..."
+	@RUSTFLAGS="-C target-cpu=native" \
+		cargo build --release --features mvpstats --quiet
+	@cp target/release/$(EXE_NAME) $(EXE)-movepicker
+	@echo "Done: ./$(EXE)-movepicker"
+	@./$(EXE)-movepicker bench $(DEPTH)
 
 v4: ## AVX512
 	@echo "Building x86-64-v4..."
@@ -186,7 +194,7 @@ clippy: ## Lint with Clippy (-D warnings, whole workspace + features)
 clean: ## Remove all build artifacts
 	@echo "Cleaning..."
 	@cargo clean
-	@rm -f $(EXE) $(DEBUG_EXE) ./search ./eval $(EXE)-corrstats
+	@rm -f $(EXE) $(DEBUG_EXE) ./search ./eval $(EXE)-corrstats $(EXE)-movepicker
 	@rm -f $(EXE_NAME)-v*-avx2* $(EXE_NAME)-v*-avx512*
 	@rm -rf target/pgo-profiles
 	@echo "Done"

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,6 +10,7 @@ pub mod history;
 pub mod mobility;
 pub mod movegen;
 pub mod movepicker;
+#[cfg(feature = "mvpstats")] pub mod mvpstats;
 pub mod search;
 pub mod search_params;
 pub mod see;

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -15,7 +15,7 @@
 //! popping the highest-scored moves from the back in 𝒪(1) time without
 //! index shifting.
 
-use std::mem::MaybeUninit;
+use std::{mem::MaybeUninit, slice};
 
 use crate::{
     core::{
@@ -80,6 +80,21 @@ pub struct MovePicker {
     cont4: ContContext,
     is_qsearch: bool,
     in_check: bool,
+    /// Quiets generated/sorted at this node, for `mvpstats`.
+    #[cfg(feature = "mvpstats")]
+    quiets_gen: u32,
+    /// Quiets yielded before the picker is dropped (cutoff or exhaustion).
+    #[cfg(feature = "mvpstats")]
+    quiets_used: u32,
+}
+
+#[cfg(feature = "mvpstats")]
+impl Drop for MovePicker {
+    fn drop(&mut self) {
+        if self.quiets_gen > 0 {
+            crate::engine::mvpstats::record_quiets(self.quiets_gen, self.quiets_used);
+        }
+    }
 }
 
 impl MovePicker {
@@ -107,6 +122,10 @@ impl MovePicker {
             cont4,
             is_qsearch: false,
             in_check: false,
+            #[cfg(feature = "mvpstats")]
+            quiets_gen: 0,
+            #[cfg(feature = "mvpstats")]
+            quiets_used: 0,
         }
     }
 
@@ -127,6 +146,10 @@ impl MovePicker {
             cont4: ContContext::default(),
             is_qsearch: true,
             in_check,
+            #[cfg(feature = "mvpstats")]
+            quiets_gen: 0,
+            #[cfg(feature = "mvpstats")]
+            quiets_used: 0,
         }
     }
 
@@ -137,6 +160,7 @@ impl MovePicker {
             match self.stage {
                 Stage::Hash => {
                     self.stage = Stage::GenCaptures;
+
                     if let Some(mv) = self.hash_move {
                         return Some(mv);
                     }
@@ -155,7 +179,7 @@ impl MovePicker {
                         unsafe {
                             let ptr = self.candidates.as_mut_ptr() as *mut u32;
                             // Sort natively ascending. Best elements float to the end.
-                            std::slice::from_raw_parts_mut(ptr, self.count).sort_unstable();
+                            slice::from_raw_parts_mut(ptr, self.count).sort_unstable();
                         }
                     }
                     self.stage = Stage::YieldCaptures;
@@ -198,12 +222,17 @@ impl MovePicker {
 
                 Stage::GenQuiets => {
                     self.gen_quiets(board, history);
+
+                    #[cfg(feature = "mvpstats")]
+                    {
+                        self.quiets_gen = self.count as u32;
+                    }
                     // SAFETY: self.count accurately tracks initialized items.
                     // ptr covers valid memory and is sorted in-place.
                     if self.count > 1 {
                         unsafe {
                             let ptr = self.candidates.as_mut_ptr() as *mut u32;
-                            std::slice::from_raw_parts_mut(ptr, self.count).sort_unstable();
+                            slice::from_raw_parts_mut(ptr, self.count).sort_unstable();
                         }
                     }
                     self.stage = Stage::YieldQuiets;
@@ -219,10 +248,13 @@ impl MovePicker {
                     let mv = unsafe { self.read_move(self.count) };
 
                     if Some(mv) != self.hash_move {
+                        #[cfg(feature = "mvpstats")]
+                        {
+                            self.quiets_used += 1;
+                        }
                         return Some(mv);
                     }
                 },
-
                 Stage::Done => return None,
             }
         }
@@ -306,6 +338,7 @@ impl MovePicker {
                 let v_val = *crate::debug_index!(self.mvvlva_v, victim as usize);
                 let chist = history.score_capture(stm, PT, to, victim);
                 let score = self.cap_score(v_val - a_pen, chist);
+
                 self.add_move_packed(Move::new(from, to, Move::CAPTURE), score as MoveScore);
             }
         }
@@ -317,6 +350,7 @@ impl MovePicker {
         let sort_score = (score as i32 + 32768).clamp(0, 65535) as u32;
         let packed = (sort_score << 16) | (mv.inner() as u32);
         crate::debug_index_mut!(self.candidates, self.count).write(packed);
+
         self.count += 1;
     }
 
@@ -328,6 +362,7 @@ impl MovePicker {
         // Victim is always pawn (the captured pawn sits on an adjacent square, not on `mv.to()`).
         let victim = if mv.is_en_passant() { PieceType::Pawn } else { board.piece_at(mv.to()) };
         let chist = history.score_capture(board.stm, attacker, mv.to(), victim);
+
         self.add_move_packed(mv, self.cap_score(mvv as i32, chist) as MoveScore);
     }
 
@@ -379,7 +414,6 @@ impl MovePicker {
             debug_assert!(usize::from(p) < 8);
             s += *crate::debug_index!(self.mvvlva_v, p as usize);
         }
-
         s as MoveScore
     }
 

--- a/src/engine/mvpstats.rs
+++ b/src/engine/mvpstats.rs
@@ -99,7 +99,7 @@ fn report_quiets() {
         human(generated),
         human(consumed)
     );
-    columns(&["consumed", "nodes", "share", "cumul"]);
+    columns(["consumed", "nodes", "share", "cumul"]);
     histogram(&QUIET_HIST, nodes, 0);
 }
 
@@ -115,7 +115,7 @@ fn report_cutoffs() {
 
     header("MovePicker cutoff ordering");
     println!("  fail-high nodes {}   first-move cutoff {rate}", human(nodes));
-    columns(&["move", "nodes", "share", "cumul"]);
+    columns(["move", "nodes", "share", "cumul"]);
     histogram(&CUTOFF_HIST, nodes, 1);
 
     println!("  {}by mechanism{}", header_color().0, header_color().1);
@@ -149,10 +149,9 @@ fn header(title: &str) {
     println!("\n{gold}{BOLD}{title}{reset}");
 }
 
-fn columns(labels: &[&str]) {
+fn columns(labels: [&str; 4]) {
     let (gold, reset) = header_color();
-    let row: Vec<String> = labels.iter().map(|l| format!("{l:>8}")).collect();
-    println!("  {gold}{BOLD}{}{reset}", row.join("  "));
+    println!("  {gold}{BOLD}{:>8}  {:>11}  {:>7}  {:>7}{reset}", labels[0], labels[1], labels[2], labels[3]);
 }
 
 fn header_color() -> (String, &'static str) {

--- a/src/engine/mvpstats.rs
+++ b/src/engine/mvpstats.rs
@@ -1,0 +1,177 @@
+//! Move-picker instrumentation — does the ordering earn its keep?
+//!
+//! Two questions, two metric blocks. Adding a third is a static block, a
+//! `record_*` hook, and one line in [`report`].
+//!
+//! - **Quiet sort utilization.** A node at the quiet stage sorts every quiet,
+//!   then yields best-first until a cutoff. Generated-vs-consumed and the
+//!   consumption histogram say whether that full sort is load-bearing or thrown
+//!   away — back-loaded means justified, front-loaded (mass at 0–1) means a
+//!   lazy max-scan would win. The catch is selection bias: cut-nodes usually
+//!   cut before quiets are even generated, so the nodes that pay the sort are
+//!   the ones that consume it.
+//!
+//! - **Beta-cutoff ordering.** At a fail-high node, which move number caused the
+//!   cutoff and which heuristic surfaced it. The first-move cutoff rate is the
+//!   single number that says the staging is good — the whole point of ordering
+//!   is to make the cutoff happen on move one.
+//!
+//! Compiled only under the `mvpstats` feature — zero cost in release builds.
+
+use std::{
+    io,
+    io::IsTerminal,
+    sync::atomic::{AtomicU64, Ordering::Relaxed},
+};
+
+use crate::color;
+
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const HEADER: color::Rgb = (218, 165, 32);
+
+/// Consumption buckets: index = quiets used, the last bucket is "11 or more".
+const QUIET_BUCKETS: usize = 12;
+
+static QUIET_HIST: [AtomicU64; QUIET_BUCKETS] = [const { AtomicU64::new(0) }; QUIET_BUCKETS];
+static QUIET_GENERATED: AtomicU64 = AtomicU64::new(0);
+static QUIET_CONSUMED: AtomicU64 = AtomicU64::new(0);
+static QUIET_NODES: AtomicU64 = AtomicU64::new(0);
+
+const KINDS: usize = 4;
+const KIND_NAMES: [&str; KINDS] = ["hash", "capture", "killer", "quiet"];
+
+/// Cutoff move-index buckets: 1-based move number, the last bucket is "8 or more".
+const CUTOFF_BUCKETS: usize = 8;
+
+static CUTOFF_HIST: [AtomicU64; CUTOFF_BUCKETS] = [const { AtomicU64::new(0) }; CUTOFF_BUCKETS];
+static CUTOFF_KIND: [AtomicU64; KINDS] = [const { AtomicU64::new(0) }; KINDS];
+static CUTOFF_NODES: AtomicU64 = AtomicU64::new(0);
+
+/// Record one quiet-stage node; `generated` quiets sorted, `consumed` yielded
+/// before the picker was dropped (a cutoff or natural exhaustion).
+#[inline]
+pub fn record_quiets(generated: u32, consumed: u32) {
+    QUIET_HIST[(consumed as usize).min(QUIET_BUCKETS - 1)].fetch_add(1, Relaxed);
+    QUIET_GENERATED.fetch_add(u64::from(generated), Relaxed);
+    QUIET_CONSUMED.fetch_add(u64::from(consumed), Relaxed);
+    QUIET_NODES.fetch_add(1, Relaxed);
+}
+
+/// Which mechanism surfaced the move that caused a beta cutoff.
+#[derive(Clone, Copy)]
+pub enum CutoffKind {
+    Hash = 0,
+    Capture = 1,
+    Killer = 2,
+    Quiet = 3,
+}
+
+/// The cutoff fired on the `index`-th searched move (1-based), surfaced by `kind`.
+#[inline]
+pub fn record_cutoff(index: u32, kind: CutoffKind) {
+    CUTOFF_HIST[(index.max(1) as usize - 1).min(CUTOFF_BUCKETS - 1)].fetch_add(1, Relaxed);
+    CUTOFF_KIND[kind as usize].fetch_add(1, Relaxed);
+    CUTOFF_NODES.fetch_add(1, Relaxed);
+}
+
+pub fn report() {
+    report_quiets();
+    report_cutoffs();
+}
+
+fn report_quiets() {
+    let nodes = QUIET_NODES.load(Relaxed);
+
+    if nodes == 0 {
+        return;
+    }
+
+    let generated = QUIET_GENERATED.load(Relaxed);
+    let consumed = QUIET_CONSUMED.load(Relaxed);
+    let used_pct = 100.0 * consumed as f64 / generated as f64;
+    let used = colored(format!("{used_pct:.1}%"), (used_pct / 50.0 - 1.0).clamp(-1.0, 1.0));
+
+    header("MovePicker quiet stats");
+    println!(
+        "  sorting nodes {}   generated {}   consumed {}   ({used} used)",
+        human(nodes),
+        human(generated),
+        human(consumed)
+    );
+    columns(&["consumed", "nodes", "share", "cumul"]);
+    histogram(&QUIET_HIST, nodes, 0);
+}
+
+fn report_cutoffs() {
+    let nodes = CUTOFF_NODES.load(Relaxed);
+
+    if nodes == 0 {
+        return;
+    }
+
+    let first = 100.0 * CUTOFF_HIST[0].load(Relaxed) as f64 / nodes as f64;
+    let rate = colored(format!("{first:.1}%"), (first / 90.0 - 1.0).clamp(-1.0, 1.0));
+
+    header("MovePicker cutoff ordering");
+    println!("  fail-high nodes {}   first-move cutoff {rate}", human(nodes));
+    columns(&["move", "nodes", "share", "cumul"]);
+    histogram(&CUTOFF_HIST, nodes, 1);
+
+    println!("  {}by mechanism{}", header_color().0, header_color().1);
+    for (i, name) in KIND_NAMES.iter().enumerate() {
+        let c = CUTOFF_KIND[i].load(Relaxed);
+        println!("  {name:>8}  {:>11}  {:>6.1}%", human(c), 100.0 * c as f64 / nodes as f64);
+    }
+}
+
+fn histogram(buckets: &[AtomicU64], nodes: u64, base: usize) {
+    let mut cumulative = 0u64;
+
+    for (i, b) in buckets.iter().enumerate() {
+        let c = b.load(Relaxed);
+        cumulative += c;
+
+        let n = base + i;
+        let label = if i == buckets.len() - 1 { format!("{n}+") } else { n.to_string() };
+
+        println!(
+            "  {label:>8}  {:>11}  {:>6.1}%  {:>6.1}%",
+            human(c),
+            100.0 * c as f64 / nodes as f64,
+            100.0 * cumulative as f64 / nodes as f64
+        );
+    }
+}
+
+fn header(title: &str) {
+    let (gold, reset) = header_color();
+    println!("\n{gold}{BOLD}{title}{reset}");
+}
+
+fn columns(labels: &[&str]) {
+    let (gold, reset) = header_color();
+    let row: Vec<String> = labels.iter().map(|l| format!("{l:>8}")).collect();
+    println!("  {gold}{BOLD}{}{reset}", row.join("  "));
+}
+
+fn header_color() -> (String, &'static str) {
+    if io::stdout().is_terminal() { (color::ansi_fg(HEADER), RESET) } else { (String::new(), "") }
+}
+
+fn colored(text: String, advantage: f64) -> String {
+    if io::stdout().is_terminal() {
+        format!("{}{text}{RESET}", color::ansi_fg(color::advantage(advantage)))
+    } else {
+        text
+    }
+}
+
+/// Hooman counts.
+fn human(n: u64) -> String {
+    match n {
+        1_000_000.. => format!("{:.2}M", n as f64 / 1e6),
+        1_000.. => format!("{:.1}K", n as f64 / 1e3),
+        _ => n.to_string(),
+    }
+}

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1239,6 +1239,21 @@ impl Worker<'_> {
                 self.search_move::<N>(searcher, mv, depth, &mut res, beta, ply, None, Some(mv) == pv_move, reduction)?;
 
                 if likely(res.alpha >= beta) {
+                    #[cfg(feature = "mvpstats")]
+                    {
+                        use crate::engine::mvpstats::{CutoffKind, record_cutoff};
+                        let kind = if Some(mv) == hash_move {
+                            CutoffKind::Hash
+                        } else if mv.is_capture() {
+                            CutoffKind::Capture
+                        } else if mv == self.stack[ply].killers[0] || mv == self.stack[ply].killers[1] {
+                            CutoffKind::Killer
+                        } else {
+                            CutoffKind::Quiet
+                        };
+                        record_cutoff(res.move_count as u32, kind);
+                    }
+
                     // ── History Gravity Heuristic (~95 Elo) ──
                     // When a move causes a beta-cutoff, its presumably a strong response.
                     // We reward it so it surfaces earlier in future sibling nodes,

--- a/src/tools/bench.rs
+++ b/src/tools/bench.rs
@@ -94,6 +94,9 @@ pub fn run(depth: i32) {
     let nps = (total_nodes as f64 / elapsed) as u64;
     println!("Bench: {total_nodes} nodes {nps} nps · {elapsed:.1}s");
 
+    #[cfg(feature = "mvpstats")]
+    crate::engine::mvpstats::report();
+
     #[cfg(feature = "corrstats")]
     crate::engine::corrstats::report();
 }


### PR DESCRIPTION
```
MovePicker quiet stats
  sorting nodes 407.6K   generated 12.12M   consumed 9.72M   (80.2% used)
  consumed        nodes    share    cumul
         0            0     0.0%     0.0%
         1        49.2K    12.1%    12.1%
         2        14.1K     3.5%    15.5%
         3         6.8K     1.7%    17.2%
         4         3.9K     0.9%    18.1%
         5         2.6K     0.6%    18.8%
         6         2.0K     0.5%    19.3%
         7         2.0K     0.5%    19.7%
         8         2.1K     0.5%    20.3%
         9         1.9K     0.5%    20.7%
        10         2.2K     0.5%    21.3%
       11+       320.9K    78.7%   100.0%

MovePicker cutoff ordering
  fail-high nodes 543.6K   first-move cutoff 84.8%
      move        nodes    share    cumul
         1       460.8K    84.8%    84.8%
         2        54.5K    10.0%    94.8%
         3        14.8K     2.7%    97.5%
         4         4.9K     0.9%    98.4%
         5         2.8K     0.5%    98.9%
         6         1.8K     0.3%    99.3%
         7          837     0.2%    99.4%
        8+         3.2K     0.6%   100.0%
  by mechanism
      hash       217.2K    40.0%
   capture       249.3K    45.9%
    killer        47.3K     8.7%
     quiet        29.7K     5.5%
```

No functional change.

Bench: 5797963