### PR TITLE
Only apply quiet malus on quiet cutoffs

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -1481,6 +1481,16 @@ impl Worker<'_> {
                             self.stack[ply].killers[1] = self.stack[ply].killers[0];
                             self.stack[ply].killers[0] = mv;
                         }
+
+                        // ── Quiet Malus (~25 Elo)
+                        // A bonus alone can only lift entries, so a move that cut once
+                        // and keeps failing never comes back down.
+                        let quiet_limit = self.stack[ply].quiet_count - appended_quiet as usize;
+                        for i in 0..quiet_limit {
+                            let qm = self.stack[ply].quiet_moves[i];
+                            let q_pt = self.pos.expect_piece_at(qm.from());
+                            self.history.update(stm, q_pt, qm.from(), qm.to(), threats, cont1, cont2, cont4, -bonus);
+                        }
                     } else if mv.is_capture() && !mv.is_promotion() {
                         // ── Capture History Update
                         // Promotion-captures are excluded: the picker scores them outside the
@@ -1493,16 +1503,6 @@ impl Worker<'_> {
                         let attacker = self.pos.expect_piece_at(mv.from());
                         let victim = if mv.is_en_passant() { PieceType::Pawn } else { self.pos.piece_at(mv.to()) };
                         self.history.update_capture(stm, attacker, mv.to(), victim, bonus);
-                    }
-
-                    // ── Quiet Malus (~25 Elo)
-                    // A bonus alone can only lift entries, so a move that cut once
-                    // and keeps failing never comes back down.
-                    let quiet_limit = self.stack[ply].quiet_count - appended_quiet as usize;
-                    for i in 0..quiet_limit {
-                        let qm = self.stack[ply].quiet_moves[i];
-                        let q_pt = self.pos.expect_piece_at(qm.from());
-                        self.history.update(stm, q_pt, qm.from(), qm.to(), threats, cont1, cont2, cont4, -bonus);
                     }
 
                     // ── Capture Malus


### PR DESCRIPTION
```
Elo   | 4.50 +- 5.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.28 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 6016 W: 1585 L: 1507 D: 2924
Penta | [105, 716, 1314, 742, 131]
```
https://asylum.red/test/6199/

```
Elo   | 6.35 +- 6.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.28 (-2.89, 2.25) [-4.50, 0.50]
Games | N: 4266 W: 1050 L: 972 D: 2244
Penta | [51, 477, 1000, 553, 52]
```
https://asylum.red/test/6200/

Bench: 5714273