### PR TITLE
Reserve future overhead before per-move division in repeating controls

### DIFF
--- a/src/engine/tm.rs
+++ b/src/engine/tm.rs
@@ -165,8 +165,11 @@ fn compute_budget(
     }
 
     let mtg = clock.moves_to_go(phase, params);
-    let soft_ms = clock.soft_ms(mtg, params);
-    let hard_ms = clock.hard_ms(mtg, params);
+    let future_reserve = if clock.movestogo > 0 { overhead.saturating_mul(clock.movestogo.saturating_add(1)) } else { 0 };
+    let usable_time = clock.time.saturating_sub(future_reserve);
+    let usable_clock = Clock { time: usable_time, ..clock };
+    let soft_ms = usable_clock.soft_ms(mtg, params);
+    let hard_ms = usable_clock.hard_ms(mtg, params);
 
     (with_overhead(soft_ms.min(hard_ms), overhead), with_overhead(hard_ms, overhead))
 }


### PR DESCRIPTION
```
Elo   | 3.11 +- 4.89 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.25 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 7940 W: 2209 L: 2138 D: 3593
Penta | [164, 903, 1797, 910, 196]
```
https://asylum.red/test/6130/

Bench: 5503980