### PR TITLE
Fail-high-count LMR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.34"
+version = "0.5.35"
 dependencies = [
  "atomic-wait",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.5.35"
+version = "0.5.36"
 dependencies = [
  "atomic-wait",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.5.35"
+version = "0.5.36"
 license = "AGPL-3.0"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -152,7 +152,7 @@ pub struct Searcher<'cfg> {
 pub struct Worker<'h> {
     pub pos: Position,
     pub accumulator: Vi16x8,
-    pub stack: Box<[Stack; MAX_PLY + 1]>,
+    pub stack: Box<[Stack; MAX_PLY + 2]>,
     pub history: &'h mut History,
     /// Per-search pawn-structure cache, keyed on the incremental `pawn_key`.
     pub pawn_cache: PawnCache,
@@ -263,6 +263,8 @@ pub struct Stack {
     pub moved_to: Square,
     pub static_eval: i32,
     pub is_null: bool,
+    /// Beta cutoffs among this node's children.
+    pub cutoff_count: i32,
 }
 
 /// Search was cut short: time, node limit, or external stop signal.
@@ -415,6 +417,7 @@ impl Default for Stack {
             moved_to: Square(0),
             static_eval: tt::SCORE_NONE,
             is_null: false,
+            cutoff_count: 0,
         }
     }
 }
@@ -477,7 +480,7 @@ impl<'cfg> Searcher<'cfg> {
         let mut worker = Worker {
             pos: self.root_pos,
             accumulator: root_acc,
-            stack: vec![Stack::default(); MAX_PLY + 1]
+            stack: vec![Stack::default(); MAX_PLY + 2]
                 .into_boxed_slice()
                 .try_into()
                 .unwrap_or_else(|_| unreachable!()),
@@ -905,6 +908,10 @@ impl Worker<'_> {
             return Ok(self.evaluate());
         }
 
+        // Clear the grandchild fail-high counter; our own [ply + 1], read in LMR,
+        // was cleared by the parent's reset two plies up.
+        self.stack[ply + 2].cutoff_count = 0;
+
         // ── Mate Distance Pruning ──
         // Scores are bounded; no line from here can find mate faster than
         // MATE - ply plies, and we can't be mated before -MATE + ply.
@@ -1313,6 +1320,10 @@ impl Worker<'_> {
                     // like a check; reduce it less so the threat gets a real search.
                     r -= self.pos.new_threats(pt, mv.from(), mv.to()).popcount() as i32 * threat_lmr_bonus();
 
+                    // Fail-highs are piling up at this depth; the late quiets here are
+                    // unlikely to be the move, so reduce them harder.
+                    r += fhc_lmr_malus() * (self.stack[ply + 1].cutoff_count > 2) as i32;
+
                     let max_r = (depth - lmr_retained()) * LMR_SCALE;
 
                     (r - hist / lmr_hist_div()).clamp(0, max_r) / LMR_SCALE
@@ -1327,6 +1338,8 @@ impl Worker<'_> {
                 self.search_move::<N>(searcher, mv, depth, &mut res, beta, ply, None, Some(mv) == pv_move, reduction)?;
 
                 if likely(res.alpha >= beta) {
+                    self.stack[ply].cutoff_count += 1;
+
                     #[cfg(feature = "mvpstats")]
                     {
                         use crate::engine::mvpstats::{CutoffKind, record_cutoff};

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -314,6 +314,7 @@ search_params! {
         T (killer_lmr_bonus, 1024,  64),
         T (check_lmr_bonus,     1,   1,    3),
         T (threat_lmr_bonus, 1024,   0),
+        T (fhc_lmr_malus,     512,   0),
         NT(lmr_retained,        1),
 
         //                default   min  max  step


### PR DESCRIPTION
```
Elo   | 3.32 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.09 (-2.47, 2.91) [0.00, 5.00]
Games | N: 32478 W: 9740 L: 9430 D: 13308
Penta | [939, 3786, 6533, 3988, 993]
```
https://asylum.red/test/5440/

```
Elo   | 7.16 +- 4.71 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.04 (-2.47, 2.91) [0.00, 5.00]
Games | N: 8252 W: 2299 L: 2129 D: 3824
Penta | [157, 900, 1859, 1036, 174]
```
https://asylum.red/test/5441/