### PR TITLE
Lazy Symmetric MultiProcessing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "atomic-wait"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55b94919229f2c42292fd71ffa4b75e83193bffdd77b1e858cd55fd2d0b0ea8"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,7 +129,7 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -418,6 +428,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 name = "soul"
 version = "0.5.25"
 dependencies = [
+ "atomic-wait",
  "ctrlc",
  "fastrand",
  "parking_lot",
@@ -547,12 +558,69 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.25"
+version = "0.5.26"
 dependencies = [
  "atomic-wait",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ zstd = { version = "0.13.3", default-features = false }
 fastrand = "2.4.1"
 ctrlc = "3.5.2"
 zerocopy = { version = "0.8.48", default-features = false, features = ["derive", "simd"] }
+atomic-wait = "1.1"
 
 [features]
 searchtune = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.25"
+version = "0.5.26"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -732,7 +732,7 @@ impl<'cfg> Searcher<'cfg> {
     fn check_signals(&mut self) -> bool {
         if self.cfg.stop.load(Ordering::Acquire)
             || self.tm.is_hard_limit_reached()
-            || (self.cfg.limits.nodes > 0 && self.cfg.total_nodes.load(Ordering::Relaxed) >= self.cfg.limits.nodes)
+            || (self.cfg.limits.nodes > 0 && self.node_count() >= self.cfg.limits.nodes)
         {
             self.cfg.stop.store(true, Ordering::Release);
             return true;
@@ -753,13 +753,21 @@ impl<'cfg> Searcher<'cfg> {
         self.cfg.stop.load(Ordering::Acquire)
     }
 
+    /// Node count for display and limits.
+    /// Under Lazy SMP uses the shared aggregate; single-threaded uses the
+    /// local counter to avoid atomic overhead on every node.
+    #[inline(always)]
+    fn node_count(&self) -> u64 {
+        if self.cfg.threads == 1 { self.nodes } else { self.cfg.total_nodes.load(Ordering::Relaxed) }
+    }
+
     /// Assemble the display snapshot shared by depth-complete and realtime reporting.
     /// `pv` and `history` are borrowed by the returned struct,
     /// so the caller owns them for the duration of the print.
     #[cold]
     fn search_info_data<'a>(&'a self, depth: i32, score: i32, pv: &'a Line, history: &'a [PvSnapshot]) -> tui::SearchInfoData<'a> {
         let ms = self.tm.elapsed().as_millis().max(1);
-        let total = self.cfg.total_nodes.load(Ordering::Relaxed);
+        let total = self.node_count();
         let nps = (u128::from(total) * 1000) / ms;
 
         tui::SearchInfoData {
@@ -860,7 +868,9 @@ impl Worker<'_> {
         }
 
         searcher.nodes += 1;
-        searcher.cfg.total_nodes.fetch_add(1, Ordering::Relaxed);
+        if searcher.cfg.threads > 1 {
+            searcher.cfg.total_nodes.fetch_add(1, Ordering::Relaxed);
+        }
 
         if self.is_draw(ply, &searcher.zobrist_trail) {
             return Ok(draw_score(searcher.nodes));
@@ -1612,7 +1622,9 @@ impl Worker<'_> {
         }
 
         searcher.nodes += 1;
-        searcher.cfg.total_nodes.fetch_add(1, Ordering::Relaxed);
+        if searcher.cfg.threads > 1 {
+            searcher.cfg.total_nodes.fetch_add(1, Ordering::Relaxed);
+        }
 
         if self.is_draw(ply, &searcher.zobrist_trail) {
             return Ok(draw_score(searcher.nodes));

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -205,7 +205,7 @@ pub struct SearchConfig {
     /// (every ~2048 nodes), with a Relaxed store — no lock prefix,
     /// no cross-core contention. The display and node-limit paths sum
     /// all slots. Slightly stale, invisible at display intervals.
-    pub node_slots: Arc<Box<[AtomicU64]>>,
+    pub node_slots: Arc<[AtomicU64]>,
     pub mvvlva_v: [i32; 8], // victim values, indexed by PieceType
     pub mvvlva_a: [i32; 8], // attacker penalties, indexed by PieceType
     /// `ln(i) · LMR_SCALE` lookup, indexed by depth or move count.
@@ -299,11 +299,16 @@ impl SearchConfig {
             search_params,
             threads: 1,
             thread_id: 0,
-            node_slots: Arc::new((0..1).map(|_| AtomicU64::new(0)).collect()),
+            node_slots: Self::node_slots(1),
             mvvlva_v,
             mvvlva_a,
             lmr_table,
         }
+    }
+
+    /// `threads` zeroed node counters, one slot per thread.
+    pub fn node_slots(threads: usize) -> Arc<[AtomicU64]> {
+        (0..threads).map(|_| AtomicU64::new(0)).collect()
     }
 
     /// Composed LMR reduction in `LMR_SCALE` units.

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -2,8 +2,12 @@
 //!
 //! # Architecture
 //!
-//! The search is single-threaded, but separates state into two entities
-//! to provide a clean seam for future parallelism:
+//! Lazy SMP: threads search the same root in parallel, sharing only the TT and
+//! a stop flag. No explicit work distribution — each thread runs its own
+//! iterative-deepening loop, and the TT is the coordination surface. Diversity
+//! is emergent from threads cross-probing each other's entries at different depths.
+//!
+//! State splits into two entities per thread:
 //! - `Searcher`: Owns global engine state (time management, history table, root moves).
 //! - `Worker`: Owns thread-local mutability (the board, SIMD accumulator, ply stack).
 //!
@@ -18,7 +22,7 @@ use std::{
     io::Write,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Instant,
 };
@@ -115,12 +119,14 @@ impl NodeType for NonPvNode {
 // ──────── Searcher & Worker ────────
 //
 // Searcher owns the global search state — root moves, node counter,
-// time management, zobrist trail. One per go command.
+// time management, zobrist trail. One per thread.
 //
 // Worker owns the mutable board that changes as we descend the tree:
 // position, accumulator, per-ply stack.
 //
-// This separation is the natural seam for future parallelism:
+// Each thread gets its own Searcher+Worker pair. Threads share only
+// the TT, the stop flag, and the node counter — everything else is
+// thread-private.
 // one Searcher, N Workers, each exploring a different subtree.
 
 pub struct Searcher<'cfg> {
@@ -192,6 +198,13 @@ pub struct SearchConfig {
     pub display: SearchDisplay,
     pub search_params: SearchParams,
     pub overhead: u64,
+    pub threads: usize,
+    pub thread_id: usize,
+    /// Aggregate node count across all threads, for correct display in
+    /// multi-threaded searches. Each thread `fetch_add`s its increment;
+    /// the `Relaxed` ordering is safe because the counter is only used
+    /// for `info` output, not synchronization.
+    pub total_nodes: Arc<AtomicU64>,
     pub mvvlva_v: [i32; 8], // victim values, indexed by PieceType
     pub mvvlva_a: [i32; 8], // attacker penalties, indexed by PieceType
     /// `ln(i) · LMR_SCALE` lookup, indexed by depth or move count.
@@ -276,7 +289,20 @@ impl SearchConfig {
         let (mvvlva_v, mvvlva_a) = Self::build_mvvlva(&search_params);
         let lmr_table = Self::build_lmr_table();
 
-        Self { limits, start_time, stop, overhead, display, search_params, mvvlva_v, mvvlva_a, lmr_table }
+        Self {
+            limits,
+            start_time,
+            stop,
+            overhead,
+            display,
+            search_params,
+            threads: 1,
+            thread_id: 0,
+            total_nodes: Arc::new(AtomicU64::new(0)),
+            mvvlva_v,
+            mvvlva_a,
+            lmr_table,
+        }
     }
 
     /// Composed LMR reduction in `LMR_SCALE` units.
@@ -462,6 +488,19 @@ impl<'cfg> Searcher<'cfg> {
             self.tm.set_bm_stab_factor(tm_single_root() as f64 / 100.0);
         }
 
+        // ── Lazy SMP ──
+        // Every thread searches every depth, sharing nothing but the TT and
+        // the stop flag. Diversity is emergent: thread A writes an entry at
+        // the edge of what it can reach, thread B probes it mid-search and
+        // redirects its tree along a branch A already explored. The TT is
+        // the coordination surface.
+        //
+        // Helpers search the full depth ladder alongside main. The only
+        // asymmetry is time management — only the main thread checks the
+        // clock. Helpers stop only on the global flag or a depth limit;
+        // they don't need to finish "in time," they just need to feed the
+        // TT for as long as the main thread is still running.
+
         for depth in 1..=depth_limit {
             self.iter_depth = depth;
 
@@ -477,7 +516,11 @@ impl<'cfg> Searcher<'cfg> {
             // prev_depth_time * 2 is a rough branching-factor proxy;
             // each additional ply typically costs about twice the previous one,
             // so if we can't afford that estimate we stop before starting it.
-            if depth > 1
+            //
+            // Helpers skip time management — their job is to fill the TT, not
+            // decide when to stop. Main calls the shots.
+            if self.cfg.thread_id == 0
+                && depth > 1
                 && (elapsed >= self.tm.soft_limit().as_millis() as u64
                     || elapsed + (prev_depth_time * tm_iter_scale() as u64 / 100) > self.tm.hard_limit().as_millis() as u64
                     || (self.cfg.limits.softnodes > 0 && self.nodes >= self.cfg.limits.softnodes))
@@ -689,7 +732,7 @@ impl<'cfg> Searcher<'cfg> {
     fn check_signals(&mut self) -> bool {
         if self.cfg.stop.load(Ordering::Acquire)
             || self.tm.is_hard_limit_reached()
-            || (self.cfg.limits.nodes > 0 && self.nodes >= self.cfg.limits.nodes)
+            || (self.cfg.limits.nodes > 0 && self.cfg.total_nodes.load(Ordering::Relaxed) >= self.cfg.limits.nodes)
         {
             self.cfg.stop.store(true, Ordering::Release);
             return true;
@@ -716,14 +759,15 @@ impl<'cfg> Searcher<'cfg> {
     #[cold]
     fn search_info_data<'a>(&'a self, depth: i32, score: i32, pv: &'a Line, history: &'a [PvSnapshot]) -> tui::SearchInfoData<'a> {
         let ms = self.tm.elapsed().as_millis().max(1);
-        let nps = (u128::from(self.nodes) * 1000) / ms;
+        let total = self.cfg.total_nodes.load(Ordering::Relaxed);
+        let nps = (u128::from(total) * 1000) / ms;
 
         tui::SearchInfoData {
             depth,
             score,
             pv,
             sel_depth: self.sel_depth,
-            nodes: self.nodes,
+            nodes: total,
             nps: u64::try_from(nps).unwrap_or(u64::MAX),
             time_ms: ms,
             hashfull: self.tt.hashfull(),
@@ -816,6 +860,7 @@ impl Worker<'_> {
         }
 
         searcher.nodes += 1;
+        searcher.cfg.total_nodes.fetch_add(1, Ordering::Relaxed);
 
         if self.is_draw(ply, &searcher.zobrist_trail) {
             return Ok(draw_score(searcher.nodes));
@@ -1567,6 +1612,7 @@ impl Worker<'_> {
         }
 
         searcher.nodes += 1;
+        searcher.cfg.total_nodes.fetch_add(1, Ordering::Relaxed);
 
         if self.is_draw(ply, &searcher.zobrist_trail) {
             return Ok(draw_score(searcher.nodes));

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -200,11 +200,12 @@ pub struct SearchConfig {
     pub overhead: u64,
     pub threads: usize,
     pub thread_id: usize,
-    /// Aggregate node count across all threads, for correct display in
-    /// multi-threaded searches. Each thread `fetch_add`s its increment;
-    /// the `Relaxed` ordering is safe because the counter is only used
-    /// for `info` output, not synchronization.
-    pub total_nodes: Arc<AtomicU64>,
+    /// Per-thread node counters, one slot per thread.
+    /// Each thread writes only its own slot, inside `check_signals`
+    /// (every ~2048 nodes), with a Relaxed store — no lock prefix,
+    /// no cross-core contention. The display and node-limit paths sum
+    /// all slots. Slightly stale, invisible at display intervals.
+    pub node_slots: Arc<Box<[AtomicU64]>>,
     pub mvvlva_v: [i32; 8], // victim values, indexed by PieceType
     pub mvvlva_a: [i32; 8], // attacker penalties, indexed by PieceType
     /// `ln(i) · LMR_SCALE` lookup, indexed by depth or move count.
@@ -298,7 +299,7 @@ impl SearchConfig {
             search_params,
             threads: 1,
             thread_id: 0,
-            total_nodes: Arc::new(AtomicU64::new(0)),
+            node_slots: Arc::new((0..1).map(|_| AtomicU64::new(0)).collect()),
             mvvlva_v,
             mvvlva_a,
             lmr_table,
@@ -730,6 +731,11 @@ impl<'cfg> Searcher<'cfg> {
     /// Also drives realtime TUI updates — piggybacks on the same interval.
     #[inline]
     fn check_signals(&mut self) -> bool {
+        // Publish the local node count into this thread's slot so the
+        // display and node-limit paths see the aggregate. Relaxed store
+        // (plain mov on x86) — this slot has exactly one writer.
+        self.cfg.node_slots[self.cfg.thread_id].store(self.nodes, Ordering::Relaxed);
+
         if self.cfg.stop.load(Ordering::Acquire)
             || self.tm.is_hard_limit_reached()
             || (self.cfg.limits.nodes > 0 && self.node_count() >= self.cfg.limits.nodes)
@@ -753,12 +759,12 @@ impl<'cfg> Searcher<'cfg> {
         self.cfg.stop.load(Ordering::Acquire)
     }
 
-    /// Node count for display and limits.
-    /// Under Lazy SMP uses the shared aggregate; single-threaded uses the
-    /// local counter to avoid atomic overhead on every node.
+    /// Sums per-thread node counters. Each thread publishes its local count
+    /// into its own slot every ~2048 nodes, so the aggregate may trail by
+    /// up to `NODE_CHECK_INTERVAL · threads` — invisible at display intervals.
     #[inline(always)]
     fn node_count(&self) -> u64 {
-        if self.cfg.threads == 1 { self.nodes } else { self.cfg.total_nodes.load(Ordering::Relaxed) }
+        self.cfg.node_slots.iter().map(|s| s.load(Ordering::Relaxed)).sum()
     }
 
     /// Assemble the display snapshot shared by depth-complete and realtime reporting.
@@ -868,9 +874,6 @@ impl Worker<'_> {
         }
 
         searcher.nodes += 1;
-        if searcher.cfg.threads > 1 {
-            searcher.cfg.total_nodes.fetch_add(1, Ordering::Relaxed);
-        }
 
         if self.is_draw(ply, &searcher.zobrist_trail) {
             return Ok(draw_score(searcher.nodes));
@@ -1622,9 +1625,6 @@ impl Worker<'_> {
         }
 
         searcher.nodes += 1;
-        if searcher.cfg.threads > 1 {
-            searcher.cfg.total_nodes.fetch_add(1, Ordering::Relaxed);
-        }
 
         if self.is_draw(ply, &searcher.zobrist_trail) {
             return Ok(draw_score(searcher.nodes));

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -497,10 +497,11 @@ impl<'cfg> Searcher<'cfg> {
         // the coordination surface.
         //
         // Helpers search the full depth ladder alongside main. The only
-        // asymmetry is time management — only the main thread checks the
-        // clock. Helpers stop only on the global flag or a depth limit;
-        // they don't need to finish "in time," they just need to feed the
-        // TT for as long as the main thread is still running.
+        // asymmetry is soft time management — main alone decides when to stop
+        // starting iterations. Helpers still honor the global flag and the
+        // shared hard cap (same start_time, same limits) via check_signals;
+        // they just don't gate their own iterations on the clock, they feed
+        // the TT for as long as the main thread is still running.
 
         for depth in 1..=depth_limit {
             self.iter_depth = depth;

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -244,14 +244,17 @@ impl TranspositionTable {
         let idx = self.index(hash);
         let key16 = verification_key(hash);
         let cur = self.generation.load(Ordering::Relaxed);
+
         let mut replace_idx = idx;
         let mut worst_quality = i32::MAX;
+        let mut is_exact_match = false;
 
         for i in 0..CLUSTER_SIZE {
             let (key, bound, depth) = self.entries[idx + i].meta();
 
             if bound == BOUND_NONE || key == key16 {
                 replace_idx = idx + i;
+                is_exact_match = key == key16;
                 break;
             }
 
@@ -264,16 +267,14 @@ impl TranspositionTable {
             }
         }
 
-        let existing = self.entries[replace_idx].load();
-        let is_exact_match = existing.key == key16;
-
         let mut store_mv = mv.inner();
         let mut store_pv = pv as u8;
         // Preserve an existing highly-valued move if the new store provides
         // `Move::null()` and the hash matches. The pv flag rides with the
         // move it describes — losing it would erase the position's
-        // PV-history context.
+        // PV-history context. Only this path needs the full slot, so decode it here.
         if mv.is_null() && is_exact_match {
+            let existing = self.entries[replace_idx].load();
             store_mv = existing.mv;
             store_pv |= existing.pv;
         }
@@ -327,11 +328,10 @@ impl TranspositionTable {
         }
 
         if let Some(best) = best_idx {
-            let existing = self.entries[best].load();
             // Preserve any prior PV-history bit when overwriting the same
             // position — qs visits would otherwise erase the propagated flag
-            // stamped by a previous negamax store.
-            let store_pv = if is_key_match { (pv as u8) | existing.pv } else { pv as u8 };
+            // stamped by a previous negamax store. Only a key match reads it back.
+            let store_pv = if is_key_match { (pv as u8) | self.entries[best].load().pv } else { pv as u8 };
 
             self.entries[best].store(Decoded {
                 key: key16,

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -221,11 +221,12 @@ impl TranspositionTable {
 
         let idx = self.index(hash);
         let key16 = verification_key(hash);
+        let cluster = self.cluster(idx);
 
-        for i in 0..CLUSTER_SIZE {
-            let (key, bound, _) = self.entries[idx + i].meta();
+        for slot in cluster {
+            let (key, bound, _) = slot.meta();
             if key == key16 && bound != BOUND_NONE {
-                let entry = self.entries[idx + i].load();
+                let entry = slot.load();
                 // A concurrent store that published a new key after our meta()
                 // but before load() can leave us with a mismatched key — the
                 // Acquire on `a` in load() synchronizes with the store's Release,
@@ -251,26 +252,27 @@ impl TranspositionTable {
         let idx = self.index(hash);
         let key16 = verification_key(hash);
         let cur = self.generation.load(Ordering::Relaxed);
+        let cluster = self.cluster(idx);
 
-        let mut replace_idx = idx;
+        let mut replace = 0;
         let mut worst_quality = i32::MAX;
         let mut is_exact_match = false;
 
-        for i in 0..CLUSTER_SIZE {
-            let (key, bound, depth) = self.entries[idx + i].meta();
+        for (i, slot) in cluster.iter().enumerate() {
+            let (key, bound, depth) = slot.meta();
 
             if bound == BOUND_NONE || key == key16 {
-                replace_idx = idx + i;
+                replace = i;
                 is_exact_match = key == key16;
                 break;
             }
 
-            let gen_diff = cur.wrapping_sub(self.entries[idx + i].age()) as i32;
+            let gen_diff = cur.wrapping_sub(slot.age()) as i32;
             let quality = depth as i32 - gen_diff * AGE_FACTOR;
 
             if quality < worst_quality {
                 worst_quality = quality;
-                replace_idx = idx + i;
+                replace = i;
             }
         }
 
@@ -281,12 +283,12 @@ impl TranspositionTable {
         // move it describes — losing it would erase the position's
         // PV-history context. Only this path needs the full slot, so decode it here.
         if mv.is_null() && is_exact_match {
-            let existing = self.entries[replace_idx].load();
+            let existing = cluster[replace].load();
             store_mv = existing.mv;
             store_pv |= existing.pv;
         }
 
-        self.entries[replace_idx].store(Decoded {
+        cluster[replace].store(Decoded {
             key: key16,
             mv: store_mv,
             score: Self::score_to_tt(score, ply) as i16,
@@ -312,25 +314,26 @@ impl TranspositionTable {
         let idx = self.index(hash);
         let key16 = verification_key(hash);
         let cur = self.generation.load(Ordering::Relaxed);
+        let cluster = self.cluster(idx);
         let mut best_idx: Option<usize> = None;
         let mut best_quality = i32::MAX;
         let mut is_key_match = false;
 
-        for i in 0..CLUSTER_SIZE {
-            let (key, bound, depth) = self.entries[idx + i].meta();
+        for (i, slot) in cluster.iter().enumerate() {
+            let (key, bound, depth) = slot.meta();
 
             if key == key16 || bound == BOUND_NONE || depth == 0 {
-                best_idx = Some(idx + i);
+                best_idx = Some(i);
                 is_key_match = key == key16;
                 break;
             }
 
-            let gen_diff = cur.wrapping_sub(self.entries[idx + i].age()) as i32;
+            let gen_diff = cur.wrapping_sub(slot.age()) as i32;
             let quality = depth as i32 - gen_diff * AGE_FACTOR;
 
             if quality <= 0 && quality < best_quality {
                 best_quality = quality;
-                best_idx = Some(idx + i);
+                best_idx = Some(i);
             }
         }
 
@@ -338,9 +341,9 @@ impl TranspositionTable {
             // Preserve any prior PV-history bit when overwriting the same
             // position — qs visits would otherwise erase the propagated flag
             // stamped by a previous negamax store. Only a key match reads it back.
-            let store_pv = if is_key_match { (pv as u8) | self.entries[best].load().pv } else { pv as u8 };
+            let store_pv = if is_key_match { (pv as u8) | cluster[best].load().pv } else { pv as u8 };
 
-            self.entries[best].store(Decoded {
+            cluster[best].store(Decoded {
                 key: key16,
                 mv: mv.inner(),
                 score: Self::score_to_tt(score, ply) as i16,
@@ -351,6 +354,18 @@ impl TranspositionTable {
                 pv: store_pv,
             });
         }
+    }
+
+    /// The cluster of `CLUSTER_SIZE` slots based at `idx`. Typed as an array
+    /// reference, not a slice, so the scan loop drops the per-slot bounds check:
+    /// LLVM can't prove `idx + CLUSTER_SIZE <= len` on its own — the index drops
+    /// out of a mulhi64 — but it trusts the length of a fixed-size array.
+    #[inline(always)]
+    fn cluster(&self, idx: usize) -> &[TtEntry; CLUSTER_SIZE] {
+        // SAFETY: idx is index()'s cluster-aligned output — k * CLUSTER_SIZE for
+        // some k < len / CLUSTER_SIZE — so all CLUSTER_SIZE slots from idx sit
+        // inside the table. TtEntry aligns to 4, so add(idx) stays aligned.
+        unsafe { &*(self.entries.as_ptr().add(idx) as *const [TtEntry; CLUSTER_SIZE]) }
     }
 
     /// Maps 64-bit hash to the first index of a 3-entry cluster.

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -100,10 +100,12 @@ impl Default for TtEntry {
 
 impl TtEntry {
     /// Cheap scan read; word `a` decoded to (key, bound, depth) — every field
-    /// the cluster scan compares. The payload stays packed until a key matches.
+    /// the cluster scan compares. Relaxed: the replacement and `hashfull` scans
+    /// never read payload off this load, so no acquire ordering is owed — the
+    /// payload-preserve paths go through `load()`, which carries its own.
     #[inline(always)]
     fn meta(&self) -> (u16, u8, u8) {
-        let a = self.a.load(Ordering::Acquire);
+        let a = self.a.load(Ordering::Relaxed);
         (a as u16, (a >> 16) as u8, (a >> 24) as u8)
     }
 

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -2,8 +2,8 @@
 //!
 //! # Notes
 //!
-//! Lockless single-threaded design: probe and store take `&self` and
-//! mutate entries through raw pointers. A 16-bit verification key guards
+//! Lockless design: probe and store take `&self` and mutate entries
+//! through per-word atomics. A 16-bit verification key guards
 //! against hash collisions; the rare aliasing that slips through (~1 in 2¹⁶
 //! within a probed cluster) can only return a stale score, never a corrupting
 //! move, because every stored move is re-validated by `is_pseudo_legal` before
@@ -16,7 +16,7 @@
 
 use std::{
     arch, mem, ptr,
-    sync::atomic::{AtomicU8, Ordering},
+    sync::atomic::{AtomicU8, AtomicU32, Ordering},
 };
 
 use crate::core::{
@@ -55,23 +55,71 @@ const fn verification_key(hash: u64) -> u16 {
     hash as u16
 }
 
-#[derive(Clone, Copy, Default)]
+/// A cluster slot, packed into three `AtomicU32`s for Lazy SMP.
+/// An `AtomicU64` would force 8-byte alignment and pad the 12-byte slot to 16,
+/// thinning the table. `a` holds key+move, `b` holds score+eval, `c` holds metadata.
+/// A torn read across words mixes metadata onto a matching move;
+/// `is_pseudo_legal` catches stale moves downstream. Worst case is a stale cutoff, never corruption.
 #[repr(C)]
-pub struct TtEntry {
+struct TtEntry {
+    a: AtomicU32,
+    b: AtomicU32,
+    c: AtomicU32,
+}
+
+/// The decoded view of a [`TtEntry`], used by probe and store.
+#[derive(Clone, Copy, Default)]
+struct Decoded {
     /// 16-bit verification key (low bits of the Zobrist hash). Collisions that
     /// survive it are caught downstream by `is_pseudo_legal` on the stored move.
-    pub key: u16,
-    /// Best move found in this position
-    pub mv: u16,
-    pub score: i16,
+    key: u16,
+    mv: u16,
+    score: i16,
     /// Raw static eval at store time (`SCORE_NONE` when stored in check), so a
     /// hit can reuse it instead of recomputing the full evaluation.
-    pub eval: i16,
-    pub depth: u8,
-    pub bound: u8,
+    eval: i16,
+    depth: u8,
+    bound: u8,
     /// Generation at store time — prior-generation entries evict first.
-    pub age: u8,
-    pub pv: u8,
+    age: u8,
+    pv: u8,
+}
+
+impl Default for TtEntry {
+    fn default() -> Self {
+        Self { a: AtomicU32::new(0), b: AtomicU32::new(0), c: AtomicU32::new(0) }
+    }
+}
+
+impl TtEntry {
+    #[inline(always)]
+    fn load(&self) -> Decoded {
+        let a = self.a.load(Ordering::Relaxed);
+        let b = self.b.load(Ordering::Relaxed);
+        let c = self.c.load(Ordering::Relaxed);
+
+        Decoded {
+            key: a as u16,
+            mv: (a >> 16) as u16,
+            score: b as u16 as i16,
+            eval: (b >> 16) as u16 as i16,
+            depth: c as u8,
+            bound: (c >> 8) as u8,
+            age: (c >> 16) as u8,
+            pv: (c >> 24) as u8,
+        }
+    }
+
+    #[inline(always)]
+    fn store(&self, d: Decoded) {
+        let a = d.key as u32 | (d.mv as u32) << 16;
+        let b = d.score as u16 as u32 | (d.eval as u16 as u32) << 16;
+        let c = d.depth as u32 | (d.bound as u32) << 8 | (d.age as u32) << 16 | (d.pv as u32) << 24;
+
+        self.a.store(a, Ordering::Relaxed);
+        self.b.store(b, Ordering::Relaxed);
+        self.c.store(c, Ordering::Relaxed);
+    }
 }
 
 pub struct TranspositionTable {
@@ -80,12 +128,6 @@ pub struct TranspositionTable {
     /// Wraps at 255; `wrapping_sub` handles roll-over correctly.
     pub generation: AtomicU8,
 }
-
-// SAFETY: The TT bypasses Rust's safety borrow rules via raw pointers during probe and store,
-// which mutate fields through a &self shared reference. This is mathematically safe for single
-// threaded execution.
-unsafe impl Send for TranspositionTable {}
-unsafe impl Sync for TranspositionTable {}
 
 impl TranspositionTable {
     /// Allocates a new Transposition Table of the given size in MB.
@@ -99,13 +141,14 @@ impl TranspositionTable {
         let bytes = size_mb.max(1) * 1024 * 1024;
         let count = (bytes / mem::size_of::<TtEntry>()).max(CLUSTER_SIZE);
         let clusters = count / CLUSTER_SIZE;
-        self.entries = vec![TtEntry::default(); clusters * CLUSTER_SIZE].into_boxed_slice();
+        let n = clusters * CLUSTER_SIZE;
+        self.entries = (0..n).map(|_| TtEntry::default()).collect::<Vec<_>>().into_boxed_slice();
     }
 
     /// Returns TT occupancy in permille (0–1000).
     pub fn hashfull(&self) -> usize {
         let sample = self.entries.len().min(1000);
-        self.entries[..sample].iter().filter(|e| e.bound != BOUND_NONE).count() * 1000 / sample.max(1)
+        self.entries[..sample].iter().filter(|e| e.load().bound != BOUND_NONE).count() * 1000 / sample.max(1)
     }
 
     /// Zero every entry and reset the generation counter.
@@ -116,6 +159,8 @@ impl TranspositionTable {
 
         let ptr = self.entries.as_ptr() as *mut TtEntry;
 
+        // SAFETY: Only called by `ucinewgame` when the engine is idle.
+        // Bypassing atomics for a bulk memset is safe with no concurrent searchers.
         unsafe {
             ptr::write_bytes(ptr, 0, self.entries.len());
         }
@@ -153,7 +198,7 @@ impl TranspositionTable {
         let key16 = verification_key(hash);
 
         for i in 0..CLUSTER_SIZE {
-            let entry = unsafe { &*self.entries.as_ptr().add(idx + i) };
+            let entry = self.entries[idx + i].load();
             // The bound guard keeps an empty slot (key 0) from matching a real
             // position whose low 16 bits happen to be 0.
             if entry.key == key16 && entry.bound != BOUND_NONE {
@@ -179,7 +224,7 @@ impl TranspositionTable {
         let mut worst_quality = i32::MAX;
 
         for i in 0..CLUSTER_SIZE {
-            let entry = unsafe { &*self.entries.as_ptr().add(idx + i) };
+            let entry = self.entries[idx + i].load();
 
             if entry.bound == BOUND_NONE || entry.key == key16 {
                 replace_idx = idx + i;
@@ -195,11 +240,8 @@ impl TranspositionTable {
             }
         }
 
-        // SAFETY: Obtaining mutable reference to a slot via an immutable &self.
-        // Standard high-performance lockless TT approach.
-        let entry = unsafe { &mut *(self.entries.as_ptr().add(replace_idx) as *mut TtEntry) };
-        let is_exact_match = entry.key == key16;
-        entry.key = key16;
+        let existing = self.entries[replace_idx].load();
+        let is_exact_match = existing.key == key16;
 
         let mut store_mv = mv.inner();
         let mut store_pv = pv as u8;
@@ -208,17 +250,20 @@ impl TranspositionTable {
         // move it describes — losing it would erase the position's
         // PV-history context.
         if mv.is_null() && is_exact_match {
-            store_mv = entry.mv;
-            store_pv |= entry.pv;
+            store_mv = existing.mv;
+            store_pv |= existing.pv;
         }
 
-        entry.mv = store_mv;
-        entry.score = Self::score_to_tt(score, ply) as i16;
-        entry.eval = eval.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
-        entry.depth = depth as u8;
-        entry.bound = bound;
-        entry.age = cur;
-        entry.pv = store_pv;
+        self.entries[replace_idx].store(Decoded {
+            key: key16,
+            mv: store_mv,
+            score: Self::score_to_tt(score, ply) as i16,
+            eval: eval.clamp(i16::MIN as i32, i16::MAX as i32) as i16,
+            depth: depth as u8,
+            bound,
+            age: cur,
+            pv: store_pv,
+        });
     }
 
     /// Stores a qsearch result (depth = 0).
@@ -240,7 +285,7 @@ impl TranspositionTable {
         let mut is_key_match = false;
 
         for i in 0..CLUSTER_SIZE {
-            let entry = unsafe { &*self.entries.as_ptr().add(idx + i) };
+            let entry = self.entries[idx + i].load();
 
             if entry.key == key16 || entry.bound == BOUND_NONE || entry.depth == 0 {
                 best_idx = Some(idx + i);
@@ -258,22 +303,22 @@ impl TranspositionTable {
         }
 
         if let Some(best) = best_idx {
-            // SAFETY: Obtaining mutable reference to a slot via an immutable &self.
-            // Standard high-performance lockless TT approach.
-            let entry = unsafe { &mut *(self.entries.as_ptr().add(best) as *mut TtEntry) };
+            let existing = self.entries[best].load();
             // Preserve any prior PV-history bit when overwriting the same
             // position — qs visits would otherwise erase the propagated flag
             // stamped by a previous negamax store.
-            let store_pv = if is_key_match { (pv as u8) | entry.pv } else { pv as u8 };
+            let store_pv = if is_key_match { (pv as u8) | existing.pv } else { pv as u8 };
 
-            entry.key = key16;
-            entry.mv = mv.inner();
-            entry.score = Self::score_to_tt(score, ply) as i16;
-            entry.eval = eval.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
-            entry.depth = 0;
-            entry.bound = bound;
-            entry.age = cur;
-            entry.pv = store_pv;
+            self.entries[best].store(Decoded {
+                key: key16,
+                mv: mv.inner(),
+                score: Self::score_to_tt(score, ply) as i16,
+                eval: eval.clamp(i16::MIN as i32, i16::MAX as i32) as i16,
+                depth: 0,
+                bound,
+                age: cur,
+                pv: store_pv,
+            });
         }
     }
 

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -57,14 +57,21 @@ const fn verification_key(hash: u64) -> u16 {
 
 /// A cluster slot, packed into three `AtomicU32`s for Lazy SMP.
 /// An `AtomicU64` would force 8-byte alignment and pad the 12-byte slot to 16,
-/// thinning the table. `a` holds key+move, `b` holds score+eval, `c` holds metadata.
+/// thinning the table.
+///
+/// The words are ordered by how often the cluster scan reads them, not by type.
+/// Every scan touches only `a` (key+bound+depth); `b` adds age for replacement
+/// quality; `c` is pure payload, read only after a key match. So a probing miss
+/// costs one atomic load, not three — and atomic loads can't be elided, so the
+/// layout is what keeps the hottest loop cheap.
+///
 /// A torn read across words mixes metadata onto a matching move;
 /// `is_pseudo_legal` catches stale moves downstream. Worst case is a stale cutoff, never corruption.
 #[repr(C)]
 struct TtEntry {
-    a: AtomicU32,
-    b: AtomicU32,
-    c: AtomicU32,
+    a: AtomicU32, // key(16)   | bound(8) | depth(8)
+    b: AtomicU32, // mv(16)    | age(8)   | pv(8)
+    c: AtomicU32, // score(16) | eval(16)
 }
 
 /// The decoded view of a [`TtEntry`], used by probe and store.
@@ -92,6 +99,20 @@ impl Default for TtEntry {
 }
 
 impl TtEntry {
+    /// Cheap scan read; word `a` decoded to (key, bound, depth) — every field
+    /// the cluster scan compares. The payload stays packed until a key matches.
+    #[inline(always)]
+    fn meta(&self) -> (u16, u8, u8) {
+        let a = self.a.load(Ordering::Relaxed);
+        (a as u16, (a >> 16) as u8, (a >> 24) as u8)
+    }
+
+    /// Store generation, for replacement-quality aging.
+    #[inline(always)]
+    fn age(&self) -> u8 {
+        (self.b.load(Ordering::Relaxed) >> 16) as u8
+    }
+
     #[inline(always)]
     fn load(&self) -> Decoded {
         let a = self.a.load(Ordering::Relaxed);
@@ -100,21 +121,21 @@ impl TtEntry {
 
         Decoded {
             key: a as u16,
-            mv: (a >> 16) as u16,
-            score: b as u16 as i16,
-            eval: (b >> 16) as u16 as i16,
-            depth: c as u8,
-            bound: (c >> 8) as u8,
-            age: (c >> 16) as u8,
-            pv: (c >> 24) as u8,
+            bound: (a >> 16) as u8,
+            depth: (a >> 24) as u8,
+            mv: b as u16,
+            age: (b >> 16) as u8,
+            pv: (b >> 24) as u8,
+            score: c as u16 as i16,
+            eval: (c >> 16) as u16 as i16,
         }
     }
 
     #[inline(always)]
     fn store(&self, d: Decoded) {
-        let a = d.key as u32 | (d.mv as u32) << 16;
-        let b = d.score as u16 as u32 | (d.eval as u16 as u32) << 16;
-        let c = d.depth as u32 | (d.bound as u32) << 8 | (d.age as u32) << 16 | (d.pv as u32) << 24;
+        let a = d.key as u32 | (d.bound as u32) << 16 | (d.depth as u32) << 24;
+        let b = d.mv as u32 | (d.age as u32) << 16 | (d.pv as u32) << 24;
+        let c = d.score as u16 as u32 | (d.eval as u16 as u32) << 16;
 
         self.a.store(a, Ordering::Relaxed);
         self.b.store(b, Ordering::Relaxed);
@@ -142,13 +163,15 @@ impl TranspositionTable {
         let count = (bytes / mem::size_of::<TtEntry>()).max(CLUSTER_SIZE);
         let clusters = count / CLUSTER_SIZE;
         let n = clusters * CLUSTER_SIZE;
+
         self.entries = (0..n).map(|_| TtEntry::default()).collect::<Vec<_>>().into_boxed_slice();
     }
 
     /// Returns TT occupancy in permille (0–1000).
     pub fn hashfull(&self) -> usize {
         let sample = self.entries.len().min(1000);
-        self.entries[..sample].iter().filter(|e| e.load().bound != BOUND_NONE).count() * 1000 / sample.max(1)
+
+        self.entries[..sample].iter().filter(|e| e.meta().1 != BOUND_NONE).count() * 1000 / sample.max(1)
     }
 
     /// Zero every entry and reset the generation counter.
@@ -198,10 +221,11 @@ impl TranspositionTable {
         let key16 = verification_key(hash);
 
         for i in 0..CLUSTER_SIZE {
-            let entry = self.entries[idx + i].load();
+            let (key, bound, _) = self.entries[idx + i].meta();
             // The bound guard keeps an empty slot (key 0) from matching a real
             // position whose low 16 bits happen to be 0.
-            if entry.key == key16 && entry.bound != BOUND_NONE {
+            if key == key16 && bound != BOUND_NONE {
+                let entry = self.entries[idx + i].load();
                 let score = Self::score_from_tt(entry.score as i32, ply);
                 let mv = Move::from_u16(entry.mv);
 
@@ -224,15 +248,15 @@ impl TranspositionTable {
         let mut worst_quality = i32::MAX;
 
         for i in 0..CLUSTER_SIZE {
-            let entry = self.entries[idx + i].load();
+            let (key, bound, depth) = self.entries[idx + i].meta();
 
-            if entry.bound == BOUND_NONE || entry.key == key16 {
+            if bound == BOUND_NONE || key == key16 {
                 replace_idx = idx + i;
                 break;
             }
 
-            let gen_diff = cur.wrapping_sub(entry.age) as i32;
-            let quality = entry.depth as i32 - gen_diff * AGE_FACTOR;
+            let gen_diff = cur.wrapping_sub(self.entries[idx + i].age()) as i32;
+            let quality = depth as i32 - gen_diff * AGE_FACTOR;
 
             if quality < worst_quality {
                 worst_quality = quality;
@@ -285,16 +309,16 @@ impl TranspositionTable {
         let mut is_key_match = false;
 
         for i in 0..CLUSTER_SIZE {
-            let entry = self.entries[idx + i].load();
+            let (key, bound, depth) = self.entries[idx + i].meta();
 
-            if entry.key == key16 || entry.bound == BOUND_NONE || entry.depth == 0 {
+            if key == key16 || bound == BOUND_NONE || depth == 0 {
                 best_idx = Some(idx + i);
-                is_key_match = entry.key == key16;
+                is_key_match = key == key16;
                 break;
             }
 
-            let gen_diff = cur.wrapping_sub(entry.age) as i32;
-            let quality = entry.depth as i32 - gen_diff * AGE_FACTOR;
+            let gen_diff = cur.wrapping_sub(self.entries[idx + i].age()) as i32;
+            let quality = depth as i32 - gen_diff * AGE_FACTOR;
 
             if quality <= 0 && quality < best_quality {
                 best_quality = quality;

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -107,6 +107,38 @@ impl TtEntry {
         (a as u16, (a >> 16) as u8, (a >> 24) as u8)
     }
 
+    /// The probe's per-slot read: one Acquire load of `a` gates the scan, and
+    /// the payload words are pulled only on a key hit — a miss costs a single
+    /// atomic load. The Acquire on `a` synchronizes with the store's Release,
+    /// so a matching key implies the `b`/`c` writes that preceded it are visible.
+    ///
+    /// `a` is read once, so there's no meta-vs-load key disagreement to guard.
+    /// The only tear left is a concurrent same-key re-store landing fresh `b`/`c`
+    /// over a stale `a` — a stale cutoff at worst, caught by `is_pseudo_legal`.
+    #[inline(always)]
+    fn probe_read(&self, key16: u16) -> Option<Decoded> {
+        let a = self.a.load(Ordering::Acquire);
+        let bound = (a >> 16) as u8;
+
+        if a as u16 != key16 || bound == BOUND_NONE {
+            return None;
+        }
+
+        let b = self.b.load(Ordering::Relaxed);
+        let c = self.c.load(Ordering::Relaxed);
+
+        Some(Decoded {
+            key: key16,
+            bound,
+            depth: (a >> 24) as u8,
+            mv: b as u16,
+            age: (b >> 16) as u8,
+            pv: (b >> 24) as u8,
+            score: c as u16 as i16,
+            eval: (c >> 16) as u16 as i16,
+        })
+    }
+
     /// Store generation, for replacement-quality aging.
     #[inline(always)]
     fn age(&self) -> u8 {
@@ -224,16 +256,7 @@ impl TranspositionTable {
         let cluster = self.cluster(idx);
 
         for slot in cluster {
-            let (key, bound, _) = slot.meta();
-            if key == key16 && bound != BOUND_NONE {
-                let entry = slot.load();
-                // A concurrent store that published a new key after our meta()
-                // but before load() can leave us with a mismatched key — the
-                // Acquire on `a` in load() synchronizes with the store's Release,
-                // and this re-check discards the torn hit.
-                if entry.key != key16 {
-                    continue;
-                }
+            if let Some(entry) = slot.probe_read(key16) {
                 let score = Self::score_from_tt(entry.score as i32, ply);
                 let mv = Move::from_u16(entry.mv);
 

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -103,7 +103,7 @@ impl TtEntry {
     /// the cluster scan compares. The payload stays packed until a key matches.
     #[inline(always)]
     fn meta(&self) -> (u16, u8, u8) {
-        let a = self.a.load(Ordering::Relaxed);
+        let a = self.a.load(Ordering::Acquire);
         (a as u16, (a >> 16) as u8, (a >> 24) as u8)
     }
 
@@ -115,7 +115,7 @@ impl TtEntry {
 
     #[inline(always)]
     fn load(&self) -> Decoded {
-        let a = self.a.load(Ordering::Relaxed);
+        let a = self.a.load(Ordering::Acquire);
         let b = self.b.load(Ordering::Relaxed);
         let c = self.c.load(Ordering::Relaxed);
 
@@ -137,9 +137,11 @@ impl TtEntry {
         let b = d.mv as u32 | (d.age as u32) << 16 | (d.pv as u32) << 24;
         let c = d.score as u16 as u32 | (d.eval as u16 as u32) << 16;
 
-        self.a.store(a, Ordering::Relaxed);
-        self.b.store(b, Ordering::Relaxed);
         self.c.store(c, Ordering::Relaxed);
+        self.b.store(b, Ordering::Relaxed);
+        // key published last — an Acquire load on `a` that sees the new key
+        // is guaranteed to see the `b` and `c` stores that precede it.
+        self.a.store(a, Ordering::Release);
     }
 }
 
@@ -222,10 +224,15 @@ impl TranspositionTable {
 
         for i in 0..CLUSTER_SIZE {
             let (key, bound, _) = self.entries[idx + i].meta();
-            // The bound guard keeps an empty slot (key 0) from matching a real
-            // position whose low 16 bits happen to be 0.
             if key == key16 && bound != BOUND_NONE {
                 let entry = self.entries[idx + i].load();
+                // A concurrent store that published a new key after our meta()
+                // but before load() can leave us with a mismatched key — the
+                // Acquire on `a` in load() synchronizes with the store's Release,
+                // and this re-check discards the torn hit.
+                if entry.key != key16 {
+                    continue;
+                }
                 let score = Self::score_from_tt(entry.score as i32, ply);
                 let mv = Move::from_u16(entry.mv);
 

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -1,5 +1,6 @@
 //! External interfaces for UCI and XBoard communication.
 
+pub mod smp;
 pub mod spmc;
 pub mod uci;
 pub mod xboard;

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -1,4 +1,5 @@
 //! External interfaces for UCI and XBoard communication.
 
+pub mod spmc;
 pub mod uci;
 pub mod xboard;

--- a/src/protocols/smp.rs
+++ b/src/protocols/smp.rs
@@ -10,7 +10,11 @@ use std::{sync::Arc, thread};
 
 use crate::{
     core::board::Position,
-    engine::{history::History, search::{SearchConfig, Searcher}, tt::TranspositionTable},
+    engine::{
+        history::History,
+        search::{SearchConfig, Searcher},
+        tt::TranspositionTable,
+    },
     protocols::spmc,
 };
 

--- a/src/protocols/smp.rs
+++ b/src/protocols/smp.rs
@@ -1,0 +1,81 @@
+//! Lazy SMP thread pool.
+//!
+//! Helpers are persistent, parked on an SPMC broadcast channel between
+//! searches. `launch` sends one payload to all helpers; each receives it
+//! inside a handler that runs the search, and the channel auto-signals
+//! completion when the handler returns. `wait` blocks until every helper
+//! has finished. `wake` (via `Drop`) shuts them down.
+
+use std::{sync::Arc, thread};
+
+use crate::{
+    core::board::Position,
+    engine::{history::History, search::{SearchConfig, Searcher}, tt::TranspositionTable},
+    protocols::spmc,
+};
+
+pub struct LazySmpPool {
+    tx: spmc::Sender<(SearchConfig, Position, Vec<u64>)>,
+    handles: Vec<thread::JoinHandle<()>>,
+}
+
+impl LazySmpPool {
+    pub fn new(threads: usize, tt: Arc<TranspositionTable>) -> Arc<Self> {
+        if threads <= 1 {
+            let (tx, _) = spmc::channel::<(SearchConfig, Position, Vec<u64>)>(0);
+            return Arc::new(Self { tx, handles: Vec::new() });
+        }
+
+        let n = threads - 1;
+        let (tx, rxs) = spmc::channel::<(SearchConfig, Position, Vec<u64>)>(n as u32);
+        let mut handles = Vec::with_capacity(n);
+
+        for (i, mut rx) in rxs.into_iter().enumerate() {
+            let helper_id = i + 1;
+            let tt = Arc::clone(&tt);
+
+            handles.push(thread::spawn(move || {
+                while rx
+                    .recv(|(config, board, history)| {
+                        let mut local_cfg = config.clone();
+                        local_cfg.thread_id = helper_id;
+                        let mut htable = History::new();
+                        let mut ctx = Searcher::new(&local_cfg, board, history, tt.clone());
+                        ctx.iterative_deepening(&mut htable);
+                    })
+                    .is_some()
+                {}
+            }));
+        }
+        Arc::new(Self { tx, handles })
+    }
+
+    pub fn launch(&self, cfg: &SearchConfig, board: Position, history: &[u64]) {
+        if self.handles.is_empty() {
+            return;
+        }
+
+        let mut hcfg = (*cfg).clone();
+
+        hcfg.limits.silent = true;
+        self.tx.send((hcfg, board, history.to_vec()));
+    }
+
+    pub fn wait(&self) {
+        if self.handles.is_empty() {
+            return;
+        }
+        self.tx.wait();
+    }
+}
+
+impl Drop for LazySmpPool {
+    fn drop(&mut self) {
+        self.tx.wait();
+        self.tx.wake();
+
+        for h in self.handles.drain(..) {
+            let _ = h.join();
+        }
+    }
+}

--- a/src/protocols/spmc.rs
+++ b/src/protocols/spmc.rs
@@ -7,7 +7,7 @@
 //! `recv`, the sender's `wait()` unblocks and the message is deallocated.
 //!
 //! A generation bit toggles each `send` so receivers don't pick up stale
-//! messages between `wait` and the next `send`. An `exit` flag shut down
+//! messages between `wait` and the next `send`. An `exit` flag shuts down
 //! receivers cleanly — `wake()` sets the flag and unparks every receiver,
 //! at which point `recv` returns `None`.
 

--- a/src/protocols/spmc.rs
+++ b/src/protocols/spmc.rs
@@ -61,7 +61,7 @@ pub fn channel<M>(num_receivers: u32) -> (Sender<M>, Vec<Receiver<M>>) {
 
     let tx = Sender { shared: Arc::clone(&shared) };
     let rxs = (0..num_receivers)
-        .map(|_| Receiver { shared: Arc::clone(&shared), generation: false })
+        .map(|_| Receiver { shared: Arc::clone(&shared), generation: true })
         .collect();
 
     (tx, rxs)

--- a/src/protocols/spmc.rs
+++ b/src/protocols/spmc.rs
@@ -1,0 +1,164 @@
+//! Non-blocking single-producer multi-consumer broadcast channel.
+//!
+//! `send(msg)` heap-allocates one message, wakes every receiver, and returns.
+//! `recv(handler)` blocks until a message arrives, runs the handler with a
+//! shared reference to it, then automatically signals completion (decrements
+//! the outstanding-receiver count). When every receiver has returned from
+//! `recv`, the sender's `wait()` unblocks and the message is deallocated.
+//!
+//! A generation bit toggles each `send` so receivers don't pick up stale
+//! messages between `wait` and the next `send`. An `exit` flag shut down
+//! receivers cleanly — `wake()` sets the flag and unparks every receiver,
+//! at which point `recv` returns `None`.
+
+use std::{
+    ptr,
+    sync::{
+        Arc,
+        atomic::{
+            AtomicBool, AtomicPtr, AtomicU32,
+            Ordering::{Acquire, Relaxed, Release},
+        },
+    },
+};
+
+use atomic_wait::{wait, wake_all};
+
+struct Shared<M> {
+    msg: AtomicPtr<M>,
+    ready: AtomicBool,
+    futex: AtomicU32,
+    exit: AtomicBool,
+    num_receivers: u32,
+}
+
+pub struct Sender<M> {
+    shared: Arc<Shared<M>>,
+}
+
+pub struct Receiver<M> {
+    shared: Arc<Shared<M>>,
+    generation: bool,
+}
+
+fn pack(remaining: u32, generation: bool) -> u32 {
+    debug_assert!(remaining < u32::MAX >> 1);
+    remaining | (generation as u32) << 31
+}
+
+fn unpack(v: u32) -> (u32, bool) {
+    (v & (u32::MAX >> 1), (v >> 31) != 0)
+}
+
+pub fn channel<M>(num_receivers: u32) -> (Sender<M>, Vec<Receiver<M>>) {
+    let shared = Arc::new(Shared {
+        msg: AtomicPtr::new(ptr::null_mut()),
+        ready: AtomicBool::new(false),
+        futex: AtomicU32::new(pack(0, false)),
+        exit: AtomicBool::new(false),
+        num_receivers,
+    });
+
+    let tx = Sender { shared: Arc::clone(&shared) };
+    let rxs = (0..num_receivers)
+        .map(|_| Receiver { shared: Arc::clone(&shared), generation: false })
+        .collect();
+
+    (tx, rxs)
+}
+
+impl<M> Sender<M> {
+    /// Stores a heap-allocated `msg`, toggles the generation, wakes every
+    /// receiver, and returns. The message is freed in `wait()`.
+    pub fn send(&self, msg: M) {
+        let shared = &*self.shared;
+
+        let boxed = Box::new(msg);
+        shared.msg.store(Box::into_raw(boxed), Relaxed);
+        shared.ready.store(true, Release);
+
+        let (_, generation) = unpack(shared.futex.load(Relaxed));
+        shared.futex.store(pack(shared.num_receivers, !generation), Release);
+        wake_all(&shared.futex);
+    }
+
+    /// Blocks until every receiver has returned from `recv`, then frees the
+    /// message so the next `send()` can allocate fresh.
+    pub fn wait(&self) {
+        let shared = &*self.shared;
+
+        let mut val = shared.futex.load(Acquire);
+
+        while unpack(val).0 != 0 {
+            wait(&shared.futex, val);
+            val = shared.futex.load(Acquire);
+        }
+
+        shared.ready.store(false, Release);
+
+        let ptr = shared.msg.swap(ptr::null_mut(), Relaxed);
+
+        if !ptr.is_null() {
+            // SAFETY: Created by Box::into_raw in send(); all receivers
+            // have returned from recv (outstanding count is zero).
+            unsafe {
+                drop(Box::from_raw(ptr));
+            }
+        }
+    }
+
+    /// Signals all receivers to exit and unparks them. After this call,
+    /// every parked `recv()` returns `None` and receivers should terminate.
+    pub fn wake(&self) {
+        let shared = &*self.shared;
+        shared.exit.store(true, Release);
+        wake_all(&shared.futex);
+    }
+}
+
+impl<M> Receiver<M> {
+    /// Blocks until `send()` delivers a message with a fresh generation,
+    /// runs `handler` on a shared reference to it, automatically decrements
+    /// the outstanding-receiver count, and returns `Some(handler_result)`.
+    ///
+    /// Returns `None` if the channel has been shut down via `Sender::wake()`.
+    pub fn recv<R>(&mut self, handler: impl FnOnce(&M) -> R) -> Option<R> {
+        let shared = &*self.shared;
+
+        loop {
+            let val = shared.futex.load(Acquire);
+
+            if shared.exit.load(Acquire) {
+                return None;
+            }
+
+            if shared.ready.load(Acquire) && unpack(val).1 == self.generation {
+                break;
+            }
+            wait(&shared.futex, val);
+        }
+
+        self.generation = !self.generation;
+
+        // SAFETY: The Acquire loads above establish that send()'s
+        // msg store (happens-before the Release store on ready/futex)
+        // is visible here.
+        let msg_ref = unsafe { &*shared.msg.load(Relaxed) };
+        let result = handler(msg_ref);
+
+        // Decrement outstanding. If this was the last receiver, wake the
+        // sender (parked in wait()).
+        if unpack(shared.futex.fetch_sub(1, Release)).0 == 1 {
+            wake_all(&shared.futex);
+        }
+
+        Some(result)
+    }
+}
+
+// SAFETY: Single-producer design. Each receiver is used from one thread.
+// The msg pointer is guarded by the futex + generation protocol.
+unsafe impl<M: Send> Send for Sender<M> {}
+unsafe impl<M: Send> Send for Receiver<M> {}
+unsafe impl<M: Sync> Sync for Sender<M> {}
+unsafe impl<M: Sync> Sync for Receiver<M> {}

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -9,7 +9,7 @@ use std::{
     str::FromStr,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         mpsc::{self, Sender},
     },
     thread,
@@ -294,6 +294,7 @@ pub fn run_cli_go(args: &[String]) {
 
     let mut cfg = SearchConfig::new_full(limits, Instant::now(), stop, overhead, display, SearchParams::default());
     cfg.threads = state.threads;
+    cfg.node_slots = Arc::new((0..state.threads).map(|_| AtomicU64::new(0)).collect());
 
     let search_tx = state.search_tx.clone();
 
@@ -626,6 +627,7 @@ where I: Iterator<Item = &'a str> {
     let display = state.search_display();
     let mut cfg = SearchConfig::new_full(limits, start_time, stop, overhead, display, SearchParams::default());
     cfg.threads = state.threads;
+    cfg.node_slots = Arc::new((0..state.threads).map(|_| AtomicU64::new(0)).collect());
 
     state.is_searching.store(true, Ordering::Release);
 

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -54,9 +54,82 @@ static LICENSE_NOTICE: &str = concat!(
     "Source code: <https://github.com/Aethdv/Soul>"
 );
 
+// ── Lazy SMP Thread Pool ──
+// Helpers are persistent, parked on an SPMC broadcast channel between
+// searches. launch sends one payload to all helpers; each receives it
+// inside a handler that runs the search, and the channel auto-signals
+// completion when the handler returns. wait blocks until every helper
+// has finished. wake shuts them down.
+
+use crate::protocols::spmc;
+
+struct LazySmpPool {
+    tx: spmc::Sender<(SearchConfig, Position, Vec<u64>)>,
+    _handles: Vec<thread::JoinHandle<()>>,
+}
+
+impl LazySmpPool {
+    fn new(threads: usize, tt: Arc<TranspositionTable>) -> Arc<Self> {
+        if threads <= 1 {
+            let (tx, _) = spmc::channel::<(SearchConfig, Position, Vec<u64>)>(0);
+            return Arc::new(Self { tx, _handles: Vec::new() });
+        }
+
+        let n = threads - 1;
+        let (tx, rxs) = spmc::channel::<(SearchConfig, Position, Vec<u64>)>(n as u32);
+        let mut handles = Vec::with_capacity(n);
+
+        for mut rx in rxs {
+            let tt = Arc::clone(&tt);
+
+            handles.push(thread::spawn(move || {
+                while rx
+                    .recv(|(config, board, history)| {
+                        let mut htable = History::new();
+                        let mut ctx = Searcher::new(config, board, history, tt.clone());
+                        ctx.iterative_deepening(&mut htable);
+                    })
+                    .is_some()
+                {}
+            }));
+        }
+        Arc::new(Self { tx, _handles: handles })
+    }
+
+    fn launch(&self, cfg: &SearchConfig, board: Position, history: &[u64]) {
+        if self._handles.is_empty() {
+            return;
+        }
+
+        let mut hcfg = (*cfg).clone();
+
+        hcfg.limits.silent = true;
+        hcfg.thread_id = 1;
+        self.tx.send((hcfg, board, history.to_vec()));
+    }
+
+    fn wait(&self) {
+        if self._handles.is_empty() {
+            return;
+        }
+        self.tx.wait();
+    }
+}
+
+impl Drop for LazySmpPool {
+    fn drop(&mut self) {
+        self.tx.wait();
+        self.tx.wake();
+
+        for h in self._handles.drain(..) {
+            let _ = h.join();
+        }
+    }
+}
+
 #[allow(clippy::large_enum_variant)]
 enum SearchCommand {
-    Go(Box<SearchConfig>, Position, Vec<u64>, History, Arc<TranspositionTable>, Sender<History>),
+    Go(Box<SearchConfig>, Position, Vec<u64>, History, Arc<TranspositionTable>, Sender<History>, Arc<LazySmpPool>),
     Quit,
 }
 
@@ -71,6 +144,7 @@ pub struct UciState {
     history_tx: mpsc::Sender<History>,
     history_rx: mpsc::Receiver<History>,
     is_searching: Arc<AtomicBool>,
+    smp_pool: Arc<LazySmpPool>,
     threads: usize,
     hash_size: usize,
     overhead: u64,
@@ -89,6 +163,7 @@ impl UciState {
         let history = vec![board.hash];
         let stop = Arc::new(AtomicBool::new(false));
         let is_searching = Arc::new(AtomicBool::new(false));
+        let tt = Arc::new(TranspositionTable::new(16));
 
         let (tx, rx) = mpsc::channel::<SearchCommand>();
         let (h_tx, h_rx) = mpsc::channel::<History>();
@@ -98,41 +173,22 @@ impl UciState {
         thread::spawn(move || {
             while let Ok(cmd) = rx.recv() {
                 match cmd {
-                    SearchCommand::Go(cfg, board, history, mut history_table, tt, result_tx) => {
+                    SearchCommand::Go(cfg, board, history, mut history_table, tt, result_tx, pool) => {
                         // ── Lazy SMP ──
-                        // Helpers search the same root, sharing only the TT and stop flag.
-                        // Tree diversity deepens the shared table. Main reports and decides.
-                        let mut helpers = Vec::new();
-
-                        for i in 1..cfg.threads {
-                            let mut hcfg = (*cfg).clone();
-                            hcfg.limits.silent = true;
-                            hcfg.thread_id = i;
-
-                            let hboard = board;
-                            let hhistory = history.clone();
-                            let htt = Arc::clone(&tt);
-
-                            helpers.push(thread::spawn(move || {
-                                let mut htable = History::new();
-                                let mut ctx = Searcher::new(&hcfg, &hboard, &hhistory, htt);
-                                ctx.iterative_deepening(&mut htable);
-                            }));
-                        }
+                        // Helpers are persistent — parked on a channel, not spawned per
+                        // search. The pool sends each helper a cloned config and root state,
+                        // then they run iterative_deepening alongside main. The TT is the
+                        // only coordination surface.
+                        pool.launch(&cfg, board, &history);
 
                         let mut ctx = Searcher::new(&cfg, &board, &history, tt);
                         ctx.iterative_deepening(&mut history_table);
 
-                        // Main is done. Signal helpers, join, then clear the flag so
-                        // the next search starts clean.
-                        if !helpers.is_empty() {
-                            cfg.stop.store(true, Ordering::Release);
-
-                            for h in helpers {
-                                let _ = h.join();
-                            }
-                            cfg.stop.store(false, Ordering::Release);
-                        }
+                        // Main is done. Signal helpers, wait for them to park,
+                        // then clear the flag so the next search starts clean.
+                        cfg.stop.store(true, Ordering::Release);
+                        pool.wait();
+                        cfg.stop.store(false, Ordering::Release);
 
                         is_searching_worker.store(false, Ordering::Release);
 
@@ -148,12 +204,13 @@ impl UciState {
             board,
             history,
             persistent_history: History::new(),
-            tt: Arc::new(TranspositionTable::new(16)),
+            tt: tt.clone(),
             stop,
             search_tx: tx,
             history_tx: h_tx,
             history_rx: h_rx,
             is_searching,
+            smp_pool: LazySmpPool::new(1, tt),
             threads: 1,
             hash_size: 16,
             overhead: 10,
@@ -249,6 +306,7 @@ pub fn run_cli_go(args: &[String]) {
             state.persistent_history.clone(),
             state.tt.clone(),
             state.history_tx.clone(),
+            state.smp_pool.clone(),
         ))
         .unwrap();
 
@@ -582,6 +640,7 @@ where I: Iterator<Item = &'a str> {
             state.persistent_history.clone(),
             state.tt.clone(),
             state.history_tx.clone(),
+            state.smp_pool.clone(),
         ))
         .unwrap();
 }
@@ -650,7 +709,11 @@ where I: Iterator<Item = &'a str> {
         },
 
         "threads" => {
-            state.threads = value.parse::<usize>().unwrap_or(1).clamp(1, 1024);
+            let n = value.parse::<usize>().unwrap_or(1).clamp(1, 1024);
+            if n != state.threads {
+                state.threads = n;
+                state.smp_pool = LazySmpPool::new(n, state.tt.clone());
+            }
         },
         _ => {},
     }

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -71,6 +71,7 @@ pub struct UciState {
     history_tx: mpsc::Sender<History>,
     history_rx: mpsc::Receiver<History>,
     is_searching: Arc<AtomicBool>,
+    threads: usize,
     hash_size: usize,
     overhead: u64,
     show_wdl: bool,
@@ -98,9 +99,41 @@ impl UciState {
             while let Ok(cmd) = rx.recv() {
                 match cmd {
                     SearchCommand::Go(cfg, board, history, mut history_table, tt, result_tx) => {
-                        let mut ctx = Searcher::new(&cfg, &board, &history, tt);
+                        // ── Lazy SMP ──
+                        // Helpers search the same root, sharing only the TT and stop flag.
+                        // Tree diversity deepens the shared table. Main reports and decides.
+                        let mut helpers = Vec::new();
 
+                        for i in 1..cfg.threads {
+                            let mut hcfg = (*cfg).clone();
+                            hcfg.limits.silent = true;
+                            hcfg.thread_id = i;
+
+                            let hboard = board;
+                            let hhistory = history.clone();
+                            let htt = Arc::clone(&tt);
+
+                            helpers.push(thread::spawn(move || {
+                                let mut htable = History::new();
+                                let mut ctx = Searcher::new(&hcfg, &hboard, &hhistory, htt);
+                                ctx.iterative_deepening(&mut htable);
+                            }));
+                        }
+
+                        let mut ctx = Searcher::new(&cfg, &board, &history, tt);
                         ctx.iterative_deepening(&mut history_table);
+
+                        // Main is done. Signal helpers, join, then clear the flag so
+                        // the next search starts clean.
+                        if !helpers.is_empty() {
+                            cfg.stop.store(true, Ordering::Release);
+
+                            for h in helpers {
+                                let _ = h.join();
+                            }
+                            cfg.stop.store(false, Ordering::Release);
+                        }
+
                         is_searching_worker.store(false, Ordering::Release);
 
                         let _ = result_tx.send(history_table);
@@ -121,6 +154,7 @@ impl UciState {
             history_tx: h_tx,
             history_rx: h_rx,
             is_searching,
+            threads: 1,
             hash_size: 16,
             overhead: 10,
             show_wdl: false,
@@ -201,7 +235,8 @@ pub fn run_cli_go(args: &[String]) {
     let limits = parse_go_limits(&board, &mut iter);
     let display = state.search_display();
 
-    let cfg = SearchConfig::new_full(limits, Instant::now(), stop, overhead, display, SearchParams::default());
+    let mut cfg = SearchConfig::new_full(limits, Instant::now(), stop, overhead, display, SearchParams::default());
+    cfg.threads = state.threads;
 
     let search_tx = state.search_tx.clone();
 
@@ -321,14 +356,17 @@ fn spawn_stdin_listener(stop: Arc<AtomicBool>) -> mpsc::Receiver<String> {
 
     thread::spawn(move || {
         let stdin = io::stdin();
+
         loop {
             let mut line = String::new();
+
             match stdin.read_line(&mut line) {
                 Ok(0) | Err(_) => break,
                 Ok(_) => {},
             }
 
             let trimmed = line.trim();
+
             if trimmed.is_empty() {
                 continue;
             }
@@ -458,7 +496,7 @@ fn print_id() {
 
 fn print_options() {
     println!("option name Hash type spin default 16 min 1 max 65536");
-    println!("option name Threads type spin default 1 min 1 max 1");
+    println!("option name Threads type spin default 1 min 1 max 1024");
     println!("option name Overhead type spin default 10 min 0 max 1000");
     println!("option name UCI_ShowWDL type check default false");
     println!("option name UCI_Chess960 type check default false");
@@ -528,7 +566,8 @@ where I: Iterator<Item = &'a str> {
 
     let start_time = Instant::now();
     let display = state.search_display();
-    let cfg = SearchConfig::new_full(limits, start_time, stop, overhead, display, SearchParams::default());
+    let mut cfg = SearchConfig::new_full(limits, start_time, stop, overhead, display, SearchParams::default());
+    cfg.threads = state.threads;
 
     state.is_searching.store(true, Ordering::Release);
 
@@ -611,7 +650,7 @@ where I: Iterator<Item = &'a str> {
         },
 
         "threads" => {
-            // Dummy. not supported yet.
+            state.threads = value.parse::<usize>().unwrap_or(1).clamp(1, 1024);
         },
         _ => {},
     }

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -684,6 +684,7 @@ where I: Iterator<Item = &'a str> {
             if let Ok(mb) = value.parse::<usize>() {
                 state.hash_size = mb;
                 state.tt = Arc::new(TranspositionTable::new(mb));
+                state.smp_pool = LazySmpPool::new(state.threads, state.tt.clone());
             }
         },
 

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -9,7 +9,7 @@ use std::{
     str::FromStr,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
         mpsc::{self, Sender},
     },
     thread,
@@ -222,7 +222,7 @@ pub fn run_cli_go(args: &[String]) {
 
     let mut cfg = SearchConfig::new_full(limits, Instant::now(), stop, overhead, display, SearchParams::default());
     cfg.threads = state.threads;
-    cfg.node_slots = Arc::new((0..state.threads).map(|_| AtomicU64::new(0)).collect());
+    cfg.node_slots = SearchConfig::node_slots(state.threads);
 
     let search_tx = state.search_tx.clone();
 
@@ -555,7 +555,7 @@ where I: Iterator<Item = &'a str> {
     let display = state.search_display();
     let mut cfg = SearchConfig::new_full(limits, start_time, stop, overhead, display, SearchParams::default());
     cfg.threads = state.threads;
-    cfg.node_slots = Arc::new((0..state.threads).map(|_| AtomicU64::new(0)).collect());
+    cfg.node_slots = SearchConfig::node_slots(state.threads);
 
     state.is_searching.store(true, Ordering::Release);
 

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -65,14 +65,14 @@ use crate::protocols::spmc;
 
 struct LazySmpPool {
     tx: spmc::Sender<(SearchConfig, Position, Vec<u64>)>,
-    _handles: Vec<thread::JoinHandle<()>>,
+    handles: Vec<thread::JoinHandle<()>>,
 }
 
 impl LazySmpPool {
     fn new(threads: usize, tt: Arc<TranspositionTable>) -> Arc<Self> {
         if threads <= 1 {
             let (tx, _) = spmc::channel::<(SearchConfig, Position, Vec<u64>)>(0);
-            return Arc::new(Self { tx, _handles: Vec::new() });
+            return Arc::new(Self { tx, handles: Vec::new() });
         }
 
         let n = threads - 1;
@@ -96,11 +96,11 @@ impl LazySmpPool {
                 {}
             }));
         }
-        Arc::new(Self { tx, _handles: handles })
+        Arc::new(Self { tx, handles })
     }
 
     fn launch(&self, cfg: &SearchConfig, board: Position, history: &[u64]) {
-        if self._handles.is_empty() {
+        if self.handles.is_empty() {
             return;
         }
 
@@ -111,7 +111,7 @@ impl LazySmpPool {
     }
 
     fn wait(&self) {
-        if self._handles.is_empty() {
+        if self.handles.is_empty() {
             return;
         }
         self.tx.wait();
@@ -123,7 +123,7 @@ impl Drop for LazySmpPool {
         self.tx.wait();
         self.tx.wake();
 
-        for h in self._handles.drain(..) {
+        for h in self.handles.drain(..) {
             let _ = h.join();
         }
     }

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -33,6 +33,7 @@ use crate::{
         search_params::SearchParams,
         tt::TranspositionTable,
     },
+    protocols::smp::LazySmpPool,
     tools,
     weave::Vi16x8,
 };
@@ -53,81 +54,6 @@ static LICENSE_NOTICE: &str = concat!(
     "along with this program. If not, see <https://www.gnu.org/licenses/>.\n\n",
     "Source code: <https://github.com/Aethdv/Soul>"
 );
-
-// ── Lazy SMP Thread Pool ──
-// Helpers are persistent, parked on an SPMC broadcast channel between
-// searches. launch sends one payload to all helpers; each receives it
-// inside a handler that runs the search, and the channel auto-signals
-// completion when the handler returns. wait blocks until every helper
-// has finished. wake shuts them down.
-
-use crate::protocols::spmc;
-
-struct LazySmpPool {
-    tx: spmc::Sender<(SearchConfig, Position, Vec<u64>)>,
-    handles: Vec<thread::JoinHandle<()>>,
-}
-
-impl LazySmpPool {
-    fn new(threads: usize, tt: Arc<TranspositionTable>) -> Arc<Self> {
-        if threads <= 1 {
-            let (tx, _) = spmc::channel::<(SearchConfig, Position, Vec<u64>)>(0);
-            return Arc::new(Self { tx, handles: Vec::new() });
-        }
-
-        let n = threads - 1;
-        let (tx, rxs) = spmc::channel::<(SearchConfig, Position, Vec<u64>)>(n as u32);
-        let mut handles = Vec::with_capacity(n);
-
-        for (i, mut rx) in rxs.into_iter().enumerate() {
-            let helper_id = i + 1;
-            let tt = Arc::clone(&tt);
-
-            handles.push(thread::spawn(move || {
-                while rx
-                    .recv(|(config, board, history)| {
-                        let mut local_cfg = config.clone();
-                        local_cfg.thread_id = helper_id;
-                        let mut htable = History::new();
-                        let mut ctx = Searcher::new(&local_cfg, board, history, tt.clone());
-                        ctx.iterative_deepening(&mut htable);
-                    })
-                    .is_some()
-                {}
-            }));
-        }
-        Arc::new(Self { tx, handles })
-    }
-
-    fn launch(&self, cfg: &SearchConfig, board: Position, history: &[u64]) {
-        if self.handles.is_empty() {
-            return;
-        }
-
-        let mut hcfg = (*cfg).clone();
-
-        hcfg.limits.silent = true;
-        self.tx.send((hcfg, board, history.to_vec()));
-    }
-
-    fn wait(&self) {
-        if self.handles.is_empty() {
-            return;
-        }
-        self.tx.wait();
-    }
-}
-
-impl Drop for LazySmpPool {
-    fn drop(&mut self) {
-        self.tx.wait();
-        self.tx.wake();
-
-        for h in self.handles.drain(..) {
-            let _ = h.join();
-        }
-    }
-}
 
 #[allow(clippy::large_enum_variant)]
 enum SearchCommand {

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -79,14 +79,17 @@ impl LazySmpPool {
         let (tx, rxs) = spmc::channel::<(SearchConfig, Position, Vec<u64>)>(n as u32);
         let mut handles = Vec::with_capacity(n);
 
-        for mut rx in rxs {
+        for (i, mut rx) in rxs.into_iter().enumerate() {
+            let helper_id = i + 1;
             let tt = Arc::clone(&tt);
 
             handles.push(thread::spawn(move || {
                 while rx
                     .recv(|(config, board, history)| {
+                        let mut local_cfg = config.clone();
+                        local_cfg.thread_id = helper_id;
                         let mut htable = History::new();
-                        let mut ctx = Searcher::new(config, board, history, tt.clone());
+                        let mut ctx = Searcher::new(&local_cfg, board, history, tt.clone());
                         ctx.iterative_deepening(&mut htable);
                     })
                     .is_some()
@@ -104,7 +107,6 @@ impl LazySmpPool {
         let mut hcfg = (*cfg).clone();
 
         hcfg.limits.silent = true;
-        hcfg.thread_id = 1;
         self.tx.send((hcfg, board, history.to_vec()));
     }
 

--- a/src/protocols/xboard.rs
+++ b/src/protocols/xboard.rs
@@ -6,7 +6,7 @@ use std::{
     io::{self, StdinLock, Write},
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     thread::{self, JoinHandle},
     time::Instant,
@@ -28,6 +28,7 @@ use crate::{
         search_params::SearchParams,
         tt::TranspositionTable,
     },
+    protocols::smp::LazySmpPool,
     weave::Vi16x8,
 };
 
@@ -54,6 +55,8 @@ struct XBoardState {
     engine_side: Option<Color>,
     is_frc: bool,
     nps: Option<u64>,
+    threads: usize,
+    smp_pool: Arc<LazySmpPool>,
 }
 
 pub fn main_loop(lines: &mut io::Lines<StdinLock>) {
@@ -84,13 +87,14 @@ impl XBoardState {
     fn new() -> Self {
         let board = Position::from_fen(STARTPOS);
         let history = vec![board.hash];
+        let tt = Arc::new(TranspositionTable::new(16));
 
         Self {
             accumulator: board.get_initial_accumulator(),
             board,
             history,
             persistent_history: Arc::new(Mutex::new(History::new())),
-            tt: Arc::new(TranspositionTable::new(16)),
+            tt: tt.clone(),
             mode: Mode::Normal,
             stop_signal: Arc::new(AtomicBool::new(false)),
             search_thread: None,
@@ -101,6 +105,8 @@ impl XBoardState {
             engine_side: None,
             is_frc: false,
             nps: None,
+            threads: 1,
+            smp_pool: LazySmpPool::new(1, tt),
         }
     }
 
@@ -153,13 +159,28 @@ impl XBoardState {
         let mut persistent_history = history_arc.lock().clone();
 
         let tt = self.tt.clone();
+        let threads = self.threads;
+        let pool = self.smp_pool.clone();
 
         self.search_thread = Some(thread::spawn(move || {
             let display = SearchDisplay { show_wdl, ..SearchDisplay::DEFAULT };
-            let cfg = SearchConfig::new_full(limits, Instant::now(), stop, overhead, display, SearchParams::default());
-            let mut ctx = Searcher::new(&cfg, &board, &history, tt);
+            let mut cfg = SearchConfig::new_full(limits, Instant::now(), stop, overhead, display, SearchParams::default());
+            cfg.threads = threads;
+            cfg.node_slots = Arc::new((0..threads).map(|_| AtomicU64::new(0)).collect());
 
+            // ── Lazy SMP ──
+            // Persistent helpers fan out across the depth ladder alongside main;
+            // the TT is the only shared surface. Main finishes, then we signal
+            // the helpers and wait for them to park before clearing the flag.
+            pool.launch(&cfg, board, &history);
+
+            let mut ctx = Searcher::new(&cfg, &board, &history, tt);
             ctx.iterative_deepening(&mut persistent_history);
+
+            cfg.stop.store(true, Ordering::Release);
+            pool.wait();
+            cfg.stop.store(false, Ordering::Release);
+
             *history_arc.lock() = persistent_history;
         }));
     }
@@ -261,13 +282,19 @@ fn handle_command<'a>(state: &mut XBoardState, cmd: &str, args: &mut impl Iterat
             {
                 state.hash_size = mb;
                 state.tt = Arc::new(TranspositionTable::new(mb));
+                state.smp_pool = LazySmpPool::new(state.threads, state.tt.clone());
             }
         },
 
         "cores" => {
-            // "Dummy" impl.
-            if let Some(_arg) = args.next() {
-                // state.threads = arg.parse() ...
+            if let Some(arg) = args.next()
+                && let Ok(n) = arg.parse::<usize>()
+            {
+                let n = n.clamp(1, 1024);
+                if n != state.threads {
+                    state.threads = n;
+                    state.smp_pool = LazySmpPool::new(n, state.tt.clone());
+                }
             }
         },
 
@@ -431,6 +458,7 @@ fn cmd_option<'a>(state: &mut XBoardState, args: &mut impl Iterator<Item = &'a s
             if let Ok(mb) = value.parse::<usize>() {
                 state.hash_size = mb;
                 state.tt = Arc::new(TranspositionTable::new(mb));
+                state.smp_pool = LazySmpPool::new(state.threads, state.tt.clone());
             }
         },
 

--- a/src/protocols/xboard.rs
+++ b/src/protocols/xboard.rs
@@ -6,7 +6,7 @@ use std::{
     io::{self, StdinLock, Write},
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     thread::{self, JoinHandle},
     time::Instant,
@@ -166,7 +166,7 @@ impl XBoardState {
             let display = SearchDisplay { show_wdl, ..SearchDisplay::DEFAULT };
             let mut cfg = SearchConfig::new_full(limits, Instant::now(), stop, overhead, display, SearchParams::default());
             cfg.threads = threads;
-            cfg.node_slots = Arc::new((0..threads).map(|_| AtomicU64::new(0)).collect());
+            cfg.node_slots = SearchConfig::node_slots(threads);
 
             // ── Lazy SMP ──
             // Persistent helpers fan out across the depth ladder alongside main;


### PR DESCRIPTION
Threads search the same root in parallel, sharing only the TT and the stop
flag. No work splitting; each thread runs its own iterative-deepening loop
and the TT is the coordination surface. Diversity is emergent: a helper probes an
entry main wrote at the edge of its reach and redirects its tree down a branch
main already explored. Standard lazy SMP, nothing exotic. The value is the
plumbing being clean enough to build voting on next.

## What changed

- **SPMC broadcast channel** (`protocols/spmc.rs`). Helpers are persistent,
  parked on a futex between searches rather than spawned per `go`. `send` wakes
  all, `wait` blocks until every helper has parked again. A generation bit stops
  a returning receiver from re-grabbing a stale message; an `exit` flag shuts
  them down on quit.

- **TT goes lockless-concurrent.** The 12-byte entry splits into three
  `AtomicU32`s, ordered by how often the cluster scan reads them: `a`
  (key+bound+depth) on every probe, `b` and `c` only after a key match.
  A probing miss costs one atomic load, not three. The key is published last under
  a Release store and read first under Acquire, so a matching key implies the
  `b`/`c` writes before it are visible. `a` is read once per slot, so the only
  tear left is a same-key re-store landing fresh payload over a stale key word;
  that move still passes `is_pseudo_legal` in search, so the worst case is a
  stale cutoff, never board corruption. The race every lockless TT accepts.

- **Per-thread node counters.** One slot per thread, each thread writing only
  its own with a Relaxed store inside `check_signals`. Display and node-limit
  paths sum the slots. No shared counter, no cross-core contention on the hot
  path.

- **Both protocols.** UCI `Threads` and XBoard `cores` drive the same pool,
  which lives in `protocols/smp.rs` and is shared between them.

- Helpers run silent and skip soft time management; main alone decides when to
  stop starting iterations. They honor the shared hard cap and the global stop
  flag like everyone else.

## Results

8.0+0.08s, 384MB:

Threads=2     `+103.5 ± 20.9`    [0, 5] passed   https://asylum.red/test/5250/
Threads=4     `+164.7 ± 24.5`    [0, 5] passed   https://asylum.red/test/5251/
Threads=8     `+263.9 ± 32.9`    [0, 5] passed  https://asylum.red/test/5253/
Threads=16   `+257.8 ± 32.4`    [0, 5] passed   https://asylum.red/test/5254/
Threads=24   `+307.8 ± 35.0`    [0, 5] passed   https://asylum.red/test/5256/
Threads=32   `+296.3 ± 37.2`    [0, 5] passed   https://asylum.red/test/5255/

8T  vs 4T   `+76.42 ± 18.01`   [0, 5] passed   https://asylum.red/test/5266/
16T vs 8T  `+52.06 ± 14.28`   [0, 5] passed   https://asylum.red/test/5267/

1T vs 1T (base)  `-0.53 ± 2.14` [-4.50, 0.50] passed https://asylum.red/test/5274/