### PR TITLE
Reshape the TT probe result and validate its move lazily

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -56,7 +56,7 @@ use crate::{
         see::see_ge,
         tm::TimeManager,
         tt,
-        tt::{TranspositionTable, TtData},
+        tt::{TranspositionTable, TtData, TtMove},
         tui,
     },
     tools::perft::perft,
@@ -961,10 +961,12 @@ impl Worker<'_> {
         //
         // No probe during a singular verification: the entry here is the excluded move
         // itself, and its score is the very cutoff the verification exists to test.
-        let tt_probe = if excluded.is_null() { searcher.tt.probe(&self.pos, ply) } else { TtData::NONE };
+        let tt_probe = if excluded.is_null() { searcher.tt.probe(self.pos.hash, ply) } else { TtData::NONE };
+        let tt_move = tt_probe.mv(&self.pos);
 
+        // A collision invalidates the whole slot, not just the move it stored.
         #[rustfmt::skip]
-        if tt_probe.valid
+        if tt_move != TtMove::Collision
             && !N::PV
             && tt_probe.depth >= depth
             && tt::can_cutoff(tt_probe.bound, tt_probe.score, alpha, beta)
@@ -1183,7 +1185,7 @@ impl Worker<'_> {
         // No TT move means we are searching blind, and blind ordering does not
         // deserve full depth. The entry this search stores hands the next iteration
         // the move it was missing.
-        let depth = if depth >= sp.iir_depth && tt_probe.mv.is_none() { depth - sp.iir_reduction } else { depth };
+        let depth = if depth >= sp.iir_depth && tt_move.get().is_none() { depth - sp.iir_reduction } else { depth };
 
         // ──────── Move loop ────────
 
@@ -1237,7 +1239,7 @@ impl Worker<'_> {
             let (cont1, cont2, cont4) = cont_contexts(&self.stack[..], ply);
 
             let mut picker =
-                MovePicker::new(tt_probe.mv, searcher.cfg, pins, self.stack[ply].killers, threats, cont1, cont2, cont4);
+                MovePicker::new(tt_move.get(), searcher.cfg, pins, self.stack[ply].killers, threats, cont1, cont2, cont4);
 
             self.xb_enter(ply);
 
@@ -1384,7 +1386,7 @@ impl Worker<'_> {
                 if !N::ROOT
                     && !N::PV
                     && excluded.is_null()
-                    && Some(mv) == tt_probe.mv
+                    && Some(mv) == tt_move.get()
                     && depth >= sp.singext_min_depth
                     && tt_probe.depth >= depth - sp.singext_tt_depth
                     && tt_probe.bound != tt::Bound::Upper
