### PR TITLE
Refuse a QSearch cutoff from a collided slot

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1819,7 +1819,8 @@ impl Worker<'_> {
         //
         // Quiescence TT Move (~9 Elo)
         let qs_tt = searcher.tt.probe(self.pos.hash, ply);
-        if !N::PV && tt::can_cutoff(qs_tt.bound, qs_tt.score, alpha, beta) {
+        // The guard runs last so only a cutting probe pays for it.
+        if !N::PV && tt::can_cutoff(qs_tt.bound, qs_tt.score, alpha, beta) && qs_tt.mv(&self.pos) != TtMove::Collision {
             return Ok(qs_tt.score);
         }
 


### PR DESCRIPTION
```
Elo   | -0.11 +- 3.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.23 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 16244 W: 4434 L: 4439 D: 7371
Penta | [368, 1914, 3554, 1927, 359]
```
https://asylum.red/test/6050/

Bench: 5355809