### PR TITLE
Stop dividing one thread's best-move changes by the thread count

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -691,7 +691,7 @@ impl<'cfg> Searcher<'cfg> {
     fn build_tm(cfg: &SearchConfig, pos: &Position) -> TimeManager {
         let phase = i32::from(pos.get_initial_accumulator().to_array()[2]);
         let game_ply = u64::from(pos.fullmove_number.saturating_sub(1)) * 2 + u64::from(pos.stm == Color::Black);
-        TimeManager::new(&cfg.limits, cfg.start_time, pos.stm, cfg.overhead, phase, game_ply, &cfg.search_params, cfg.threads)
+        TimeManager::new(&cfg.limits, cfg.start_time, pos.stm, cfg.overhead, phase, game_ply, &cfg.search_params)
     }
 
     /// Periodic signal check: stop flag, hard time limit, node limit.
@@ -2058,7 +2058,7 @@ mod tests {
         let mut out = Vec::new();
         for (movestogo, forced) in [(0, false), (30, true), (2, false)] {
             let limits = Limits { wtime: 60_000, btime: 60_000, winc: 600, binc: 600, movestogo, ..Default::default() };
-            let mut tm = TimeManager::new(&limits, Instant::now(), Color::White, 10, TOTAL_PHASE / 2, 40, params, 1);
+            let mut tm = TimeManager::new(&limits, Instant::now(), Color::White, 10, TOTAL_PHASE / 2, 40, params);
             if forced {
                 tm.scale_base_soft(f64::from(params.tm_single_root) / 100.0);
             }

--- a/src/engine/tm.rs
+++ b/src/engine/tm.rs
@@ -32,7 +32,6 @@ pub struct TimeManager {
     bm_inst: f64,
     score_factor: f64,
     bm_changes: f64,
-    threads: usize,
 }
 
 pub struct Iteration {
@@ -54,20 +53,9 @@ impl TimeManager {
         phase: i32,
         game_ply: u64,
         params: &SearchParams,
-        threads: usize,
     ) -> Self {
         let (soft, hard) = compute_budget(limits, stm, overhead, phase, game_ply, params);
-        Self {
-            start,
-            soft,
-            hard,
-            base_soft: soft,
-            effort: 1.0,
-            bm_inst: 1.0,
-            score_factor: 1.0,
-            bm_changes: 0.0,
-            threads,
-        }
+        Self { start, soft, hard, base_soft: soft, effort: 1.0, bm_inst: 1.0, score_factor: 1.0, bm_changes: 0.0 }
     }
 
     #[inline]
@@ -148,7 +136,7 @@ impl TimeManager {
         if iter.best_move_changed {
             self.bm_changes += 1.0;
         }
-        self.bm_inst = 1.0 + f64::from(params.bm_inst_scale) / 100.0 * self.bm_changes / self.threads as f64;
+        self.bm_inst = 1.0 + f64::from(params.bm_inst_scale) / 100.0 * self.bm_changes;
         self.bm_changes *= f64::from(params.bm_inst_decay) / 100.0;
 
         self.recompute_soft();
@@ -260,7 +248,7 @@ mod tests {
     fn a_forced_move_discount_outlives_the_iteration_factors() {
         let params = SearchParams::default();
         let limits = Limits { wtime: 8000, btime: 8000, winc: 80, binc: 80, ..Default::default() };
-        let mut tm = TimeManager::new(&limits, Instant::now(), Color::White, 10, TOTAL_PHASE, 0, &params, 1);
+        let mut tm = TimeManager::new(&limits, Instant::now(), Color::White, 10, TOTAL_PHASE, 0, &params);
         let undiscounted = tm.soft_limit();
 
         tm.scale_base_soft(f64::from(params.tm_single_root) / 100.0);


### PR DESCRIPTION
```
Elo   | 0.63 +- 2.14 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=32MB
LLR   | -2.48 (-2.47, 2.91) [0.00, 5.00]
Games | N: 39906 W: 10351 L: 10279 D: 19276
Penta | [712, 4907, 8706, 4853, 775]
```
https://asylum.red/test/6136/

Non-Reg [-4.5, 0.5]: LLR 4.9562

Bench: 5503980