@@ -1433,7 +1435,7 @@ impl Worker<'_> {
                     {
                         use crate::engine::mvpstats::{CutoffKind, record_cutoff};
 
-                        let kind = if Some(mv) == tt_probe.mv {
+                        let kind = if Some(mv) == tt_move.get() {
                             CutoffKind::Hash
                         } else if mv.is_capture() {
                             CutoffKind::Capture
@@ -1816,7 +1818,7 @@ impl Worker<'_> {
         // sequence for accurate PV reporting.
         //
         // Quiescence TT Move (~9 Elo)
-        let qs_tt = searcher.tt.probe(&self.pos, ply);
+        let qs_tt = searcher.tt.probe(self.pos.hash, ply);
         if !N::PV && tt::can_cutoff(qs_tt.bound, qs_tt.score, alpha, beta) {
             return Ok(qs_tt.score);
         }
@@ -1876,7 +1878,7 @@ impl Worker<'_> {
         let ksq = pins.king(stm);
         let pinned = pins.blockers(stm);
 
-        let mut picker = MovePicker::new_qsearch(qs_tt.mv, searcher.cfg, pins, in_check);
+        let mut picker = MovePicker::new_qsearch(qs_tt.mv(&self.pos).get(), searcher.cfg, pins, in_check);
 
         let recapture_only = !in_check && qs_ply >= sp.qs_recapture_ply;
 

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -50,13 +50,13 @@ use crate::{
     engine::{
         eval::{EvalParams, PawnCache, SharedFeatures, evaluate_generic, extract_phase},
         history::{self, ContContext, History, HistoryCaps},
-        movegen::{gen_legal_moves, is_legal, is_pseudo_legal},
+        movegen::{gen_legal_moves, is_legal},
         movepicker::MovePicker,
         search_params::*,
         see::see_ge,
         tm::TimeManager,
         tt,
-        tt::TranspositionTable,
+        tt::{TranspositionTable, TtData},
         tui,
     },
     tools::perft::perft,
@@ -961,25 +961,16 @@ impl Worker<'_> {
         //
         // No probe during a singular verification: the entry here is the excluded move
         // itself, and its score is the very cutoff the verification exists to test.
-        let tt_probe = if excluded.is_null() { searcher.tt.probe(self.pos.hash, ply) } else { None };
-        let (tt_move, tt_pv, tt_eval, tt_score, tt_bound, tt_depth) = if let Some(hit) = tt_probe {
-            // Guard against hash collisions: an illegal non-null move invalidates
-            // both the TT move and any cutoff. Null moves are valid, stored on fail-low.
-            let tt_move = if !hit.mv.is_null() && is_pseudo_legal(&self.pos, hit.mv) { Some(hit.mv) } else { None };
-            let valid = tt_move.is_some() || hit.mv.is_null();
+        let tt_probe = if excluded.is_null() { searcher.tt.probe(&self.pos, ply) } else { TtData::NONE };
 
-            #[rustfmt::skip]
-                if valid
-                    && !N::PV
-                    && hit.depth >= depth
-                    && tt::can_cutoff(hit.bound, hit.score, alpha, beta)
-                {
-                    return Ok(hit.score);
-                }
-            (tt_move, hit.pv, Some(hit.eval), hit.score, hit.bound, hit.depth)
-        } else {
-            (None, false, None, tt::SCORE_NONE, tt::Bound::None, 0)
-        };
+        #[rustfmt::skip]
+        if tt_probe.valid
+            && !N::PV
+            && tt_probe.depth >= depth
+            && tt::can_cutoff(tt_probe.bound, tt_probe.score, alpha, beta)
+        {
+            return Ok(tt_probe.score);
+        }
 
         let checkers = self.xb_checkers();
         let in_check = checkers.is_not_empty();
@@ -996,8 +987,8 @@ impl Worker<'_> {
         // the full evaluation; the stored sentinel (an in-check store) falls through.
         let raw_static_eval = if in_check {
             tt::SCORE_NONE
-        } else if let Some(eval) = tt_eval.filter(|&e| e != tt::SCORE_NONE) {
-            eval
+        } else if tt_probe.eval != tt::SCORE_NONE {
+            tt_probe.eval
         } else {
             self.evaluate()
         };
@@ -1028,7 +1019,11 @@ impl Worker<'_> {
 
         // ── TT-Clamped Eval
         // A mate score is a distance, not a valuation, so it never stands in for one.
-        let tt_clamped_eval = if is_mate(tt_score) { static_eval } else { tt::clamp_to_bound(tt_bound, tt_score, static_eval) };
+        let tt_clamped_eval = if is_mate(tt_probe.score) {
+            static_eval
+        } else {
+            tt::clamp_to_bound(tt_probe.bound, tt_probe.score, static_eval)
+        };
 
         // ── Reverse Futility Pruning (~52 Elo)
         // Position is already so good that even after subtracting a generous
@@ -1177,7 +1172,7 @@ impl Worker<'_> {
                 if value >= probcut_beta {
                     searcher
                         .tt
-                        .store(self.pos.hash, ply, probcut_depth, value, mv, tt::Bound::Lower, tt_pv, raw_static_eval);
+                        .store(self.pos.hash, ply, probcut_depth, value, mv, tt::Bound::Lower, tt_probe.pv, raw_static_eval);
 
                     return Ok(value);
                 }
@@ -1188,7 +1183,7 @@ impl Worker<'_> {
         // No TT move means we are searching blind, and blind ordering does not
         // deserve full depth. The entry this search stores hands the next iteration
         // the move it was missing.
-        let depth = if depth >= sp.iir_depth && tt_move.is_none() { depth - sp.iir_reduction } else { depth };
+        let depth = if depth >= sp.iir_depth && tt_probe.mv.is_none() { depth - sp.iir_reduction } else { depth };
 
         // ──────── Move loop ────────
 
@@ -1241,7 +1236,8 @@ impl Worker<'_> {
             // picker incorporate recent positional context into quiet ordering.
             let (cont1, cont2, cont4) = cont_contexts(&self.stack[..], ply);
 
-            let mut picker = MovePicker::new(tt_move, searcher.cfg, pins, self.stack[ply].killers, threats, cont1, cont2, cont4);
+            let mut picker =
+                MovePicker::new(tt_probe.mv, searcher.cfg, pins, self.stack[ply].killers, threats, cont1, cont2, cont4);
 
             self.xb_enter(ply);
 
@@ -1388,13 +1384,13 @@ impl Worker<'_> {
                 if !N::ROOT
                     && !N::PV
                     && excluded.is_null()
-                    && Some(mv) == tt_move
+                    && Some(mv) == tt_probe.mv
                     && depth >= sp.singext_min_depth
-                    && tt_depth >= depth - sp.singext_tt_depth
-                    && tt_bound != tt::Bound::Upper
-                    && !is_mate(tt_score)
+                    && tt_probe.depth >= depth - sp.singext_tt_depth
+                    && tt_probe.bound != tt::Bound::Upper
+                    && !is_mate(tt_probe.score)
                 {
-                    let sing_beta = (tt_score - depth * sp.singext_margin).max(-MATE_BOUND);
+                    let sing_beta = (tt_probe.score - depth * sp.singext_margin).max(-MATE_BOUND);
                     let sing_depth = (depth - 1) / 2;
 
                     // The verification recurses at this same ply and stomps the quiet
@@ -1437,7 +1433,7 @@ impl Worker<'_> {
                     {
                         use crate::engine::mvpstats::{CutoffKind, record_cutoff};
 
-                        let kind = if Some(mv) == tt_move {
+                        let kind = if Some(mv) == tt_probe.mv {
                             CutoffKind::Hash
                         } else if mv.is_capture() {
                             CutoffKind::Capture
@@ -1537,9 +1533,16 @@ impl Worker<'_> {
         // The verification searched this position with a move missing, so its
         // result is a lie about the real node. Keep it out of the table.
         if excluded.is_null() {
-            searcher
-                .tt
-                .store(self.pos.hash, ply, depth, res.best_eval, res.best_move, bound, N::PV || tt_pv, raw_static_eval);
+            searcher.tt.store(
+                self.pos.hash,
+                ply,
+                depth,
+                res.best_eval,
+                res.best_move,
+                bound,
+                N::PV || tt_probe.pv,
+                raw_static_eval,
+            );
         }
 
         // ── Correction History Update
@@ -1813,16 +1816,10 @@ impl Worker<'_> {
         // sequence for accurate PV reporting.
         //
         // Quiescence TT Move (~9 Elo)
-        let (qs_tt_move, qs_tt_pv, qs_tt_eval) = if let Some(hit) = searcher.tt.probe(self.pos.hash, ply) {
-            if !N::PV && tt::can_cutoff(hit.bound, hit.score, alpha, beta) {
-                return Ok(hit.score);
-            }
-
-            let mv = if !hit.mv.is_null() && is_pseudo_legal(&self.pos, hit.mv) { Some(hit.mv) } else { None };
-            (mv, hit.pv, Some(hit.eval))
-        } else {
-            (None, false, None)
-        };
+        let qs_tt = searcher.tt.probe(&self.pos, ply);
+        if !N::PV && tt::can_cutoff(qs_tt.bound, qs_tt.score, alpha, beta) {
+            return Ok(qs_tt.score);
+        }
 
         let checkers = self.xb_checkers();
         let in_check = checkers.is_not_empty();
@@ -1836,8 +1833,8 @@ impl Worker<'_> {
         // sentinel (an in-check store) falls through.
         let raw_eval = if in_check {
             tt::SCORE_NONE
-        } else if let Some(eval) = qs_tt_eval.filter(|&e| e != tt::SCORE_NONE) {
-            eval
+        } else if qs_tt.eval != tt::SCORE_NONE {
+            qs_tt.eval
         } else {
             self.evaluate()
         };
@@ -1879,7 +1876,7 @@ impl Worker<'_> {
         let ksq = pins.king(stm);
         let pinned = pins.blockers(stm);
 
-        let mut picker = MovePicker::new_qsearch(qs_tt_move, searcher.cfg, pins, in_check);
+        let mut picker = MovePicker::new_qsearch(qs_tt.mv, searcher.cfg, pins, in_check);
 
         let recapture_only = !in_check && qs_ply >= sp.qs_recapture_ply;
 
@@ -1960,7 +1957,7 @@ impl Worker<'_> {
 
         searcher
             .tt
-            .store_qs(self.pos.hash, ply, best_eval, best_move, bound, N::PV || qs_tt_pv, raw_eval);
+            .store_qs(self.pos.hash, ply, best_eval, best_move, bound, N::PV || qs_tt.pv, raw_eval);
 
         Ok(best_eval)
     }

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -136,24 +136,32 @@ struct Cluster {
     slots: [TtEntry; CLUSTER_SIZE],
 }
 
-/// What a slot matched, before the collision guard runs.
-#[derive(Clone, Copy)]
-struct TtHit {
-    mv: Move,
-    score: i32,
-    depth: i32,
-    bound: Bound,
-    pv: bool,
-    /// Raw static eval at store time, `SCORE_NONE` when the position was in check.
-    eval: i32,
+/// The three things a stored move can turn out to be.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TtMove {
+    /// The slot stored a null move, which a fail-low store does.
+    Null,
+    /// The stored move is pseudo-legal here.
+    Found(Move),
+    /// A non-null move that no piece on this board could make, so the whole slot
+    /// belongs to another position and its score proves nothing.
+    Collision,
 }
 
+impl TtMove {
+    #[inline(always)]
+    pub fn get(self) -> Option<Move> {
+        match self {
+            Self::Found(mv) => Some(mv),
+            Self::Null | Self::Collision => None,
+        }
+    }
+}
+
+/// What a probe hands back, already unfolded into search units.
 #[derive(Clone, Copy)]
 pub struct TtData {
-    /// The stored move once it survives the collision guard, None when absent or fake.
-    pub mv: Option<Move>,
-    /// Whether the entry may be trusted at all.
-    pub valid: bool,
+    mv: Move,
     pub pv: bool,
     /// Raw static eval at store time, `SCORE_NONE` when the position was in check.
     pub eval: i32,
@@ -164,20 +172,18 @@ pub struct TtData {
 
 impl TtData {
     /// No slot matched.
-    pub const NONE: Self =
-        Self { mv: None, valid: true, pv: false, eval: SCORE_NONE, score: SCORE_NONE, bound: Bound::None, depth: 0 };
+    pub const NONE: Self = Self { mv: Move::null(), pv: false, eval: SCORE_NONE, score: SCORE_NONE, bound: Bound::None, depth: 0 };
 
+    /// Runs the collision guard, a full pseudo-legality check. Bind it once per node,
+    /// and after the cutoff test: a probe that cuts never needs the move.
     #[inline(always)]
-    fn from_hit(hit: TtHit, pos: &Position) -> Self {
-        let mv = if !hit.mv.is_null() && is_pseudo_legal(pos, hit.mv) { Some(hit.mv) } else { None };
-        Self {
-            mv,
-            valid: mv.is_some() || hit.mv.is_null(),
-            pv: hit.pv,
-            eval: hit.eval,
-            score: hit.score,
-            bound: hit.bound,
-            depth: hit.depth,
+    pub fn mv(&self, pos: &Position) -> TtMove {
+        if self.mv.is_null() {
+            TtMove::Null
+        } else if is_pseudo_legal(pos, self.mv) {
+            TtMove::Found(self.mv)
+        } else {
+            TtMove::Collision
         }
     }
 }
@@ -225,7 +231,7 @@ impl TtEntry {
     /// pairs with the store's Release on `key`, the handshake that makes a matched
     /// key imply visible payload.
     #[inline(always)]
-    fn probe_read(&self, key16: u16, ply: usize) -> Option<TtHit> {
+    fn probe_read(&self, key16: u16, ply: usize) -> Option<TtData> {
         if self.key.load(Ordering::Acquire) != key16 {
             return None;
         }
@@ -235,7 +241,7 @@ impl TtEntry {
         if bound == Bound::None {
             return None;
         }
-        Some(TtHit {
+        Some(TtData {
             mv: Move::from_u16(self.mv.load(Ordering::Relaxed)),
             score: score_from_tt(i32::from(self.score.load(Ordering::Relaxed).cast_signed()), ply),
             depth: i32::from(packed_depth(packed)),
@@ -362,17 +368,13 @@ impl TranspositionTable {
     }
 
     #[inline(always)]
-    pub fn probe(&self, pos: &Position, ply: usize) -> TtData {
-        let key16 = verification_key(pos.hash);
-        match self
-            .cluster(self.index(pos.hash))
+    pub fn probe(&self, hash: u64, ply: usize) -> TtData {
+        let key16 = verification_key(hash);
+        self.cluster(self.index(hash))
             .slots
             .iter()
             .find_map(|slot| slot.probe_read(key16, ply))
-        {
-            Some(hit) => TtData::from_hit(hit, pos),
-            None => TtData::NONE,
-        }
+            .unwrap_or(TtData::NONE)
     }
 
     /// Insert or update this position.

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -21,12 +21,29 @@ use std::{
 
 use crate::{
     core::{
+        board::Position,
         defs::{score_from_tt, score_to_tt},
         moves::Move,
     },
+    engine::movegen::is_pseudo_legal,
     hugepages::{HugePages, PageKind},
     numa::NumaTopology,
 };
+
+/// No eval stored, which is what an in-check store leaves behind.
+/// Sits above MATE, so it can never be mistaken for a score.
+pub const SCORE_NONE: i32 = 32000;
+
+const CLUSTER_SIZE: usize = 3;
+
+/// Higher values evict stale entries faster.
+const AGE_FACTOR: i32 = 4;
+/// `age` is 5 bits; generation distance is read modulo 32.
+const AGE_MASK: u8 = 0x1F;
+
+const _: () = assert!(mem::size_of::<TtEntry>() == 10);
+const _: () = assert!(mem::size_of::<Cluster>() == 32);
+const _: () = assert!(mem::align_of::<Cluster>() == 32);
 
 /// What a stored score proves. Discriminants are the on-slot encoding, two bits of `packed`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
@@ -50,21 +67,6 @@ impl Bound {
         unsafe { mem::transmute((bits & 0x3) as u8) }
     }
 }
-
-/// No eval stored, which is what an in-check store leaves behind. Sits above MATE,
-/// so it can never be mistaken for a score, and inside i16 so it survives the slot.
-pub const SCORE_NONE: i32 = 32000;
-
-const _: () = assert!(mem::size_of::<TtEntry>() == 10);
-const _: () = assert!(mem::size_of::<Cluster>() == 32);
-const _: () = assert!(mem::align_of::<Cluster>() == 32);
-
-/// Higher values evict stale entries faster.
-const AGE_FACTOR: i32 = 4;
-/// `age` is 5 bits; generation distance is read modulo 32.
-const AGE_MASK: u8 = 0x1F;
-
-const CLUSTER_SIZE: usize = 3;
 
 /// An exact score always is. A lower bound (the position failed high when stored)
 /// only proves the truth is at least this high, so it cuts only once it clears
@@ -134,16 +136,50 @@ struct Cluster {
     slots: [TtEntry; CLUSTER_SIZE],
 }
 
-/// What a probe hands back, already unfolded into search units.
+/// What a slot matched, before the collision guard runs.
 #[derive(Clone, Copy)]
-pub struct TtHit {
-    pub mv: Move,
-    pub score: i32,
-    pub depth: i32,
-    pub bound: Bound,
+struct TtHit {
+    mv: Move,
+    score: i32,
+    depth: i32,
+    bound: Bound,
+    pv: bool,
+    /// Raw static eval at store time, `SCORE_NONE` when the position was in check.
+    eval: i32,
+}
+
+#[derive(Clone, Copy)]
+pub struct TtData {
+    /// The stored move once it survives the collision guard, None when absent or fake.
+    pub mv: Option<Move>,
+    /// Whether the entry may be trusted at all.
+    pub valid: bool,
     pub pv: bool,
     /// Raw static eval at store time, `SCORE_NONE` when the position was in check.
     pub eval: i32,
+    pub score: i32,
+    pub bound: Bound,
+    pub depth: i32,
+}
+
+impl TtData {
+    /// No slot matched.
+    pub const NONE: Self =
+        Self { mv: None, valid: true, pv: false, eval: SCORE_NONE, score: SCORE_NONE, bound: Bound::None, depth: 0 };
+
+    #[inline(always)]
+    fn from_hit(hit: TtHit, pos: &Position) -> Self {
+        let mv = if !hit.mv.is_null() && is_pseudo_legal(pos, hit.mv) { Some(hit.mv) } else { None };
+        Self {
+            mv,
+            valid: mv.is_some() || hit.mv.is_null(),
+            pv: hit.pv,
+            eval: hit.eval,
+            score: hit.score,
+            bound: hit.bound,
+            depth: hit.depth,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Default)]
@@ -169,11 +205,8 @@ const fn pack(depth: u8, bound: Bound, pv: u8, age: u8) -> u16 {
 }
 
 const fn packed_depth(packed: u16) -> u8 { (packed & 0xFF) as u8 }
-
 const fn packed_bound(packed: u16) -> Bound { Bound::from_bits(packed >> 8) }
-
 const fn packed_pv(packed: u16) -> u8 { ((packed >> 10) & 0x1) as u8 }
-
 const fn packed_age(packed: u16) -> u8 { ((packed >> 11) & 0x1F) as u8 }
 
 impl TtEntry {
@@ -329,9 +362,17 @@ impl TranspositionTable {
     }
 
     #[inline(always)]
-    pub fn probe(&self, hash: u64, ply: usize) -> Option<TtHit> {
-        let key16 = verification_key(hash);
-        self.cluster(self.index(hash)).slots.iter().find_map(|slot| slot.probe_read(key16, ply))
+    pub fn probe(&self, pos: &Position, ply: usize) -> TtData {
+        let key16 = verification_key(pos.hash);
+        match self
+            .cluster(self.index(pos.hash))
+            .slots
+            .iter()
+            .find_map(|slot| slot.probe_read(key16, ply))
+        {
+            Some(hit) => TtData::from_hit(hit, pos),
+            None => TtData::NONE,
+        }
     }
 
     /// Insert or update this position.


### PR DESCRIPTION
```
Elo   | -1.33 +- 2.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.26 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 37474 W: 10263 L: 10406 D: 16805
Penta | [714, 4215, 9022, 4072, 714]
```
https://asylum.red/test/6049/

Bench: 5355809