### PR TITLE
Compose PVs in quiescence

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -999,7 +999,7 @@ impl Worker<'_> {
 
         // ── Mate Distance Pruning
         // Scores are bounded; no line from here can find mate faster than
-        // MATE - ply plies, and we can't be mated before -MATE + ply.
+        // MATE - (ply + 1) plies, and we can't be mated before -MATE + ply.
         // Tighten the search window to those limits. If the tightened
         // window collapses (a >= b), every achievable score in this
         // subtree already satisfies the bound; return a, the tightest
@@ -2076,6 +2076,12 @@ impl Worker<'_> {
                 best_move = mv;
 
                 if score > alpha {
+                    // The last plies of a line are searched here; without
+                    // the compose the PV stops at the negamax boundary and
+                    // a mate line is reported without its mating move.
+                    let (current_stack, next_stack) = self.stack.split_at_mut(ply + 1);
+                    current_stack[ply].pv.compose(mv, &next_stack[0].pv);
+
                     if score >= beta {
                         break;
                     }


### PR DESCRIPTION
The PV chain ended at the negamax/qsearch boundary: qsearch searched the tail of every line (quiet mating moves, captures, evasions) but never composed it into the PV, so the reported line stopped short of the mate it scored.
Compose on every alpha raise in the qsearch move loop, before the cutoff check, mirroring negamax's move loop, so mate lines run to the mating move.

```
Elo   | 1.11 +- 3.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.26 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 14394 W: 4047 L: 4001 D: 6346
Penta | [284, 1599, 3405, 1605, 304]
```
https://asylum.red/test/5884/

Bench: 5101185