### PR TITLE
Pin-aware SEE

### DIFF
--- a/src/core/board/attacks.rs
+++ b/src/core/board/attacks.rs
@@ -151,3 +151,35 @@ pub fn pinned_pieces(pos: &Position, color: Color) -> Bitboard {
 
     pinned
 }
+
+/// Both colors' king-pinned pieces and their king squares. A pin is one fact, a
+/// piece tied to the line through its king, and it binds that piece the same way
+/// whether legality asks if a move leaves the line or SEE asks if a recapture
+/// would. So the position is scanned once here, and both read the one answer.
+#[derive(Clone, Copy)]
+pub struct Pins {
+    pinned: [Bitboard; 2],
+    king_sq: [Square; 2],
+}
+
+impl Pins {
+    #[inline]
+    pub fn new(pos: &Position) -> Self {
+        Self {
+            pinned: [pinned_pieces(pos, Color::White), pinned_pieces(pos, Color::Black)],
+            king_sq: [pos.pieces(PieceType::King, Color::White).lsb(), pos.pieces(PieceType::King, Color::Black).lsb()],
+        }
+    }
+
+    /// Pieces of `color` pinned to their own king.
+    #[inline]
+    pub fn blockers(&self, color: Color) -> Bitboard {
+        self.pinned[color]
+    }
+
+    /// `color`'s king square.
+    #[inline]
+    pub fn king(&self, color: Color) -> Square {
+        self.king_sq[color]
+    }
+}

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -24,6 +24,7 @@ use crate::{
         board::{
             B_OO_EMPTY, B_OOO_EMPTY, BLACK_OO, BLACK_OOO, CASTLE_B_KS, CASTLE_B_KS_CHECK, CASTLE_B_QS, CASTLE_B_QS_CHECK,
             CASTLE_W_KS, CASTLE_W_KS_CHECK, CASTLE_W_QS, CASTLE_W_QS_CHECK, Position, W_OO_EMPTY, W_OOO_EMPTY, WHITE_OO, WHITE_OOO,
+            attacks::Pins,
             bitboard::{atk_bishop, atk_king, atk_knight, atk_pawn, atk_rook},
         },
         defs::{Bitboard, Color, MAX_MOVES, MoveScore, NOT_A, NOT_H, PieceType, RANK_1, RANK_3, RANK_6, RANK_8, Square},
@@ -33,7 +34,7 @@ use crate::{
     engine::{
         history::{ContContext, History},
         search::SearchConfig,
-        see::see_ge,
+        see::see_ge_with,
     },
 };
 
@@ -81,6 +82,8 @@ pub struct MovePicker {
     mvvlva_a: [i32; 8],
     mvvlva_ep: i32,
     capt_hist_divisor: i32,
+    /// The node's pins, so the good/bad split's SEE calls don't each rescan.
+    pins: Pins,
     killers: [Move; 2],
     threats: Bitboard,
     cont1: ContContext,
@@ -110,6 +113,7 @@ impl MovePicker {
     pub fn new(
         hash_move: Option<Move>,
         cfg: &SearchConfig,
+        pins: Pins,
         killers: [Move; 2],
         threats: Bitboard,
         cont1: ContContext,
@@ -127,6 +131,7 @@ impl MovePicker {
             mvvlva_a: cfg.mvvlva_a,
             mvvlva_ep: cfg.search_params.mvvlva_ep,
             capt_hist_divisor: cfg.search_params.capt_hist_divisor,
+            pins,
             killers,
             threats,
             cont1,
@@ -142,7 +147,7 @@ impl MovePicker {
     }
 
     #[inline]
-    pub fn new_qsearch(hash_move: Option<Move>, cfg: &SearchConfig, in_check: bool) -> Self {
+    pub fn new_qsearch(hash_move: Option<Move>, cfg: &SearchConfig, pins: Pins, in_check: bool) -> Self {
         Self {
             stage: Stage::Hash,
             hash_move,
@@ -154,6 +159,7 @@ impl MovePicker {
             mvvlva_a: cfg.mvvlva_a,
             mvvlva_ep: cfg.search_params.mvvlva_ep,
             capt_hist_divisor: cfg.search_params.capt_hist_divisor,
+            pins,
             killers: [Move::null(); 2],
             threats: Bitboard(0),
             cont1: ContContext::default(),
@@ -241,7 +247,7 @@ impl MovePicker {
                         // SEE >= 0, so it's good without the exchange walk; only material-losing
                         // captures are ambiguous enough to need SEE. The common cutoff-causing
                         // captures sort to the front and skip it entirely.
-                        if victim_val < attacker_val && !see_ge(board, mv, -self.good_capture_margin) {
+                        if victim_val < attacker_val && !see_ge_with(board, mv, -self.good_capture_margin, &self.pins) {
                             // SAFETY: count + bad_count <= total moves <= MAX_MOVES, so the park
                             // slot MAX_MOVES-1-bad_count is always >= count, never aliasing the
                             // active region [0, count) nor the quiets that later fill it.

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -35,7 +35,7 @@ use std::{
 pub use crate::core::defs::Protocol;
 use crate::{
     core::{
-        board::Position,
+        board::{Position, attacks::Pins},
         defs::{INF, MATE, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square, draw_score, is_mate, is_win},
         moves::Move,
     },
@@ -45,7 +45,7 @@ use crate::{
         movegen::{gen_legal_moves, is_legal, is_pseudo_legal},
         movepicker::MovePicker,
         search_params::*,
-        see::see_ge,
+        see::see_ge_with,
         tm::TimeManager,
         tt,
         tt::TranspositionTable,
@@ -1160,6 +1160,9 @@ impl Worker<'_> {
             }
         }
 
+        // One pin scan for the whole node: legality and every SEE read it.
+        let pins = Pins::new(&self.pos);
+
         // ── ProbCut (~4 Elo) ──
         // A capture that clears a raised beta (beta + margin) under a shallow search
         // would almost surely clear plain beta at full depth, so the node is a
@@ -1171,10 +1174,10 @@ impl Worker<'_> {
 
             let stm = self.pos.stm;
             let opp = stm.opposite();
-            let ksq = self.pos.pieces(PieceType::King, stm).lsb();
-            let pinned = self.pos.king_blockers();
+            let ksq = pins.king(stm);
+            let pinned = pins.blockers(stm);
 
-            let mut picker = MovePicker::new_qsearch(None, searcher.cfg, false);
+            let mut picker = MovePicker::new_qsearch(None, searcher.cfg, pins, false);
 
             while let Some(mv) = picker.next(&self.pos, self.history) {
                 if !is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
@@ -1183,7 +1186,7 @@ impl Worker<'_> {
 
                 // The capture must win enough material to plausibly reach the
                 // raised beta from here; a smaller swing can't clear it.
-                if !see_ge(&self.pos, mv, probcut_beta - static_eval) {
+                if !see_ge_with(&self.pos, mv, probcut_beta - static_eval, &pins) {
                     continue;
                 }
 
@@ -1258,8 +1261,8 @@ impl Worker<'_> {
             let stm = self.pos.stm;
             let opp = stm.opposite();
             let threats = self.pos.threats(opp);
-            let ksq = self.pos.pieces(PieceType::King, stm).lsb();
-            let pinned = self.pos.king_blockers();
+            let ksq = pins.king(stm);
+            let pinned = pins.blockers(stm);
 
             // Track searched quiets and captures to penalize them if a later move causes a cutoff.
             self.stack[ply].quiet_count = 0;
@@ -1288,7 +1291,7 @@ impl Worker<'_> {
             };
 
             // Interior: staged move generation via MovePicker.
-            let mut picker = MovePicker::new(hash_move, searcher.cfg, self.stack[ply].killers, threats, cont1, cont2, cont4);
+            let mut picker = MovePicker::new(hash_move, searcher.cfg, pins, self.stack[ply].killers, threats, cont1, cont2, cont4);
             while let Some(mv) = picker.next(&self.pos, self.history) {
                 if !is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
                     continue;
@@ -1397,7 +1400,7 @@ impl Worker<'_> {
                     let margin =
                         if mv.is_capture() { -sp.see_capture_margin * depth } else { -sp.see_quiet_margin * depth * depth };
 
-                    if !see_ge(&self.pos, mv, margin) {
+                    if !see_ge_with(&self.pos, mv, margin, &pins) {
                         continue;
                     }
                 }
@@ -1945,10 +1948,11 @@ impl Worker<'_> {
         let mut moves_made = 0;
         let mut best_move = Move::null();
 
-        let ksq = self.pos.pieces(PieceType::King, stm).lsb();
-        let pinned = self.pos.king_blockers();
+        let pins = Pins::new(&self.pos);
+        let ksq = pins.king(stm);
+        let pinned = pins.blockers(stm);
 
-        let mut picker = MovePicker::new_qsearch(qs_tt_move, searcher.cfg, in_check);
+        let mut picker = MovePicker::new_qsearch(qs_tt_move, searcher.cfg, pins, in_check);
 
         let recapture_only = !in_check && qs_ply >= sp.qs_recapture_ply;
 
@@ -1974,7 +1978,7 @@ impl Worker<'_> {
             // Skip captures whose destination-square trade loses material
             // for us. Disabled in check because evasions are forced and
             // the only legal reply is often a losing defensive capture.
-            if !in_check && !see_ge(&self.pos, mv, 0) {
+            if !in_check && !see_ge_with(&self.pos, mv, 0, &pins) {
                 continue;
             }
 

--- a/src/engine/see.rs
+++ b/src/engine/see.rs
@@ -19,7 +19,7 @@ use crate::{
     core::{
         board::{
             Position,
-            attacks::{all_attackers_to, pinned_pieces},
+            attacks::{Pins, all_attackers_to},
             bitboard::{atk_bishop, atk_rook, line_bb},
         },
         defs::{Bitboard, Color, PieceType, Square},
@@ -42,13 +42,23 @@ const SEE_VALUE: [i32; 8] = {
 /// Is the static exchange on `mv`'s destination square at least
 /// `threshold` centipawns for the side making `mv`?
 ///
+/// Scans the pins itself, for a one-off call. A loop of exchanges at one
+/// position should share a single [`Pins`] through [`see_ge_with`] instead.
+#[must_use]
+pub fn see_ge(pos: &Position, mv: Move, threshold: i32) -> bool {
+    see_ge_with(pos, mv, threshold, &Pins::new(pos))
+}
+
+/// [`see_ge`] handed a pin scan to reuse, so a loop of exchanges at one
+/// position pays for it once.
+///
 /// Correctly models en passant (the victim pawn lives on `to ^ 8`),
 /// promotion (the pawn transforms into the promoted piece for the rest
 /// of the trade, and the side earns the `promo − pawn` upgrade),
 /// castling (materially neutral; legality already guaranteed by
 /// movegen), and revealed slider x-rays through vacated squares.
 #[must_use]
-pub fn see_ge(pos: &Position, mv: Move, threshold: i32) -> bool {
+pub fn see_ge_with(pos: &Position, mv: Move, threshold: i32, pins: &Pins) -> bool {
     // Castling is the special case the exchange loop would mishandle:
     // the king and the rook both land on movegen-verified-safe squares,
     // and no capture is involved. Material impact is zero, so any
@@ -104,8 +114,7 @@ pub fn see_ge(pos: &Position, mv: Move, threshold: i32) -> bool {
         occ ^= (to ^ 8).bitboard();
     }
 
-    // Past the early exits, so a trivial exchange skips the pin scan.
-    let excluded = pinned_excluded(pos, to);
+    let excluded = pin_excluded(pins, to);
     let mut attackers = all_attackers_to(pos, to, occ) & occ & !excluded;
 
     let diag = pos.role_bb[PieceType::Bishop] | pos.role_bb[PieceType::Queen];
@@ -197,26 +206,12 @@ fn lsb_of(bb: Bitboard) -> Option<Square> {
     if bb.is_empty() { None } else { Some(bb.lsb()) }
 }
 
-/// Pinned attackers that can't legally recapture on `to`.
-///
-/// A pinned piece moves only along its pin ray, so it can recapture on `to`
-/// only when `to` lies on that ray.
-///
-/// Pins are read once against the pre-exchange occupancy, so a pin the trade
-/// later breaks still excludes its piece. A known approximation.
-fn pinned_excluded(pos: &Position, to: Square) -> Bitboard {
-    let mut excluded = Bitboard(0);
-
-    for color in [Color::White, Color::Black] {
-        let pinned = pinned_pieces(pos, color);
-
-        if pinned.is_not_empty() {
-            let king_sq = pos.pieces(PieceType::King, color).lsb();
-            excluded |= pinned & !line_bb(king_sq, to);
-        }
-    }
-
-    excluded
+/// Pinned attackers that can't legally recapture on `to`: a pinned piece moves
+/// only along its pin ray, so it reaches `to` only when `to` lies on that ray.
+#[inline]
+fn pin_excluded(pins: &Pins, to: Square) -> Bitboard {
+    (pins.blockers(Color::White) & !line_bb(pins.king(Color::White), to))
+        | (pins.blockers(Color::Black) & !line_bb(pins.king(Color::Black), to))
 }
 
 #[cfg(test)]

--- a/src/engine/see.rs
+++ b/src/engine/see.rs
@@ -19,10 +19,10 @@ use crate::{
     core::{
         board::{
             Position,
-            attacks::all_attackers_to,
-            bitboard::{atk_bishop, atk_rook},
+            attacks::{all_attackers_to, pinned_pieces},
+            bitboard::{atk_bishop, atk_rook, line_bb},
         },
-        defs::{Bitboard, PieceType, Square},
+        defs::{Bitboard, Color, PieceType, Square},
         moves::Move,
     },
     engine::eval_params::MG_MATERIAL,
@@ -103,7 +103,10 @@ pub fn see_ge(pos: &Position, mv: Move, threshold: i32) -> bool {
     if mv.is_en_passant() {
         occ ^= (to ^ 8).bitboard();
     }
-    let mut attackers = all_attackers_to(pos, to, occ) & occ;
+
+    // Past the early exits, so a trivial exchange skips the pin scan.
+    let excluded = pinned_excluded(pos, to);
+    let mut attackers = all_attackers_to(pos, to, occ) & occ & !excluded;
 
     let diag = pos.role_bb[PieceType::Bishop] | pos.role_bb[PieceType::Queen];
     let orth = pos.role_bb[PieceType::Rook] | pos.role_bb[PieceType::Queen];
@@ -167,7 +170,7 @@ pub fn see_ge(pos: &Position, mv: Move, threshold: i32) -> bool {
             },
             _ => {},
         }
-        attackers &= occ;
+        attackers &= occ & !excluded;
 
         // Negamax flip: the next player's running deficit is this
         // attacker's value minus the previous player's deficit.
@@ -192,6 +195,28 @@ fn val(pt: PieceType) -> i32 {
 #[inline(always)]
 fn lsb_of(bb: Bitboard) -> Option<Square> {
     if bb.is_empty() { None } else { Some(bb.lsb()) }
+}
+
+/// Pinned attackers that can't legally recapture on `to`.
+///
+/// A pinned piece moves only along its pin ray, so it can recapture on `to`
+/// only when `to` lies on that ray.
+///
+/// Pins are read once against the pre-exchange occupancy, so a pin the trade
+/// later breaks still excludes its piece. A known approximation.
+fn pinned_excluded(pos: &Position, to: Square) -> Bitboard {
+    let mut excluded = Bitboard(0);
+
+    for color in [Color::White, Color::Black] {
+        let pinned = pinned_pieces(pos, color);
+
+        if pinned.is_not_empty() {
+            let king_sq = pos.pieces(PieceType::King, color).lsb();
+            excluded |= pinned & !line_bb(king_sq, to);
+        }
+    }
+
+    excluded
 }
 
 #[cfg(test)]
@@ -317,5 +342,11 @@ mod tests {
     fn capture_promotion_undefended() {
         // PxN with promotion: +N + (Q − P)
         assert_see("4n2k/3P4/8/8/8/8/8/4K3 w - - 0 1", "d7e8q", n() + q() - p());
+    }
+
+    #[test]
+    fn pinned_defender_cannot_recapture() {
+        // Nc4 guards e5 but is pinned to Ka6 by Be2, so RxP has no recapture
+        assert_see("8/8/k7/4p2R/2n5/8/4B3/6K1 w - - 0 1", "h5e5", p());
     }
 }


### PR DESCRIPTION
```
Elo   | 7.62 +- 5.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.47, 2.91) [0.00, 5.00]
Games | N: 8388 W: 2519 L: 2335 D: 3534
Penta | [227, 981, 1640, 1073, 273]
```
https://asylum.red/test/5580/

```
Elo   | 11.01 +- 6.29 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.47, 2.91) [0.00, 5.00]
Games | N: 4798 W: 1353 L: 1201 D: 2244
Penta | [83, 541, 1034, 623, 118]
```
https://asylum.red/test/5581/