### PR TITLE
Floor NMP at depth 3

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1047,6 +1047,7 @@ impl Worker<'_> {
             && excluded.is_null()
             && !self.stack[ply].is_null
             && !self.is_nmp_verif
+            && depth >= sp.nmp_min_depth
             && tt_clamped_eval >= beta
             && self.pos.has_non_pawn_material(self.pos.stm)
         {

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -259,6 +259,7 @@ search_params! {
         T (probcut_reduction,     5,   1,   8),
 
         //                  default  min   max
+        T (nmp_min_depth,         3,   2,    6),
         T (nmp_base_r,            4,   1,    6),
         T (nmp_depth_divisor,     5,   1,   14),
         T (nmp_eval_divisor,    237,   1,  320),


### PR DESCRIPTION
```
Elo   | 2.46 +- 1.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.47, 2.91) [0.00, 5.00]
Games | N: 53182 W: 14218 L: 13842 D: 25122
Penta | [1059, 6435, 11251, 6763, 1083]
```
https://asylum.red/test/6194/

```
Elo   | 6.08 +- 4.21 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.47, 2.91) [0.00, 5.00]
Games | N: 8922 W: 2217 L: 2061 D: 4644
Penta | [108, 995, 2115, 1119, 124]
```
https://asylum.red/test/6195/

Bench: 5486834