### PR TITLE
Threat-aware LMR

### DIFF
--- a/src/core/board/mod.rs
+++ b/src/core/board/mod.rs
@@ -592,6 +592,30 @@ impl Position {
         Bitboard((sliders | leapers).extract::<0>()) | self.pawn_attacks(color)
     }
 
+    /// Enemy pieces this quiet move newly threatens: the moved piece on `to`
+    /// attacking an enemy worth strictly more than itself: a knight or bishop
+    /// onto a rook or queen, a rook onto a queen, a pawn onto anything but a pawn.
+    /// Sliders subtract the from-square attacks, so sliding along a line already
+    /// raked isn't a fresh threat; a leaper lands on all-new squares and needs no
+    /// guard. Queen and king out-rank nothing worth the bonus.
+    #[inline]
+    pub fn new_threats(&self, pt: PieceType, from: Square, to: Square) -> Bitboard {
+        let them = self.side_bb[self.stm.opposite()];
+        let rq = (self.role_bb[PieceType::Rook] | self.role_bb[PieceType::Queen]) & them;
+        let q = self.role_bb[PieceType::Queen] & them;
+
+        match pt {
+            PieceType::Pawn => {
+                let bigger = ((self.role_bb[PieceType::Knight] | self.role_bb[PieceType::Bishop]) & them) | rq;
+                bitboard::atk_pawn(to, self.stm) & bigger
+            },
+            PieceType::Knight => bitboard::atk_knight(to) & rq,
+            PieceType::Bishop => Bitboard(bitboard::atk_bishop(to, self.occ).0 & !bitboard::atk_bishop(from, self.occ).0) & rq,
+            PieceType::Rook => Bitboard(bitboard::atk_rook(to, self.occ).0 & !bitboard::atk_rook(from, self.occ).0) & q,
+            _ => Bitboard(0),
+        }
+    }
+
     /// Can any pawn of `color` legally capture en passant on `ep_sq`?
     #[inline]
     pub fn can_capture_ep(&self, ep_sq: Square, color: Color) -> bool {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1296,6 +1296,10 @@ impl Worker<'_> {
                         r -= killer_lmr_bonus();
                     }
 
+                    // A quiet that newly attacks a bigger piece is tactically live,
+                    // like a check; reduce it less so the threat gets a real search.
+                    r -= self.pos.new_threats(pt, mv.from(), mv.to()).popcount() as i32 * threat_lmr_bonus();
+
                     let max_r = (depth - lmr_retained()) * LMR_SCALE;
 
                     (r - hist / lmr_hist_div()).clamp(0, max_r) / LMR_SCALE

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -311,7 +311,7 @@ search_params! {
         T (lmr_hist_div,        8,   1,   24),
         T (killer_lmr_bonus, 1024,  64),
         T (check_lmr_bonus,     1,   1,    3),
-        T (threat_lmr_bonus,  512,   0),
+        T (threat_lmr_bonus, 1024,   0),
         NT(lmr_retained,        1),
 
         //                default   min  max  step

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -311,6 +311,7 @@ search_params! {
         T (lmr_hist_div,        8,   1,   24),
         T (killer_lmr_bonus, 1024,  64),
         T (check_lmr_bonus,     1,   1,    3),
+        T (threat_lmr_bonus,  512,   0),
         NT(lmr_retained,        1),
 
         //                default   min  max  step


### PR DESCRIPTION
```
Elo   | 3.83 +- 3.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.47, 2.91) [0.00, 5.00]
Games | N: 22394 W: 6574 L: 6327 D: 9493
Penta | [575, 2659, 4570, 2730, 663]
```
https://asylum.red/test/5366/

```
Elo   | 3.63 +- 2.91 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.47, 2.91) [0.00, 5.00]
Games | N: 20966 W: 5589 L: 5370 D: 10007
Penta | [335, 2528, 4583, 2657, 380]
```
https://asylum.red/test/5367/