### PR TITLE
RFP TT adjusted eval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "atomic-wait",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soul"
-version = "0.6.1"
-license = "AGPL-3.0"
+version = "0.6.2"
+license = "AGPL-3.0-or-later"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]
 description = "A modern alpha-beta chess engine, featuring Hand-Crafted Evaluation with SIMD acceleration."

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -940,7 +940,7 @@ impl Worker<'_> {
         // If a previous search already explored it to sufficient depth,
         // we can reuse its result and skip the entire subtree.
         // This is what makes iterative deepening fast: earlier iterations populate the table for later ones.
-        let (tt_move, tt_pv, tt_eval) =
+        let (tt_move, tt_pv, tt_eval, tt_score, tt_bound) =
             if let Some((mv, score, depth_stored, bound, pv, eval)) = searcher.tt.probe(self.pos.hash, ply) {
                 // Hash collisions can inject moves from unrelated positions.
                 // Full pseudo-legality check rejects garbage before it reaches
@@ -957,9 +957,9 @@ impl Worker<'_> {
                 }
 
                 let tt_move = if valid && !mv.is_null() { Some(mv) } else { None };
-                (tt_move, pv, Some(eval))
+                (tt_move, pv, Some(eval), score, bound)
             } else {
-                (None, false, None)
+                (None, false, None, tt::SCORE_NONE, tt::BOUND_NONE)
             };
 
         // ── TT Move Ordering (~56 Elo) ──
@@ -1029,6 +1029,19 @@ impl Worker<'_> {
             false
         };
 
+        // ── TT-Adjusted Eval ──
+        // A bounded TT score sharpens static eval when its bound backs the side
+        // it sits on: a lower bound above us means the truth is higher still,
+        // an upper bound below means lower still.
+        let tt_adjusted_eval = if tt_bound != tt::BOUND_NONE
+            && !is_mate(tt_score)
+            && tt_bound != (if tt_score > static_eval { tt::BOUND_UPPER } else { tt::BOUND_LOWER })
+        {
+            tt_score
+        } else {
+            static_eval
+        };
+
         // ── Reverse Futility Pruning (~52 Elo) ──
         // Position is already so good that even after subtracting a generous
         // margin, we're still above beta. The opponent wouldn't have let us
@@ -1043,8 +1056,8 @@ impl Worker<'_> {
                 + rfp_margin() * depth
                 + rfp_quad_margin() * depth * depth;
 
-            if static_eval - margin >= beta {
-                return Ok((static_eval + beta) / 2);
+            if tt_adjusted_eval - margin >= beta {
+                return Ok((tt_adjusted_eval + beta) / 2);
             }
         }
 


### PR DESCRIPTION
```
Elo   | 6.69 +- 4.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.47, 2.91) [0.00, 5.00]
Games | N: 10018 W: 3039 L: 2846 D: 4133
Penta | [275, 1162, 1975, 1289, 308]
```
https://asylum.red/test/5509/

```
Elo   | 10.62 +- 6.02 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.03 (-2.47, 2.91) [0.00, 5.00]
Games | N: 5140 W: 1458 L: 1301 D: 2381
Penta | [95, 559, 1121, 684, 111]
```
https://asylum.red/test/5510/