### PR TITLE
Pool the correction-history tables, don't sum them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.27"
+version = "0.5.28"
 dependencies = [
  "atomic-wait",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.27"
+version = "0.5.28"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -329,10 +329,17 @@ impl History {
         *entry = (e + bonus - e * bonus.abs() / 16384).clamp(-16384, 16384) as i16;
     }
 
-    /// Blended correction: pawn structure + minor and major piece placement.
+    /// Blended correction. Pawn structure anchors; minor and major placement refine.
     ///
-    /// Pawn correction is at full weight; minor and major are each scaled by
-    /// their own `weight / 256` so the tuner can dial them independently.
+    /// The tables are estimates of one number: the gap between static eval and
+    /// what search found, each keyed on a different read of the position. They
+    /// correlate hard. A position that fools one usually fools the rest the same
+    /// way, so summing counts that shared error once per table and the correction
+    /// balloons the instant another joins. Average instead.
+    ///
+    /// Pawn stays whole; the placement tables fold into a weight-normalized pool,
+    /// so the pool's size holds no matter how many feed it. The weights are ratios,
+    /// not magnitudes: normalization cancels their scale and only the split survives.
     #[inline(always)]
     pub fn correction(
         &self,
@@ -355,7 +362,8 @@ impl History {
             record_read(Table::Major, major);
         }
 
-        pawn + minor * minor_weight / CORRECTION_WEIGHT_SCALE + major * major_weight / CORRECTION_WEIGHT_SCALE
+        let refine = (minor * minor_weight + major * major_weight) / (minor_weight + major_weight);
+        pawn + refine
     }
 
     #[inline(always)]


### PR DESCRIPTION
The correction-history tables each estimate the same eval error from a different key,
and the keys correlate: summing counts the shared error once per table,
so the blend overshoots the moment another table joins.

Replace the sum with a weight-normalized pool, `Σ wᵢeᵢ / Σ wᵢ`.
Pawn anchors, placement refines, and the aggregate stays bounded no matter how
many tables feed it. A new table reshapes the blend now instead of inflating it,
and the weights become ratios rather than absolute scales.

Behavior-equivalent to the old sum at the current weights.

```
Elo   | -0.28 +- 2.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.29 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 34890 W: 9970 L: 9998 D: 14922
Penta | [956, 4153, 7197, 4241, 898]
```
https://asylum.red/test/5351/