### PR TITLE
Blend the RFP return score, don't just yield static eval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.34"
+version = "0.5.35"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1037,7 +1037,7 @@ impl Worker<'_> {
                 + rfp_quad_margin() * depth * depth;
 
             if static_eval - margin >= beta {
-                return Ok(static_eval);
+                return Ok((static_eval + beta) / 2);
             }
         }
 


### PR DESCRIPTION
```
Elo   | 4.85 +- 3.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.47, 2.91) [0.00, 5.00]
Games | N: 15888 W: 4754 L: 4532 D: 6602
Penta | [452, 1876, 3143, 1944, 529]
```
https://asylum.red/test/5427/

```
Elo   | 8.29 +- 5.30 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.47, 2.91) [0.00, 5.00]
Games | N: 6662 W: 1841 L: 1682 D: 3139
Penta | [114, 776, 1425, 869, 147]
```
https://asylum.red/test/5428/