### PR TITLE
Refuse the NMP cutoff on a mate-loss score

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -42,7 +42,7 @@ use crate::{
     core::{
         board::{Position, attacks::Pins, xorboard::XorBoard},
         defs::{
-            Bitboard, Color, INF, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square, draw_score, is_mate, is_win, mate_in, mated_in,
+            Bitboard, Color, INF, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square, draw_score, is_loss, is_mate, is_win, mate_in, mated_in,
         },
         moves::Move,
     },
@@ -1096,7 +1096,7 @@ impl Worker<'_> {
             self.stack[ply + 1].is_null = false;
 
             let score = -score?;
-            if score >= beta {
+            if score >= beta && !is_loss(score) {
                 let null_score = if is_win(score) { beta } else { score };
 
                 // ── Verification Search

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -42,7 +42,8 @@ use crate::{
     core::{
         board::{Position, attacks::Pins, xorboard::XorBoard},
         defs::{
-            Bitboard, Color, INF, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square, draw_score, is_loss, is_mate, is_win, mate_in, mated_in,
+            Bitboard, Color, INF, MATE_BOUND, MAX_DEPTH, MAX_PLY, PieceType, Square, draw_score, is_loss, is_mate, is_win, mate_in,
+            mated_in,
         },
         moves::Move,
     },


### PR DESCRIPTION
```
Elo   | 3.33 +- 4.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.29 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 7404 W: 2063 L: 1992 D: 3349
Penta | [135, 773, 1838, 798, 158]
```
https://asylum.red/test/6037/

Bench: 5355809