### PR TITLE
Stop storing a scout's bound as a root move's score

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1658,18 +1658,19 @@ impl Worker<'_> {
         if N::ROOT
             && let Some(i) = root_idx
         {
-            searcher.root_moves[i].score = eval;
+            // A scout window returns a bound, not a score. The stable sort keeps -INF
+            // entries in the order the last completed iteration set them.
+            if res.move_count == 1 || eval > res.alpha {
+                searcher.root_moves[i].score = eval;
+                searcher.root_moves[i].pv.compose(mv, &self.stack[ply + 1].pv);
+            } else {
+                searcher.root_moves[i].score = -INF;
+            }
         }
 
         if eval > res.best_eval {
             res.best_eval = eval;
             res.best_move = mv;
-
-            if N::ROOT
-                && let Some(i) = root_idx
-            {
-                searcher.root_moves[i].pv.compose(mv, &self.stack[ply + 1].pv);
-            }
 
             if eval > res.alpha {
                 res.alpha = eval;


### PR DESCRIPTION
```
Elo   | 12.22 +- 8.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.29 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 2588 W: 726 L: 635 D: 1227
Penta | [41, 287, 563, 346, 57]
```
https://asylum.red/test/6140/

Bench: 5295382