### PR TITLE
QSearch TT clamp

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1882,30 +1882,29 @@ impl Worker<'_> {
             -INF
         } else {
             let eval = self.corrected_eval(raw_eval, sp);
-            if eval >= beta {
-                // Static eval is blind to quiet replies;
-                // the stand-pat verdict overstates certainty.
-                // Blend toward beta to deflate the overconfidence.
-                return Ok((eval + beta) / 2);
+
+            let stand_pat =
+                if is_mate(qs_tt.score) { eval } else { tt::clamp_to_bound(qs_tt.bound, qs_tt.score, eval) };
+
+            if stand_pat >= beta {
+                return Ok((stand_pat + beta) / 2);
             }
+
+            alpha = alpha.max(stand_pat);
 
             // ── Delta Pruning (~20 Elo)
             // Stand-pat already failed to beat alpha.
             // Even if we capture the opponent's most valuable piece, can we reach alpha?
             // If not, no capture in this position can raise us high enough, so bail early.
-            //
-            // best_capturable is just the highest MVV-LVA value among opponent pieces
-            // still on the board; delta_margin covers promotion/positional upside.
             let best_capturable = [PieceType::Queen, PieceType::Rook, PieceType::Bishop, PieceType::Knight, PieceType::Pawn]
                 .into_iter()
                 .find(|&pt| self.pos.pieces(pt, opp).is_not_empty())
                 .map_or(0, |pt| searcher.cfg.mvvlva_v[pt]);
 
-            if eval + best_capturable + sp.delta_margin < alpha {
+            if stand_pat + best_capturable + sp.delta_margin < alpha {
                 return Ok(alpha);
             }
-            alpha = alpha.max(eval);
-            eval
+            stand_pat
         };
 
         let mut moves_made = 0;

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1883,8 +1883,7 @@ impl Worker<'_> {
         } else {
             let eval = self.corrected_eval(raw_eval, sp);
 
-            let stand_pat =
-                if is_mate(qs_tt.score) { eval } else { tt::clamp_to_bound(qs_tt.bound, qs_tt.score, eval) };
+            let stand_pat = if is_mate(qs_tt.score) { eval } else { tt::clamp_to_bound(qs_tt.bound, qs_tt.score, eval) };
 
             if stand_pat >= beta {
                 return Ok((stand_pat + beta) / 2);


### PR DESCRIPTION
```
Elo   | 8.72 +- 5.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.47, 2.91) [0.00, 5.00]
Games | N: 6772 W: 1968 L: 1798 D: 3006
Penta | [154, 784, 1382, 870, 196]
```
https://asylum.red/test/6076/

```
Elo   | 4.75 +- 3.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.47, 2.91) [0.00, 5.00]
Games | N: 12880 W: 3291 L: 3115 D: 6474
Penta | [173, 1487, 2968, 1615, 197]
```
https://asylum.red/test/6079/

Bench: 5082061