### PR TITLE
Tighten beta on aspiration fail-low

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -535,8 +535,9 @@ impl<'cfg> Searcher<'cfg> {
             // one in a narrow window instead of searching (-INF, INF). Tighter
             // bounds prune far more, and most iterations land inside for free.
             // When the score escapes, the bound that broke says which way we
-            // were wrong: a fail-low drops alpha, a fail-high lifts beta. Each
-            // retry widens the window so a score that truly moved doesn't thrash.
+            // were wrong: a fail-low drops alpha and tightens beta, a fail-high
+            // lifts beta. Each retry widens the window so a score that truly
+            // moved doesn't thrash.
             let mut delta = sp.asp_initial;
             let mut alpha = if depth >= sp.asp_depth { (self.prev_score - delta).max(-INF) } else { -INF };
             let mut beta = if depth >= sp.asp_depth { (self.prev_score + delta).min(INF) } else { INF };
@@ -559,6 +560,7 @@ impl<'cfg> Searcher<'cfg> {
 
                 if score <= alpha {
                     self.print_bound(depth, score, tui::ScoreBound::Upper);
+                    beta = (alpha + beta) / 2;
                     alpha = (score - delta).max(-INF);
                 } else if score >= beta {
                     self.print_bound(depth, score, tui::ScoreBound::Lower);


### PR DESCRIPTION
```
Elo   | 2.98 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.47, 2.91) [0.00, 5.00]
Games | N: 32030 W: 8417 L: 8142 D: 15471
Penta | [614, 3831, 6888, 4030, 652]
```
https://asylum.red/test/6157/

```
Elo   | 4.06 +- 3.17 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.47, 2.91) [0.00, 5.00]
Games | N: 16084 W: 3981 L: 3793 D: 8310
Penta | [194, 1908, 3667, 2062, 211]
```
https://asylum.red/test/6158/

Bench: 4972717