### PR TITLE
Base-soft discount for a single root move

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -478,7 +478,7 @@ impl<'cfg> Searcher<'cfg> {
         // Only one legal move. Slash the budget to 5% so we exit the depth
         // loop almost instantly, banking the saved time.
         if self.root_moves.len() == 1 {
-            self.tm.set_bm_stab_factor(sp.tm_single_root as f64 / 100.0);
+            self.tm.scale_base_soft(f64::from(sp.tm_single_root) / 100.0);
         }
 
         // ── Lazy SMP
@@ -611,7 +611,7 @@ impl<'cfg> Searcher<'cfg> {
             //
             // Gated below bm_stab_depth: early iterations haven't
             // accumulated enough node signal for the ratio to be meaningful.
-            if depth >= sp.bm_stab_depth {
+            if depth >= sp.bm_stab_depth && self.root_moves.len() > 1 {
                 let best_nodes = self.root_moves[0].nodes;
                 let total_nodes = self.nodes.max(1);
                 let effort_discount = sp.bm_stab_scale as u64 * best_nodes / total_nodes;

--- a/src/engine/tm.rs
+++ b/src/engine/tm.rs
@@ -63,6 +63,12 @@ impl TimeManager {
     pub fn elapsed(&self) -> Duration { self.start.elapsed() }
 
     #[inline]
+    pub fn scale_base_soft(&mut self, factor: f64) {
+        self.base_soft = self.base_soft.mul_f64(factor);
+        self.recompute_soft();
+    }
+
+    #[inline]
     pub fn set_bm_stab_factor(&mut self, factor: f64) {
         self.bm_stab = factor;
         self.recompute_soft();
@@ -177,3 +183,25 @@ fn compute_budget(
 // The 1 ms floor keeps a zero-length window off the search, which would abort on entry.
 #[inline]
 fn with_overhead(ms: u64, overhead: u64) -> Duration { Duration::from_millis(ms.saturating_sub(overhead).max(1)) }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_forced_move_discount_outlives_the_iteration_factors() {
+        let params = SearchParams::default();
+        let limits = Limits { wtime: 8000, btime: 8000, winc: 80, binc: 80, ..Default::default() };
+        let mut tm = TimeManager::new(&limits, Instant::now(), Color::White, 10, TOTAL_PHASE, 0, &params);
+        let undiscounted = tm.soft_limit();
+
+        tm.scale_base_soft(f64::from(params.tm_single_root) / 100.0);
+        let discounted = tm.soft_limit();
+        assert!(discounted < undiscounted, "{discounted:?} is not a discount on {undiscounted:?}");
+
+        tm.set_bm_stab_factor(0.56);
+        tm.set_bm_inst_factor(1.0);
+        tm.set_score_factor(1.0);
+        assert!(tm.soft_limit() <= discounted, "the iteration factors restored {:?}", tm.soft_limit());
+    }
+}


### PR DESCRIPTION
```
Elo   | 0.20 +- 2.81 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.28 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 23736 W: 6529 L: 6515 D: 10692
Penta | [510, 2764, 5301, 2788, 505]
```
https://asylum.red/test/6132/

Bench: 5503980