### PR TITLE
Quadratic RFP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.32"
+version = "0.5.34"
 dependencies = [
  "atomic-wait",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.32"
+version = "0.5.34"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]

--- a/src/core/defs.rs
+++ b/src/core/defs.rs
@@ -359,6 +359,12 @@ pub fn draw_score(nodes: u64) -> i32 {
     (nodes & 0x7) as i32 - 3
 }
 
+/// Whether `score` is a forced mate rather than a normal evaluation.
+#[inline]
+pub fn is_mate(score: i32) -> bool {
+    score.abs() > MATE_BOUND
+}
+
 /// Let chess types serve as array indices directly:
 /// `table[Color::White]`, `scores[PieceType::Knight]`, `board[Square::E4]`.
 /// Bounds-checked in debug builds: compiles to bare pointer math in release.

--- a/src/core/primitives.rs
+++ b/src/core/primitives.rs
@@ -209,6 +209,7 @@ impl Bitboard {
         }
     }
 }
+
 impl Square {
     /// Creates a [`Square`] from a raw index.
     ///

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -36,7 +36,7 @@ pub use crate::core::defs::Protocol;
 use crate::{
     core::{
         board::Position,
-        defs::{INF, MATE, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square, draw_score},
+        defs::{INF, MATE, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square, draw_score, is_mate},
         moves::Move,
     },
     engine::{
@@ -1030,9 +1030,15 @@ impl Worker<'_> {
         if !in_check
             && !N::PV
             && depth <= rfp_depth()
-            && static_eval - rfp_margin() * depth >= beta
+            && !is_mate(beta)
         {
-            return Ok(static_eval);
+            let margin = rfp_base_margin()
+                + rfp_margin() * depth
+                + rfp_quad_margin() * depth * depth;
+
+            if static_eval - margin >= beta {
+                return Ok(static_eval);
+            }
         }
 
         // ── Razoring (~17 Elo) ──

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -277,9 +277,11 @@ search_params! {
         NT(razoring_depth,    3),
         T (razoring_margin, 300,  50),
 
-        //         default  min  max  step
-        NT(rfp_depth,    8),
-        T (rfp_margin,  45,  15),
+        //              default  min  max  step
+        NT(rfp_depth,        12),
+        T (rfp_margin,       40,  15),
+        T (rfp_base_margin,  35),
+        T (rfp_quad_margin,   3),
 
         //                  default min   max  step
         T (nmp_base_r,            3,  1,    6),


### PR DESCRIPTION
```
Elo   | 10.24 +- 6.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.47, 2.91) [0.00, 5.00]
Games | N: 5702 W: 1738 L: 1570 D: 2394
Penta | [148, 624, 1167, 736, 176]
```
https://asylum.red/test/5421/

```
Elo   | 7.87 +- 5.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.47, 2.91) [0.00, 5.00]
Games | N: 6930 W: 1904 L: 1747 D: 3279
Penta | [101, 807, 1546, 856, 155]
```
https://asylum.red/test/5422/