### PR TITLE
Build eval params once per search, not per leaf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.24"
+version = "0.5.25"
 dependencies = [
  "ctrlc",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.24"
+version = "0.5.25"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -147,6 +147,8 @@ pub struct Worker<'h> {
     pub history: &'h mut History,
     /// Per-search pawn-structure cache, keyed on the incremental `pawn_key`.
     pub pawn_cache: PawnCache,
+    /// Search-constant eval weights, built once instead of per leaf.
+    pub eval_params: EvalParams<i32>,
     /// Set while a null-move verification search is on the stack.
     /// Suppresses nested NMP, which would otherwise recurse forever on
     /// the same position at ever-shrinking depth.
@@ -447,6 +449,7 @@ impl<'cfg> Searcher<'cfg> {
                 .unwrap_or_else(|_| unreachable!()),
             history,
             pawn_cache: PawnCache::new(),
+            eval_params: EvalParams::<i32>::from_const(),
             is_nmp_verif: false,
         };
 
@@ -782,11 +785,10 @@ impl Worker<'_> {
     #[inline]
     fn evaluate(&mut self) -> i32 {
         let phase = extract_phase(&self.accumulator);
-        let params = EvalParams::<i32>::from_const();
         let pawn = self.pawn_cache.probe(&self.pos);
         let features = SharedFeatures::with_pawn(&self.pos, &pawn);
 
-        evaluate_generic::<i32>(&self.pos, &self.accumulator, phase, &params, Some(&features))
+        evaluate_generic::<i32>(&self.pos, &self.accumulator, phase, &self.eval_params, Some(&features))
     }
 
     /// Negamax with alpha-beta pruning. Since chess is zero-sum, we maximize the


### PR DESCRIPTION
```
Elo   | 3.54 +- 2.86 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.94 (-2.47, 2.91) [0.00, 5.00]
Games | N: 25684 W: 7855 L: 7593 D: 10236
Penta | [713, 2789, 5623, 2957, 760]
```
https://asylum.red/test/5212/

Bench: 5797963