### PR TITLE
Best move instability

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -469,6 +469,7 @@ impl<'cfg> Searcher<'cfg> {
         };
 
         let mut last_iter_elapsed = 0;
+        let mut bm_changes = 0.0;
 
         // ── Singular Bailout
         // Only one legal move. Slash the budget to 5% so we exit the depth
@@ -627,6 +628,22 @@ impl<'cfg> Searcher<'cfg> {
             };
 
             self.tm.set_score_factor(score_factor);
+
+            // ── Best-Move Instability TM
+            // Node effort and score swing both read a settled position as settled.
+            // Neither sees the top two moves trading places under a steady score,
+            // which is the position worth another iteration.
+            //
+            // Halving each iteration leaves the count reading recent churn rather
+            // than everything the search ever reconsidered.
+            if self.prev_pv.get(0).is_some_and(|prev| prev != self.root_moves[0].mv) {
+                bm_changes += 1.0;
+            }
+
+            let instability = 1.0 + f64::from(sp.bm_inst_scale) / 100.0 * bm_changes / self.cfg.threads as f64;
+            self.tm.set_bm_inst_factor(instability);
+            bm_changes *= 0.5;
+
             self.prev_pv = *self.root_moves[0].pv;
             self.prev_score = self.root_moves[0].score;
             self.print_info(depth, self.prev_score, &self.prev_pv);

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -173,6 +173,7 @@ search_params! {
         NT(bm_stab_base,   270),
         NT(bm_stab_scale,  220),
         NT(bm_stab_floor,   56),
+        T (bm_inst_scale,  220,  0),
 
         //                default  min   max  step
         NT(mvvlva_ep,         100,  60,  150),

--- a/src/engine/tm.rs
+++ b/src/engine/tm.rs
@@ -34,6 +34,7 @@ pub struct TimeManager {
     soft: Duration,
     base_soft: Duration,
     bm_stab: f64,
+    bm_inst: f64,
     score_factor: f64,
 }
 
@@ -50,7 +51,7 @@ impl TimeManager {
         params: &SearchParams,
     ) -> Self {
         let (soft, hard) = compute_budget(limits, stm, overhead, phase, game_ply, params);
-        Self { start, soft, hard, base_soft: soft, bm_stab: 1.0, score_factor: 1.0 }
+        Self { start, soft, hard, base_soft: soft, bm_stab: 1.0, bm_inst: 1.0, score_factor: 1.0 }
     }
 
     #[inline]
@@ -71,6 +72,14 @@ impl TimeManager {
         self.recompute_soft();
     }
 
+    /// A best move that keeps changing between iterations means the position is
+    /// still deciding itself, and the factor only ever stretches the budget.
+    #[inline]
+    pub fn set_bm_inst_factor(&mut self, factor: f64) {
+        self.bm_inst = factor;
+        self.recompute_soft();
+    }
+
     /// 1.0 is the no-op, and passing it is how a stretch from the previous
     /// iteration gets cleared.
     #[inline]
@@ -81,7 +90,7 @@ impl TimeManager {
 
     #[inline]
     fn recompute_soft(&mut self) {
-        let scaled = self.base_soft.as_millis() as f64 * self.bm_stab * self.score_factor;
+        let scaled = self.base_soft.as_millis() as f64 * self.bm_stab * self.bm_inst * self.score_factor;
         self.soft = Duration::from_millis(scaled as u64).min(self.hard);
     }
 }


### PR DESCRIPTION
```
Elo   | 12.48 +- 6.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.47, 2.91) [0.00, 5.00]
Games | N: 4372 W: 1276 L: 1119 D: 1977
Penta | [87, 486, 922, 565, 126]
```
https://asylum.red/test/6062/

```
Elo   | 7.37 +- 4.78 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.47, 2.91) [0.00, 5.00]
Games | N: 7122 W: 1864 L: 1713 D: 3545
Penta | [87, 809, 1638, 920, 107]
```
https://asylum.red/test/6063/

Bench: 4966356