### PR TITLE
NMP TT adjusted eval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soul"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "atomic-wait",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soul"
-version = "0.6.2"
+version = "0.6.3"
 license = "AGPL-3.0-or-later"
 readme = "README.md"
 authors = ["Aethdv (aethrdv@gmail.com)"]

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1085,10 +1085,10 @@ impl Worker<'_> {
             && !N::PV
             && !self.stack[ply].is_null
             && !self.is_nmp_verif
-            && static_eval >= beta
+            && tt_adjusted_eval >= beta
             && self.pos.has_non_pawn_material(self.pos.stm)
         {
-            let eval_r = ((static_eval - beta) / nmp_eval_divisor()).min(nmp_eval_max());
+            let eval_r = ((tt_adjusted_eval - beta) / nmp_eval_divisor()).min(nmp_eval_max());
             let r = nmp_base_r() + depth / nmp_depth_divisor() + eval_r;
 
             self.stack[ply].moved_pt = PieceType::None;


### PR DESCRIPTION
```
Elo   | 5.79 +- 4.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.47, 2.91) [0.00, 5.00]
Games | N: 12172 W: 3596 L: 3393 D: 5183
Penta | [331, 1373, 2506, 1514, 362]
```
https://asylum.red/test/5512/

```
Elo   | 13.82 +- 6.99 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.07 (-2.47, 2.91) [0.00, 5.00]
Games | N: 3900 W: 1110 L: 955 D: 1835
Penta | [68, 424, 839, 523, 96]
```
https://asylum.red/test/5513/