### PR TITLE
Split LMP scale on improving

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1215,6 +1215,8 @@ impl Worker<'_> {
 
             self.xb_enter(ply);
 
+            let lmp_scale = (sp.lmp_scale + if improving { sp.lmp_imp } else { -sp.lmp_imp }).max(0);
+
             while let Some(mv) = picker.next(&self.pos, self.xb_rows(), self.history) {
                 if !is_legal(&self.pos, mv, ksq, pinned, checkers, opp) {
                     continue;
@@ -1263,7 +1265,7 @@ impl Worker<'_> {
                     && mv.is_quiet()
                     && !N::PV
                     && depth <= sp.lmp_depth
-                    && res.move_count as i32 >= sp.lmp_base + sp.lmp_scale * depth * depth / 100
+                    && res.move_count as i32 >= sp.lmp_base + lmp_scale * depth * depth / 100
                 {
                     continue;
                 }

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -285,7 +285,7 @@ search_params! {
         T (lmp_depth,   5,   2, 10),
         T (lmp_base,    2,   1,  6),
         T (lmp_scale, 128,  25, 250),  // ·100
-        T (lmp_imp,    32,   0, 128),  // ·100, symmetric improving split
+        T (lmp_imp,    64,   0, 128),  // ·100, symmetric improving split
 
         //                 default   min  max
         T (hist_prune_depth,     8,    2,  12),

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -285,6 +285,7 @@ search_params! {
         T (lmp_depth,   5,   2, 10),
         T (lmp_base,    2,   1,  6),
         T (lmp_scale, 128,  25, 250),  // ·100
+        T (lmp_imp,    32,   0, 128),  // ·100, symmetric improving split
 
         //                 default   min  max
         T (hist_prune_depth,     8,    2,  12),


### PR DESCRIPTION
```
Elo   | 0.79 +- 2.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.12 (-2.47, 2.91) [0.00, 5.00]
Games | N: 21904 W: 5640 L: 5590 D: 10674
Penta | [420, 2670, 4688, 2788, 386]
```
https://asylum.red/test/6171/

```
Elo   | 4.58 +- 3.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.47, 2.91) [0.00, 5.00]
Games | N: 13058 W: 3192 L: 3020 D: 6846
Penta | [136, 1524, 3070, 1630, 169]
```
https://asylum.red/test/6172/

Bench: 5498737