### PR TITLE
Narrow draw score jitter to -1/+1

### DIFF
--- a/src/core/defs.rs
+++ b/src/core/defs.rs
@@ -313,13 +313,13 @@ impl GameOutcome {
     }
 }
 
-/// Deterministic [-3, +4] cp jitter for draw scores, keyed by the node counter.
+/// Deterministic [-1, +1] cp jitter for draw scores, keyed by the node counter.
 ///
 /// A flat `0` leaves alpha-beta indifferent between drawing lines, so it locks onto
 /// the first one examined. Breaking that tie lets the search reach draw routes where
 /// the opponent still has a chance to stray.
 #[inline]
-pub fn draw_score(nodes: u64) -> i32 { (nodes & 0x7) as i32 - 3 }
+pub fn draw_score(nodes: u64) -> i32 { (nodes & 0x2) as i32 - 1 }
 
 /// A forced mate the side to move delivers.
 #[inline]


### PR DESCRIPTION
```
Elo   | 4.98 +- 5.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.25 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 5516 W: 1496 L: 1417 D: 2603
Penta | [107, 633, 1201, 708, 109]
```
https://asylum.red/test/6145/

Bench: 5181676